### PR TITLE
tls-retreivecertificate: use 443 as port if unspecified

### DIFF
--- a/debug/src/RetrieveCertificate.hs
+++ b/debug/src/RetrieveCertificate.hs
@@ -104,6 +104,7 @@ main = do
 
     case other of
         [destination,port] -> doMain destination port opts
+        [destination]      -> doMain destination "443" opts
         _                  -> printUsage >> exitFailure
 
   where outputFormat [] = "simple"


### PR DESCRIPTION
tls-retreivecertificate's help message says that it shoud use port 443
as default port if unpsecified as a command-line argument.