### PR TITLE
Add HaNS as an additional / alternative underlying network stack.

### DIFF
--- a/core/Network/TLS.hs
+++ b/core/Network/TLS.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- |
 -- Module      : Network.TLS
 -- License     : BSD-style
@@ -48,7 +49,9 @@ module Network.TLS
     -- * Creating a context
     , contextNew
     , contextNewOnHandle
+#ifdef INCLUDE_NETWORK
     , contextNewOnSocket
+#endif
     , contextFlush
     , contextClose
     , contextHookSetHandshakeRecv

--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- |
 -- Module      : Network.TLS.Context
 -- License     : BSD-style
@@ -41,7 +42,9 @@ module Network.TLS.Context
     , contextNew
     -- * Deprecated new contexts methods
     , contextNewOnHandle
+#ifdef INCLUDE_NETWORK
     , contextNewOnSocket
+#endif
 
     -- * Context hooks
     , contextHookSetHandshakeRecv
@@ -80,7 +83,9 @@ import Control.Monad.State
 import Data.IORef
 
 -- deprecated imports
+#ifdef INCLUDE_NETWORK
 import Network.Socket (Socket)
+#endif
 import System.IO (Handle)
 
 class TLSParams a where
@@ -194,6 +199,7 @@ contextNewOnHandle :: (MonadIO m, TLSParams params)
 contextNewOnHandle handle params = contextNew handle params
 {-# DEPRECATED contextNewOnHandle "use contextNew" #-}
 
+#ifdef INCLUDE_NETWORK
 -- | create a new context on a socket.
 contextNewOnSocket :: (MonadIO m, TLSParams params)
                    => Socket -- ^ Socket of the connection.
@@ -201,6 +207,7 @@ contextNewOnSocket :: (MonadIO m, TLSParams params)
                    -> m Context
 contextNewOnSocket sock params = contextNew sock params
 {-# DEPRECATED contextNewOnSocket "use contextNew" #-}
+#endif
 
 contextHookSetHandshakeRecv :: Context -> (Handshake -> IO Handshake) -> IO ()
 contextHookSetHandshakeRecv context f =

--- a/core/Network/TLS/Extension.hs
+++ b/core/Network/TLS/Extension.hs
@@ -54,8 +54,8 @@ import Network.TLS.Extension.EC
 import Network.TLS.Struct (ExtensionID, EnumSafe8(..), EnumSafe16(..), HashAndSignatureAlgorithm)
 import Network.TLS.Wire
 import Network.TLS.Packet (putSignatureHashAlgorithm, getSignatureHashAlgorithm)
-import Network.BSD (HostName)
 
+type HostName = String
 
 -- central list defined in <http://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.txt>
 extensionID_ServerName

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -22,8 +22,6 @@ module Network.TLS.Parameters
     , CertificateRejectReason(..)
     ) where
 
-import Network.BSD (HostName)
-
 import Network.TLS.Extension
 import Network.TLS.Struct
 import qualified Network.TLS.Struct as Struct
@@ -37,6 +35,8 @@ import Network.TLS.X509
 import Data.Monoid
 import Data.Default.Class
 import qualified Data.ByteString as B
+
+type HostName = String
 
 type CommonParams = (Supported, Shared)
 

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -31,13 +31,20 @@ Flag compat
   Description:       Accept SSLv2 compatible handshake
   Default:           True
 
+Flag network
+  Description:       Use the base network library
+  Default:           True
+
+Flag hans
+  Description:       Use the Haskell Network Stack (HaNS)
+  Default:           False
+
 Library
   Build-Depends:     base >= 3 && < 5
                    , mtl
                    , transformers
                    , cereal >= 0.4
                    , bytestring
-                   , network
                    , data-default-class
                    -- crypto related
                    , memory
@@ -49,6 +56,12 @@ Library
                    , x509-store >= 1.6
                    , x509-validation >= 1.6 && < 1.7.0
                    , async
+  if flag(network)
+    Build-Depends:   network
+    cpp-options:     -DINCLUDE_NETWORK
+  if flag(hans)
+    Build-Depends:   hans
+    cpp-options:     -DINCLUDE_HANS
   Exposed-modules:   Network.TLS
                      Network.TLS.Cipher
                      Network.TLS.Compression


### PR DESCRIPTION
As stated in the commits, this pull request should have no effect when the `tls` library is built with its default flags. Instead, it modifies `tls` to be flexible with regard to which network stack(s) it is combined with by providing a `network` flag and a `hans` flag. Again, by default `network` is set and `hans` is unset, which leads to the old default behavior.

Note that these flags are not alternatives to each other; both may be set to true and both may be set to false, depending on the underlying user's needs.