### PR TITLE
adding comments about secure renegotiation.

### DIFF
--- a/core/Network/TLS/Handshake/Process.hs
+++ b/core/Network/TLS/Handshake/Process.hs
@@ -40,8 +40,8 @@ processHandshake ctx hs = do
             mapM_ (usingState_ ctx . processClientExtension) ex
             -- RFC 5746: secure renegotiation
             -- TLS_EMPTY_RENEGOTIATION_INFO_SCSV: {0x00, 0xFF}
-            usingState_ ctx $ do
-                when (0xff `elem` cids) $ setSecureRenegotiation True
+            when (0xff `elem` cids) $
+                usingState_ ctx $ setSecureRenegotiation True
             startHandshake ctx cver ran
         Certificates certs            -> processCertificates role certs
         ClientKeyXchg content         -> when (role == ServerRole) $ do

--- a/core/Network/TLS/Handshake/Process.hs
+++ b/core/Network/TLS/Handshake/Process.hs
@@ -30,6 +30,7 @@ import Network.TLS.Crypto
 import Network.TLS.Handshake.State
 import Network.TLS.Handshake.Key
 import Network.TLS.Extension
+import Network.TLS.Parameters
 import Data.X509 (CertificateChain(..), Certificate(..), getCertificate)
 
 processHandshake :: Context -> Handshake -> IO ()
@@ -40,7 +41,7 @@ processHandshake ctx hs = do
             mapM_ (usingState_ ctx . processClientExtension) ex
             -- RFC 5746: secure renegotiation
             -- TLS_EMPTY_RENEGOTIATION_INFO_SCSV: {0x00, 0xFF}
-            when (0xff `elem` cids) $
+            when (secureRenegotiation && (0xff `elem` cids)) $
                 usingState_ ctx $ setSecureRenegotiation True
             startHandshake ctx cver ran
         Certificates certs            -> processCertificates role certs
@@ -53,9 +54,10 @@ processHandshake ctx hs = do
     let encoded = encodeHandshake hs
     when (certVerifyHandshakeMaterial hs) $ usingHState ctx $ addHandshakeMessage encoded
     when (finishHandshakeTypeMaterial $ typeOfHandshake hs) $ usingHState ctx $ updateHandshakeDigest encoded
-  where -- RFC5746: secure renegotiation
+  where secureRenegotiation = supportedSecureRenegotiation $ ctxSupported ctx
+        -- RFC5746: secure renegotiation
         -- the renegotiation_info extension: 0xff01
-        processClientExtension (0xff01, content) = do
+        processClientExtension (0xff01, content) | secureRenegotiation = do
             v <- getVerifiedData ClientRole
             let bs = extensionEncode (SecureRenegotiation v Nothing)
             unless (bs `bytesEq` content) $ throwError $ Error_Protocol ("client verified data not matching: " ++ show v ++ ":" ++ show content, True, HandshakeFailure)

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -118,7 +118,10 @@ data Supported = Supported
       -- | All supported hash/signature algorithms pair for client
       -- certificate verification, ordered by decreasing priority.
     , supportedHashSignatures :: [HashAndSignatureAlgorithm]
-      -- | Set if we support secure renegotiation.
+      -- | Secure renegotiation defined in RFC5746.
+      --   If 'True', clients send the renegotiation_info extension.
+      --   If 'True', servers handle the extension or the renegotiation SCSV
+      --   then send the renegotiation_info extension.
     , supportedSecureRenegotiation :: Bool
       -- | Set if we support session.
     , supportedSession             :: Bool

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -123,6 +123,11 @@ data Supported = Supported
       --   If 'True', servers handle the extension or the renegotiation SCSV
       --   then send the renegotiation_info extension.
     , supportedSecureRenegotiation :: Bool
+      -- | If 'True', renegotiation is allowed from the client side.
+      --   This is vulnerable to DOS attacks.
+      --   If 'False', renegotiation is allowed only from the server side
+      --   via HelloRequest.
+    , supportedClientInitiatedRenegotiation :: Bool
       -- | Set if we support session.
     , supportedSession             :: Bool
     } deriving (Show,Eq)
@@ -140,6 +145,7 @@ defaultSupported = Supported
                                 , (Struct.HashSHA1,   SignatureDSS)
                                 ]
     , supportedSecureRenegotiation = True
+    , supportedClientInitiatedRenegotiation = False
     , supportedSession             = True
     }
 

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -100,8 +100,13 @@ prop_handshake_npn_initiate = do
 
 prop_handshake_renegociation :: PropertyM IO ()
 prop_handshake_renegociation = do
-    params <- pick arbitraryPairParams
-    runTLSPipe params tlsServer tlsClient
+    (cparams, sparams) <- pick arbitraryPairParams
+    let sparams' = sparams {
+            serverSupported = (serverSupported sparams) {
+                 supportedClientInitiatedRenegotiation = True
+               }
+          }
+    runTLSPipe (cparams, sparams') tlsServer tlsClient
   where tlsServer ctx queue = do
             handshake ctx
             d <- recvDataNonNull ctx


### PR DESCRIPTION
37cb71ba3f49310fc27f234ed1f643486b9f6700 was accidentally cherry-picked. I should have written this comment when I created the patch.