### PR TITLE
Require mtl >= 2 due to compilation failure on 1.*

### DIFF
--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -41,7 +41,7 @@ Flag hans
 
 Library
   Build-Depends:     base >= 3 && < 5
-                   , mtl
+                   , mtl >= 2
                    , transformers
                    , cereal >= 0.4
                    , bytestring


### PR DESCRIPTION
Without this `cabal install tls` fails on GHC < 7.6. I've [applied revisions](https://hackage.haskell.org/package/tls-1.3.4/revisions/) so a new release of tls isn't necessary.

```
Network/TLS/State.hs:96:52:
    No instance for (Applicative
                       (Control.Monad.Error.ErrorT TLSError (State TLSState)))
      arising from the 'deriving' clause of a data type declaration
    Possible fix:
      add an instance declaration for
      (Applicative
         (Control.Monad.Error.ErrorT TLSError (State TLSState)))
      or use a standalone 'deriving instance' declaration,
           so you can specify the instance context yourself
    When deriving the instance for (Applicative TLSSt)
```