### PR TITLE
Allow users to disable sending an empty packet for TLS <= 1.0 with CBC ciphers

### DIFF
--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -134,6 +134,13 @@ data Supported = Supported
       --   If 'True', servers reject handshakes which suggest
       --   a lower protocol than the highest protocol supported.
     , supportedFallbackScsv        :: Bool
+      -- | In ver <= TLS1.0, block ciphers using CBC are using CBC residue as IV, which can be guessed
+      -- by an attacker. Hence, an empty packet is normally sent before a normal data packet, to
+      -- prevent guessability. Some Microsoft TLS-based protocol implementations, however,
+      -- consider these empty packets as a protocol violation and disconnect. If this parameter is
+      -- 'False', empty packets will never be added, which is less secure, but might help in rare
+      -- cases.
+    , supportedEmptyPacket         :: Bool
     } deriving (Show,Eq)
 
 defaultSupported :: Supported
@@ -152,6 +159,7 @@ defaultSupported = Supported
     , supportedClientInitiatedRenegotiation = False
     , supportedSession             = True
     , supportedFallbackScsv        = True
+    , supportedEmptyPacket         = True
     }
 
 instance Default Supported where

--- a/core/Network/TLS/Sending.hs
+++ b/core/Network/TLS/Sending.hs
@@ -6,7 +6,7 @@
 -- Portability : unknown
 --
 -- the Sending module contains calls related to marshalling packets according
--- to the TLS state 
+-- to the TLS state
 --
 module Network.TLS.Sending (writePacket) where
 
@@ -88,5 +88,5 @@ switchTxEncryption ctx = do
                                       return (v, c)
     liftIO $ modifyMVar_ (ctxTxState ctx) (\_ -> return tx)
     -- set empty packet counter measure if condition are met
-    when (ver <= TLS10 && cc == ClientRole && isCBC tx) $ liftIO $ writeIORef (ctxNeedEmptyPacket ctx) True
+    when (ver <= TLS10 && cc == ClientRole && isCBC tx && supportedEmptyPacket (ctxSupported ctx)) $ liftIO $ writeIORef (ctxNeedEmptyPacket ctx) True
   where isCBC tx = maybe False (\c -> bulkBlockSize (cipherBulk c) > 0) (stCipher tx)


### PR DESCRIPTION
There are cases when another protocol is encapsulated to TLS and that protocol's implementation disconnects when empty unexpected packet gets received.

This pull request adds an option to avoid sending that empty packet when explicitly requested by user even if that compromises security.