### PR TITLE
Fix warnings in 7.8 about mempty and un-used imports.

### DIFF
--- a/core/Network/TLS/Credentials.hs
+++ b/core/Network/TLS/Credentials.hs
@@ -5,6 +5,7 @@
 -- Stability   : experimental
 -- Portability : unknown
 --
+{-# LANGUAGE CPP #-}
 module Network.TLS.Credentials
     ( Credential
     , Credentials(..)
@@ -17,7 +18,9 @@ module Network.TLS.Credentials
     , credentialsListSigningAlgorithms
     ) where
 
+#if __GLASGOW_HASKELL__ < 710
 import Data.Monoid
+#endif
 import Data.Maybe (catMaybes)
 import Data.List (find)
 import Network.TLS.Struct

--- a/core/Network/TLS/Extension.hs
+++ b/core/Network/TLS/Extension.hs
@@ -7,6 +7,7 @@
 --
 -- basic extensions are defined in RFC 6066
 --
+{-# LANGUAGE CPP #-}
 module Network.TLS.Extension
     ( Extension(..)
     , supportedExtensions
@@ -42,7 +43,9 @@ module Network.TLS.Extension
     ) where
 
 import Control.Monad
-
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative ((<$>), (<*>))
+#endif
 import Data.Word
 import Data.Maybe (fromMaybe, catMaybes)
 import Data.ByteString (ByteString)
@@ -52,7 +55,6 @@ import qualified Data.ByteString.Char8 as BC
 import Network.TLS.Extension.EC
 import Network.TLS.Struct (ExtensionID, EnumSafe8(..), EnumSafe16(..), HashAndSignatureAlgorithm)
 import Network.TLS.Wire
-import Network.TLS.Imports
 import Network.TLS.Packet (putSignatureHashAlgorithm, getSignatureHashAlgorithm)
 
 type HostName = String

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, OverloadedStrings #-}
+{-# LANGUAGE DeriveDataTypeable, OverloadedStrings, CPP #-}
 -- |
 -- Module      : Network.TLS.Handshake.Client
 -- License     : BSD-style
@@ -21,7 +21,6 @@ import Network.TLS.Packet
 import Network.TLS.ErrT
 import Network.TLS.Extension
 import Network.TLS.IO
-import Network.TLS.Imports
 import Network.TLS.State hiding (getNegotiatedProtocol)
 import Network.TLS.Measurement
 import Network.TLS.Wire (encodeWord16)
@@ -32,7 +31,9 @@ import Data.Maybe
 import Data.List (find)
 import qualified Data.ByteString as B
 import Data.ByteString.Char8 ()
-
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative ((<$>), (<*>))
+#endif
 import Control.Monad.State
 import Control.Exception (SomeException)
 

--- a/core/Network/TLS/Handshake/Common.hs
+++ b/core/Network/TLS/Handshake/Common.hs
@@ -135,5 +135,6 @@ getSessionData ctx = do
                         , sessionSecret  = ms
                         }
 
+extensionLookup :: ExtensionID -> [ExtensionRaw] -> Maybe Bytes
 extensionLookup toFind = fmap (\(ExtensionRaw _ content) -> content)
-                       . find (\(ExtensionRaw eid content) -> eid == toFind)
+                       . find (\(ExtensionRaw eid _) -> eid == toFind)

--- a/core/Network/TLS/Handshake/Process.hs
+++ b/core/Network/TLS/Handshake/Process.hs
@@ -7,12 +7,16 @@
 --
 -- process handshake message received
 --
+{-# LANGUAGE CPP #-}
 module Network.TLS.Handshake.Process
     ( processHandshake
     , startHandshake
     , getHandshakeDigest
     ) where
 
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative
+#endif
 import Control.Concurrent.MVar
 import Control.Monad.State (gets)
 import Control.Monad
@@ -26,7 +30,6 @@ import Network.TLS.Struct
 import Network.TLS.State
 import Network.TLS.Context.Internal
 import Network.TLS.Crypto
-import Network.TLS.Imports
 import Network.TLS.Handshake.State
 import Network.TLS.Handshake.Key
 import Network.TLS.Extension

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, OverloadedStrings #-}
+{-# LANGUAGE DeriveDataTypeable, OverloadedStrings, CPP #-}
 -- |
 -- Module      : Network.TLS.Handshake.Server
 -- License     : BSD-style
@@ -12,7 +12,6 @@ module Network.TLS.Handshake.Server
     ) where
 
 import Network.TLS.Parameters
-import Network.TLS.Imports
 import Network.TLS.Context.Internal
 import Network.TLS.Session
 import Network.TLS.Struct
@@ -33,7 +32,10 @@ import Data.Maybe (isJust, listToMaybe, mapMaybe)
 import Data.List (intersect, sortBy)
 import qualified Data.ByteString as B
 import Data.ByteString.Char8 ()
-
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative ((<$>))
+import Data.Monoid (mappend)
+#endif
 import Control.Monad.State
 
 import Network.TLS.Handshake.Signature

--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 -- |
 -- Module      : Network.TLS.Handshake.Signature
 -- License     : BSD-style
@@ -19,14 +20,15 @@ module Network.TLS.Handshake.Signature
 import Network.TLS.Crypto
 import Network.TLS.Context.Internal
 import Network.TLS.Struct
-import Network.TLS.Imports
 import Network.TLS.Packet (generateCertificateVerify_SSL, encodeSignedDHParams, encodeSignedECDHParams)
 import Network.TLS.Parameters (supportedHashSignatures)
 import Network.TLS.State
 import Network.TLS.Handshake.State
 import Network.TLS.Handshake.Key
 import Network.TLS.Util
-
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative
+#endif
 import Control.Monad.State
 
 certificateVerifyCheck :: Context
@@ -83,7 +85,7 @@ signatureHashData SignatureRSA mhash =
         Just HashSHA256 -> SHA256
         Just HashSHA1   -> SHA1
         Nothing         -> SHA1_MD5
-        Just hash       -> error ("unimplemented RSA signature hash type: " ++ show hash)
+        Just hash'       -> error ("unimplemented RSA signature hash type: " ++ show hash')
 signatureHashData SignatureDSS mhash =
     case mhash of
         Nothing       -> SHA1
@@ -96,7 +98,7 @@ signatureHashData SignatureECDSA mhash =
         Just HashSHA256 -> SHA256
         Just HashSHA1   -> SHA1
         Nothing         -> SHA1_MD5
-        Just hash       -> error ("unimplemented ECDSA signature hash type: " ++ show hash)
+        Just hash'       -> error ("unimplemented ECDSA signature hash type: " ++ show hash')
 signatureHashData sig _ = error ("unimplemented signature type: " ++ show sig)
 
 --signatureCreate :: Context -> Maybe HashAndSignatureAlgorithm -> HashDescr -> Bytes -> IO DigitallySigned

--- a/core/Network/TLS/Handshake/State.hs
+++ b/core/Network/TLS/Handshake/State.hs
@@ -51,7 +51,9 @@ import Network.TLS.Crypto
 import Network.TLS.Cipher
 import Network.TLS.Compression
 import Network.TLS.Types
+#if __GLASGOW_HASKELL__ < 710
 import Control.Applicative (Applicative, (<$>))
+#endif
 import Control.Monad.State
 import Data.X509 (CertificateChain)
 import Data.ByteArray (ByteArrayAccess)

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -5,6 +5,7 @@
 -- Stability   : experimental
 -- Portability : unknown
 --
+{-# LANGUAGE CPP #-}
 module Network.TLS.Parameters
     (
       ClientParams(..)
@@ -36,6 +37,10 @@ import Network.TLS.X509
 import Network.TLS.RNG (Seed)
 import Data.Default.Class
 import qualified Data.ByteString as B
+
+#if __GLASGOW_HASKELL__ < 710
+import Data.Monoid (mempty)
+#endif
 
 type HostName = String
 

--- a/core/Network/TLS/Record/Engage.hs
+++ b/core/Network/TLS/Record/Engage.hs
@@ -9,11 +9,14 @@
 -- The record is compressed, added some integrity field, then encrypted.
 --
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 module Network.TLS.Record.Engage
         ( engageRecord
         ) where
 
+#if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
+#endif
 import Control.Monad.State
 import Crypto.Cipher.Types (AuthTag(..))
 

--- a/core/Network/TLS/Record/State.hs
+++ b/core/Network/TLS/Record/State.hs
@@ -26,7 +26,9 @@ module Network.TLS.Record.State
     ) where
 
 import Data.Word
+#if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
+#endif
 import Control.Monad.State
 import Network.TLS.Compression
 import Network.TLS.Cipher

--- a/core/Network/TLS/Record/Types.hs
+++ b/core/Network/TLS/Record/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE CPP #-}
 -- |
 -- Module      : Network.TLS.Record.Types
 -- License     : BSD-style
@@ -41,7 +42,9 @@ module Network.TLS.Record.Types
 import Network.TLS.Struct
 import Network.TLS.Record.State
 import qualified Data.ByteString as B
+#if __GLASGOW_HASKELL__ < 710
 import Control.Applicative ((<$>))
+#endif
 
 -- | Represent a TLS record.
 data Record a = Record !ProtocolType !Version !(Fragment a) deriving (Show,Eq)

--- a/core/Network/TLS/Sending.hs
+++ b/core/Network/TLS/Sending.hs
@@ -8,9 +8,12 @@
 -- the Sending module contains calls related to marshalling packets according
 -- to the TLS state
 --
+{-# LANGUAGE CPP #-}
 module Network.TLS.Sending (writePacket) where
 
+#if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
+#endif
 import Control.Monad.State
 import Control.Concurrent.MVar
 import Data.IORef

--- a/core/Network/TLS/Wire.hs
+++ b/core/Network/TLS/Wire.hs
@@ -8,6 +8,7 @@
 -- the Wire module is a specialized marshalling/unmarshalling package related to the TLS protocol.
 -- all multibytes values are written as big endian.
 --
+{-# LANGUAGE CPP #-}
 module Network.TLS.Wire
     ( Get
     , GetResult(..)
@@ -52,7 +53,9 @@ module Network.TLS.Wire
 import Data.Serialize.Get hiding (runGet)
 import qualified Data.Serialize.Get as G
 import Data.Serialize.Put
+#if __GLASGOW_HASKELL__ < 710
 import Control.Applicative ((<$>))
+#endif
 import Control.Monad
 import qualified Data.ByteString as B
 import Data.Word

--- a/core/Tests/Certificate.hs
+++ b/core/Tests/Certificate.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 module Certificate
     ( arbitraryX509
     , arbitraryX509WithKey
@@ -6,7 +7,9 @@ module Certificate
     , simpleX509
     ) where
 
+#if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
+#endif
 import Test.Tasty.QuickCheck
 import Data.X509
 import Data.Hourglass

--- a/core/Tests/Ciphers.hs
+++ b/core/Tests/Ciphers.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE CPP #-}
 module Ciphers
     ( propertyBulkFunctional
     ) where
 
+#if __GLASGOW_HASKELL__ < 710
 import Control.Applicative ((<$>), (<*>))
+#endif
 
 import Test.Tasty.QuickCheck
 

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Connection
     ( newPairContext
     , arbitraryPairParams
@@ -15,7 +16,9 @@ import PipeChan
 import Network.TLS
 import Data.X509
 import Data.Default.Class
+#if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
+#endif
 import Control.Concurrent.Chan
 import Control.Concurrent
 import qualified Control.Exception as E

--- a/core/Tests/Marshalling.hs
+++ b/core/Tests/Marshalling.hs
@@ -2,7 +2,9 @@
 module Marshalling where
 
 import Control.Monad
+#if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
+#endif
 import Test.Tasty.QuickCheck
 import Network.TLS.Internal
 import Network.TLS

--- a/core/Tests/PipeChan.hs
+++ b/core/Tests/PipeChan.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- create a similar concept than a unix pipe.
 module PipeChan
     ( PipeChan(..)
@@ -9,7 +10,10 @@ module PipeChan
     , writePipeB
     ) where
 
+#if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
+#endif
+
 import Control.Concurrent.Chan
 import Control.Concurrent
 import Control.Monad (forever)

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -15,7 +15,9 @@ import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as C8
 import qualified Data.ByteString.Lazy as L
 import Network.TLS
+#if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
+#endif
 import Control.Concurrent
 import Control.Monad
 

--- a/debug/src/RetrieveCertificate.hs
+++ b/debug/src/RetrieveCertificate.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ScopedTypeVariables, DeriveDataTypeable, ViewPatterns #-}
+{-# LANGUAGE ScopedTypeVariables, DeriveDataTypeable, ViewPatterns, CPP #-}
 
 import Network.TLS
 import Network.TLS.Extra.Cipher
@@ -12,7 +12,9 @@ import Data.X509 as X509
 import Data.X509.Validation
 import System.X509
 
+#if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
+#endif
 import Control.Monad
 import Control.Exception
 

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE CPP #-}
 import Crypto.Random
 import Network.BSD
 import Network.Socket (socket, Family(..), SocketType(..), sClose, SockAddr(..), connect)
@@ -20,9 +21,10 @@ import System.X509
 
 import Data.Default.Class
 import Data.IORef
+#if __GLASGOW_HASKELL__ < 710
 import Data.Monoid
+#endif
 import Data.Char (isDigit)
-import Data.X509.Validation
 
 import Numeric (showHex)
 
@@ -183,7 +185,7 @@ options =
     , Option []     ["bench-send"]   (NoArg BenchSend) "benchmark send path. only with compatible server"
     , Option []     ["bench-recv"]   (NoArg BenchRecv) "benchmark recv path. only with compatible server"
     , Option []     ["bench-data"] (ReqArg BenchData "amount") "amount of data to benchmark with"
-    , Option []     ["use-cipher"] (ReqArg UseCipher "cipher-id") "use a specific cipher" 
+    , Option []     ["use-cipher"] (ReqArg UseCipher "cipher-id") "use a specific cipher"
     , Option []     ["list-ciphers"] (NoArg ListCiphers) "list all ciphers supported and exit"
     , Option []     ["debug-seed"] (ReqArg DebugSeed "debug-seed") "debug: set a specific seed for randomness"
     , Option []     ["debug-print-seed"] (NoArg DebugPrintSeed) "debug: set a specific seed for randomness"

--- a/debug/src/SimpleServer.hs
+++ b/debug/src/SimpleServer.hs
@@ -11,8 +11,6 @@ import System.Timeout
 import qualified Data.ByteString.Lazy.Char8 as LC
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString as B
-import Control.Exception
-import qualified Control.Exception as E
 import Control.Monad
 import System.Environment
 import System.Exit
@@ -21,9 +19,7 @@ import Data.X509.CertificateStore
 
 import Data.Default.Class
 import Data.IORef
-import Data.Monoid
 import Data.Char (isDigit)
-import Data.X509.Validation
 
 import Numeric (showHex)
 
@@ -86,7 +82,7 @@ sessionRef ref = SessionManager
     }
 
 getDefaultParams :: [Flag] -> CertificateStore -> IORef (SessionID, SessionData) -> Credential -> Maybe (SessionID, SessionData) -> ServerParams
-getDefaultParams flags store sStorage cred session =
+getDefaultParams flags store sStorage cred _session =
     ServerParams
         { serverWantClientCert = False
         , serverCACertificates = []
@@ -184,7 +180,7 @@ options =
     , Option []     ["bench-send"]   (NoArg BenchSend) "benchmark send path. only with compatible server"
     , Option []     ["bench-recv"]   (NoArg BenchRecv) "benchmark recv path. only with compatible server"
     , Option []     ["bench-data"] (ReqArg BenchData "amount") "amount of data to benchmark with"
-    , Option []     ["use-cipher"] (ReqArg UseCipher "cipher-id") "use a specific cipher" 
+    , Option []     ["use-cipher"] (ReqArg UseCipher "cipher-id") "use a specific cipher"
     , Option []     ["list-ciphers"] (NoArg ListCiphers) "list all ciphers supported and exit"
     , Option []     ["certificate"] (ReqArg Certificate "certificate") "certificate file"
     , Option []     ["debug-seed"] (ReqArg DebugSeed "debug-seed") "debug: set a specific seed for randomness"

--- a/debug/src/Stunnel.hs
+++ b/debug/src/Stunnel.hs
@@ -22,7 +22,6 @@ import Control.Monad (when, forever)
 import Data.Char (isDigit)
 import Data.Default.Class
 
-import Crypto.Random
 import Network.TLS
 import Network.TLS.Extra.Cipher
 

--- a/debug/tls-debug.cabal
+++ b/debug/tls-debug.cabal
@@ -25,7 +25,7 @@ Executable           tls-stunnel
                    , x509-system >= 1.0
                    , data-default-class
                    , cryptonite
-                   , tls >= 1.3.0 && < 1.4
+                   , tls <= 1.3.5
   if os(windows)
     Buildable:       False
   else
@@ -56,7 +56,8 @@ Executable           tls-retrievecertificate
                    , x509
                    , x509-system >= 1.4
                    , x509-validation >= 1.5.0
-                   , tls >= 1.3 && < 1.4
+                   , tls <= 1.3.5
+                   --, tls >= 1.3 && < 1.4
   Buildable:         True
   ghc-options:       -Wall -fno-warn-missing-signatures
 
@@ -69,7 +70,8 @@ Executable           tls-simpleclient
                    , data-default-class
                    , cryptonite >= 0.14
                    , x509-system >= 1.0
-                   , tls >= 1.3.6 && < 1.4
+                   , tls <= 1.3.5
+--                   , tls >= 1.3.6 && < 1.4
   Buildable:         True
   ghc-options:       -Wall -fno-warn-missing-signatures
 
@@ -83,7 +85,8 @@ Executable           tls-simpleserver
                    , cryptonite
                    , x509-store
                    , x509-system >= 1.0
-                   , tls >= 1.3 && < 1.4
+                   , tls <= 1.3.5
+                   --, tls >= 1.3 && < 1.4
   Buildable:         True
   ghc-options:       -Wall -fno-warn-missing-signatures
 


### PR DESCRIPTION
Uses CPP to work around various warnings. Happy to reformat as necessary, I noticed there were some differences around how to bring in pragmas (multi line vs single line), explicit imports of types/functions and whether there is a project wide prelude where you could pull in things like `Applicative`/ not have to do it all over the place.

https://github.com/vincenthz/hs-tls/issues/143