### PR TITLE
Support SNI on the server side (Issue #103)

### DIFF
--- a/core/Network/TLS.hs
+++ b/core/Network/TLS.hs
@@ -80,6 +80,9 @@ module Network.TLS
     -- * Next Protocol Negotiation
     , getNegotiatedProtocol
 
+    -- * Server Name Indication
+    , getClientSNI
+
     -- * High level API
     , sendData
     , recvData

--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -20,6 +20,9 @@ module Network.TLS.Core
     -- * Next Protocol Negotiation
     , getNegotiatedProtocol
 
+    -- * Server Name Indication
+    , getClientSNI
+
     -- * High level API
     , sendData
     , recvData
@@ -55,6 +58,13 @@ bye ctx = sendPacket ctx $ Alert [(AlertLevel_Warning, CloseNotify)]
 -- return get the protocol agreed upon.
 getNegotiatedProtocol :: MonadIO m => Context -> m (Maybe B.ByteString)
 getNegotiatedProtocol ctx = liftIO $ usingState_ ctx S.getNegotiatedProtocol
+
+type HostName = String
+
+-- | If the Server Name Indication extension has been used, return the
+-- hostname specified by the client.
+getClientSNI :: MonadIO m => Context -> m (Maybe HostName)
+getClientSNI ctx = liftIO $ usingState_ ctx S.getClientSNI
 
 -- | sendData sends a bunch of data.
 -- It will automatically chunk data to acceptable packet size

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -28,6 +28,7 @@ import Network.TLS.Handshake.State
 import Network.TLS.Handshake.Process
 import Network.TLS.Handshake.Key
 import Network.TLS.Measurement
+import Data.Monoid
 import Data.Maybe (isJust, listToMaybe, mapMaybe)
 import Data.List (intersect, sortBy)
 import qualified Data.ByteString as B

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -133,6 +133,8 @@ handshakeServerWith sparams ctx clientHello@(ClientHello clientVersion _ clientS
             (Session (Just clientSessionId)) -> liftIO $ sessionResume (sharedSessionManager $ ctxShared ctx) clientSessionId
             (Session Nothing)                -> return Nothing
 
+    maybe (return ()) (usingState_ ctx . setClientSNI) serverName
+
     case extensionDecode False `fmap` (lookup extensionID_ApplicationLayerProtocolNegotiation exts) of
         Just (Just (ApplicationLayerProtocolNegotiation protos)) -> usingState_ ctx $ setClientALPNSuggest protos
         _ -> return ()

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -239,6 +239,15 @@ data ServerHooks = ServerHooks
       -- The client cipher list cannot be empty.
     , onCipherChoosing        :: Version -> [Cipher] -> Cipher
 
+      -- | Allow the server to indicate additional credentials
+      -- to be used depending on the host name indicated by the
+      -- client.
+      --
+      -- This is most useful for transparent proxies where
+      -- credentials must be generated on the fly according to
+      -- the host the client is trying to connect to.
+    , onServerNameIndication  :: Maybe HostName -> IO Credentials
+
       -- | suggested next protocols accoring to the next protocol negotiation extension.
     , onSuggestNextProtocols  :: IO (Maybe [B.ByteString])
       -- | at each new handshake, we call this hook to see if we allow handshake to happens.
@@ -251,6 +260,7 @@ defaultServerHooks = ServerHooks
     { onCipherChoosing       = \_ -> head
     , onClientCertificate    = \_ -> return $ CertificateUsageReject $ CertificateRejectOther "no client certificates expected"
     , onUnverifiedClientCert = return False
+    , onServerNameIndication = \_ -> return mempty
     , onSuggestNextProtocols = return Nothing
     , onNewHandshake         = \_ -> return True
     , onALPNClientSuggest    = Nothing

--- a/core/Network/TLS/State.hs
+++ b/core/Network/TLS/State.hs
@@ -45,6 +45,8 @@ module Network.TLS.State
     , getClientEcPointFormatSuggest
     , getClientCertificateChain
     , setClientCertificateChain
+    , setClientSNI
+    , getClientSNI
     , getVerifiedData
     , setSession
     , getSession
@@ -67,6 +69,8 @@ import Network.TLS.ErrT
 import Crypto.Random
 import Data.X509 (CertificateChain)
 
+type HostName = String
+
 data TLSState = TLSState
     { stSession             :: Session
     , stSessionResuming     :: Bool
@@ -82,6 +86,7 @@ data TLSState = TLSState
     , stClientEllipticCurveSuggest :: Maybe [NamedCurve]
     , stClientEcPointFormatSuggest :: Maybe [EcPointFormat]
     , stClientCertificateChain :: Maybe CertificateChain
+    , stClientSNI           :: Maybe HostName
     , stRandomGen           :: StateRNG
     , stVersion             :: Maybe Version
     , stClientContext       :: Role
@@ -116,6 +121,7 @@ newTLSState rng clientContext = TLSState
     , stClientEllipticCurveSuggest = Nothing
     , stClientEcPointFormatSuggest = Nothing
     , stClientCertificateChain = Nothing
+    , stClientSNI           = Nothing
     , stRandomGen           = rng
     , stVersion             = Nothing
     , stClientContext       = clientContext
@@ -237,6 +243,12 @@ setClientCertificateChain s = modify (\st -> st { stClientCertificateChain = Jus
 
 getClientCertificateChain :: TLSSt (Maybe CertificateChain)
 getClientCertificateChain = gets stClientCertificateChain
+
+setClientSNI :: HostName -> TLSSt ()
+setClientSNI hn = modify (\st -> st { stClientSNI = Just hn })
+
+getClientSNI :: TLSSt (Maybe HostName)
+getClientSNI = gets stClientSNI
 
 getVerifiedData :: Role -> TLSSt Bytes
 getVerifiedData client = gets (if client == ClientRole then stClientVerifiedData else stServerVerifiedData)


### PR DESCRIPTION
This attempts to address issue #103. The first commit allows the server credentials used during the handshake to depend on the SNI information provided by the client. This is necessary to support the implementation of transparrent proxies or virtual hosts where different credentials should be used for different domains and credentials may need to be created on demand if the full set of supported domains is not known in advance.

The second commit provides the getClientSNI function alluded to in the original issue, allowing the server to query the host that the client specified after the handshake has completed.