### PR TITLE
Support SHA-384 with RSA

### DIFF
--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -79,6 +79,7 @@ signatureHashData :: SignatureAlgorithm -> Maybe HashAlgorithm -> Hash
 signatureHashData SignatureRSA mhash =
     case mhash of
         Just HashSHA512 -> SHA512
+        Just HashSHA384 -> SHA384
         Just HashSHA256 -> SHA256
         Just HashSHA1   -> SHA1
         Nothing         -> SHA1_MD5


### PR DESCRIPTION
Fixes getting "unimplemented RSA signature hash type: HashSHA384" when connecting as a client to Go TLS servers.