### PR TITLE
Maintain handshake information so that it can be queried ...

### DIFF
--- a/core/Network/TLS.hs
+++ b/core/Network/TLS.hs
@@ -58,6 +58,8 @@ module Network.TLS
 
     -- * Information gathering
     , Information(..)
+    , unClientRandom
+    , unServerRandom
     , contextGetInformation
 
     -- * Credentials
@@ -115,7 +117,8 @@ import Network.TLS.Backend (Backend(..), HasBackend)
 import Network.TLS.Struct ( TLSError(..), TLSException(..)
                           , HashAndSignatureAlgorithm, HashAlgorithm(..), SignatureAlgorithm(..)
                           , Header(..), ProtocolType(..), CertificateType(..)
-                          , AlertDescription(..))
+                          , AlertDescription(..)
+                          , ClientRandom(..), ServerRandom(..))
 import Network.TLS.Crypto (KxError(..))
 import Network.TLS.Cipher
 import Network.TLS.Hooks

--- a/core/Network/TLS/Struct.hs
+++ b/core/Network/TLS/Struct.hs
@@ -174,8 +174,8 @@ data Packet =
 
 data Header = Header ProtocolType Version Word16 deriving (Show,Eq)
 
-newtype ServerRandom = ServerRandom Bytes deriving (Show, Eq)
-newtype ClientRandom = ClientRandom Bytes deriving (Show, Eq)
+newtype ServerRandom = ServerRandom { unServerRandom :: Bytes } deriving (Show, Eq)
+newtype ClientRandom = ClientRandom { unClientRandom :: Bytes } deriving (Show, Eq)
 newtype Session = Session (Maybe SessionID) deriving (Show, Eq)
 
 type FinishedData = Bytes


### PR DESCRIPTION
There is at least one protocol that I know of (Tor) that requires the client random data, server random data, and master secret as part of an internal handshake / seeding process. This patch seemed like the simplest way to maintain and get that information, but I'd be happy to investigate other solutions if this is a problem.

I do need this capability, however.