### PR TITLE
Fix benchmarks build

### DIFF
--- a/core/Benchmarks/Benchmarks.hs
+++ b/core/Benchmarks/Benchmarks.hs
@@ -35,7 +35,7 @@ getParams connectVer cipher = (cParams, sParams)
                         }
         (pubKey, privKey) = getGlobalRSAPair
 
-runTLSPipe params tlsServer tlsClient d name = bench name $ do
+runTLSPipe params tlsServer tlsClient d name = bench name . nfIO $ do
     (startQueue, resultQueue) <- establishDataPipe params tlsServer tlsClient
     writeChan startQueue d
     readChan resultQueue

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -145,7 +145,7 @@ Benchmark bench-tls
                    , x509-validation
                    , data-default-class
                    , cryptonite
-                   , criterion
+                   , criterion >= 1.0
                    , mtl
                    , bytestring
                    , hourglass

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -150,6 +150,7 @@ Benchmark bench-tls
                    , bytestring
                    , hourglass
                    , QuickCheck >= 2
+                   , tasty-quickcheck
 
 source-repository head
   type: git


### PR DESCRIPTION
The `bench-tls` build was failing due to an unlisted dependency on `tasty-quickcheck`, and due to breaking changes in `criterion` 1.0.0.