### PR TITLE
Add support for initializing RNG from EntropyPool

### DIFF
--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -76,6 +76,8 @@ import Network.TLS.X509
 import Network.TLS.RNG
 import Data.Maybe (isJust)
 
+import Control.Applicative
+import Control.Concurrent.MVar
 import Control.Concurrent.MVar
 import Control.Monad.State
 import Control.Monad.Reader

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -34,6 +34,7 @@ import Network.TLS.Compression
 import Network.TLS.Crypto
 import Network.TLS.Credentials
 import Network.TLS.X509
+import Crypto.Random.EntropyPool
 import Data.Monoid
 import Data.Default.Class
 import qualified Data.ByteString as B
@@ -148,6 +149,7 @@ data Shared = Shared
     , sharedSessionManager  :: SessionManager
     , sharedCAStore         :: CertificateStore
     , sharedValidationCache :: ValidationCache
+    , sharedEntropyPool     :: Maybe EntropyPool
     }
 
 instance Show Shared where
@@ -158,6 +160,7 @@ instance Default Shared where
             , sharedCredentials     = mempty
             , sharedSessionManager  = noSessionManager
             , sharedValidationCache = def
+            , sharedEntropyPool     = Nothing
             }
 
 -- | A set of callbacks run by the clients for various corners of TLS establishment


### PR DESCRIPTION
This greatly reduces overhead on opening-closing-opening-reading-closing entropy sources on each connection. Also mitigates blocking on /dev/random when no data available: this source has better chances to gather a few bytes between rare reads. See https://github.com/vincenthz/cryptonite/pull/20 for details.