### PR TITLE
Get tls working again on GHC < 7.10, and fix the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,22 @@
 sudo: false
 
-env:
- - CABALVER=1.16 GHCVER=7.0.4 RUNTEST=0
-   addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.4,libssl-dev], sources: [hvr-ghc]}}
- - CABALVER=1.16 GHCVER=7.4.2
-   addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2,libssl-dev], sources: [hvr-ghc]}}
- - CABALVER=1.18 GHCVER=7.6.3
-   addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,libssl-dev], sources: [hvr-ghc]}}
- - CABALVER=1.18 GHCVER=7.8.4
-   addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,libssl-dev], sources: [hvr-ghc]}}
- - CABALVER=1.22 GHCVER=7.10.3
-   addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,libssl-dev], sources: [hvr-ghc]}}
- - CABALVER=1.24 GHCVER=8.0.1 RUNTEST=0
-   addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,libssl-dev], sources: [hvr-ghc]}}
- - CABALVER=head GHCVER=head RUNTEST=0
-   addons: {apt: {packages: [cabal-install-head,ghc-head,libssl-dev], sources: [hvr-ghc]}}
-
 matrix:
+  include:
+    - env: CABALVER=1.16 GHCVER=7.0.4 RUNTEST=0
+      addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.4,libssl-dev], sources: [hvr-ghc]}}
+    - env: CABALVER=1.16 GHCVER=7.4.2
+      addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2,libssl-dev], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,libssl-dev], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,libssl-dev], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,libssl-dev], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.1 RUNTEST=0
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,libssl-dev], sources: [hvr-ghc]}}
+    - env: CABALVER=head GHCVER=head RUNTEST=0
+      addons: {apt: {packages: [cabal-install-head,ghc-head,libssl-dev], sources: [hvr-ghc]}}
+
   allow_failures:
    - env: CABALVER=head GHCVER=head RUNTEST=0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,19 @@ sudo: false
 
 env:
  - CABALVER=1.16 GHCVER=7.0.4 RUNTEST=0
-addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.4,libssl-dev], sources: [hvr-ghc]}}
+   addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.4,libssl-dev], sources: [hvr-ghc]}}
  - CABALVER=1.16 GHCVER=7.4.2
-addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2,libssl-dev], sources: [hvr-ghc]}}
+   addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2,libssl-dev], sources: [hvr-ghc]}}
  - CABALVER=1.18 GHCVER=7.6.3
-addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,libssl-dev], sources: [hvr-ghc]}}
+   addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,libssl-dev], sources: [hvr-ghc]}}
  - CABALVER=1.18 GHCVER=7.8.4
-addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,libssl-dev], sources: [hvr-ghc]}}
+   addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,libssl-dev], sources: [hvr-ghc]}}
  - CABALVER=1.22 GHCVER=7.10.3
-addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,libssl-dev], sources: [hvr-ghc]}}
+   addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,libssl-dev], sources: [hvr-ghc]}}
  - CABALVER=1.24 GHCVER=8.0.1 RUNTEST=0
-addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,libssl-dev], sources: [hvr-ghc]}}
+   addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,libssl-dev], sources: [hvr-ghc]}}
  - CABALVER=head GHCVER=head RUNTEST=0
-addons: {apt: {packages: [cabal-install-head,ghc-head,libssl-dev], sources: [hvr-ghc]}}
+   addons: {apt: {packages: [cabal-install-head,ghc-head,libssl-dev], sources: [hvr-ghc]}}
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,3 +72,8 @@ script:
  - make build-openssl-server
  - ghc -threaded --make test-scripts/TestClient && echo "BUILDING TEST OK" || echo "BUILDING TEST FAILED"
  - if [ -x test-scripts/TestClient ]; then touch debug.log; ./test-scripts/TestClient debug.log; cat debug.log; fi
+
+cache:
+  directories:
+  - $HOME/.cabal
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,36 +2,23 @@ sudo: false
 
 env:
  - CABALVER=1.16 GHCVER=7.0.4 RUNTEST=0
+addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.4,libssl-dev], sources: [hvr-ghc]}}
  - CABALVER=1.16 GHCVER=7.4.2
+addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2,libssl-dev], sources: [hvr-ghc]}}
  - CABALVER=1.18 GHCVER=7.6.3
+addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,libssl-dev], sources: [hvr-ghc]}}
  - CABALVER=1.18 GHCVER=7.8.4
+addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,libssl-dev], sources: [hvr-ghc]}}
  - CABALVER=1.22 GHCVER=7.10.3
+addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,libssl-dev], sources: [hvr-ghc]}}
  - CABALVER=1.24 GHCVER=8.0.1 RUNTEST=0
+addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,libssl-dev], sources: [hvr-ghc]}}
  - CABALVER=head GHCVER=head RUNTEST=0
+addons: {apt: {packages: [cabal-install-head,ghc-head,libssl-dev], sources: [hvr-ghc]}}
 
 matrix:
   allow_failures:
    - env: CABALVER=head GHCVER=head RUNTEST=0
-
-addons:
-    apt:
-        sources:
-         - hvr-ghc
-        packages:
-         - cabal-install-1.16
-         - cabal-install-1.18
-         - cabal-install-1.20
-         - cabal-install-1.22
-         - cabal-install-1.24
-         - cabal-install-head
-         - ghc-7.0.4
-         - ghc-7.4.2
-         - ghc-7.6.3
-         - ghc-7.8.4
-         - ghc-7.10.3
-         - ghc-8.0.1
-         - ghc-head
-         - libssl-dev
 
 before_install:
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,12 @@ install:
  - travis_retry cabal update
  - cabal install utf8-string
  - cd core
- - if [ "${RUNTEST}" != "0" ]; then cabal install --only-dependencies --enable-tests; else cabal install --only-dependencies; fi
+ - | if [ "${RUNTEST}" != "0" ]; then
+       cabal install --only-dependencies --enable-tests
+     else
+       cabal install --only-dependencies
+     fi
+     cabal install
  - cd ../debug
  - if [ "${RUNTEST}" != "0" ]; then cabal install --only-dependencies --enable-tests; else cabal install --only-dependencies; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,14 @@ install:
  - travis_retry cabal update
  - cabal install utf8-string
  - cd core
- - | if [ "${RUNTEST}" != "0" ]; then
-       cabal install --only-dependencies --enable-tests
-     else
-       cabal install --only-dependencies
-     fi
-     cabal install
+ - |
+    set -e
+    if [ "${RUNTEST}" != "0" ]; then
+      cabal install --only-dependencies --enable-tests
+    else
+      cabal install --only-dependencies
+    fi
+    cabal install
  - cd ../debug
  - if [ "${RUNTEST}" != "0" ]; then cabal install --only-dependencies --enable-tests; else cabal install --only-dependencies; fi
 

--- a/core/Network/TLS/Handshake/Common.hs
+++ b/core/Network/TLS/Handshake/Common.hs
@@ -135,5 +135,6 @@ getSessionData ctx = do
                         , sessionSecret  = ms
                         }
 
+extensionLookup :: ExtensionID -> [ExtensionRaw] -> Maybe Bytes
 extensionLookup toFind = fmap (\(ExtensionRaw _ content) -> content)
-                       . find (\(ExtensionRaw eid content) -> eid == toFind)
+                       . find (\(ExtensionRaw eid _) -> eid == toFind)

--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -83,7 +83,7 @@ signatureHashData SignatureRSA mhash =
         Just HashSHA256 -> SHA256
         Just HashSHA1   -> SHA1
         Nothing         -> SHA1_MD5
-        Just hash       -> error ("unimplemented RSA signature hash type: " ++ show hash)
+        Just hsh        -> error ("unimplemented RSA signature hash type: " ++ show hsh)
 signatureHashData SignatureDSS mhash =
     case mhash of
         Nothing       -> SHA1
@@ -96,7 +96,7 @@ signatureHashData SignatureECDSA mhash =
         Just HashSHA256 -> SHA256
         Just HashSHA1   -> SHA1
         Nothing         -> SHA1_MD5
-        Just hash       -> error ("unimplemented ECDSA signature hash type: " ++ show hash)
+        Just hsh        -> error ("unimplemented ECDSA signature hash type: " ++ show hsh)
 signatureHashData sig _ = error ("unimplemented signature type: " ++ show sig)
 
 --signatureCreate :: Context -> Maybe HashAndSignatureAlgorithm -> HashDescr -> Bytes -> IO DigitallySigned

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -37,6 +37,8 @@ import Network.TLS.RNG (Seed)
 import Data.Default.Class
 import qualified Data.ByteString as B
 
+import Data.Monoid (mempty)
+
 type HostName = String
 
 type CommonParams = (Supported, Shared, DebugParams)

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -36,8 +36,9 @@ import Network.TLS.X509
 import Network.TLS.RNG (Seed)
 import Data.Default.Class
 import qualified Data.ByteString as B
-
+#if __GLASGOW_HASKELL__ < 710
 import Data.Monoid (mempty)
+#endif
 
 type HostName = String
 

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -1,3 +1,5 @@
+ {-# LANGUAGE CPP #-}
+
 -- |
 -- Module      : Network.TLS.Parameters
 -- License     : BSD-style

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -127,6 +127,7 @@ Test-Suite test-tls
                    , data-default-class
                    , tasty
                    , tasty-quickcheck
+                   , tls
                    , QuickCheck
                    , cryptonite
                    , bytestring
@@ -151,6 +152,7 @@ Benchmark bench-tls
                    , hourglass
                    , QuickCheck >= 2
                    , tasty-quickcheck
+                   , tls
 
 source-repository head
   type: git

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -132,7 +132,6 @@ Test-Suite test-tls
                    , bytestring
                    , x509
                    , x509-validation
-                   , tls
                    , hourglass
   ghc-options:       -Wall -fno-warn-orphans -fno-warn-missing-signatures -fwarn-tabs
 

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -40,7 +40,7 @@ Flag hans
   Default:           False
 
 Library
-  Build-Depends:     base >= 3 && < 5
+  Build-Depends:     base >= 4.3 && < 5
                    , mtl >= 2
                    , transformers
                    , cereal >= 0.4

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -22,7 +22,6 @@ import Data.Default.Class
 import Data.IORef
 import Data.Monoid
 import Data.Char (isDigit)
-import Data.X509.Validation
 
 import Numeric (showHex)
 

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -183,7 +183,7 @@ options =
     , Option []     ["bench-send"]   (NoArg BenchSend) "benchmark send path. only with compatible server"
     , Option []     ["bench-recv"]   (NoArg BenchRecv) "benchmark recv path. only with compatible server"
     , Option []     ["bench-data"] (ReqArg BenchData "amount") "amount of data to benchmark with"
-    , Option []     ["use-cipher"] (ReqArg UseCipher "cipher-id") "use a specific cipher" 
+    , Option []     ["use-cipher"] (ReqArg UseCipher "cipher-id") "use a specific cipher"
     , Option []     ["list-ciphers"] (NoArg ListCiphers) "list all ciphers supported and exit"
     , Option []     ["debug-seed"] (ReqArg DebugSeed "debug-seed") "debug: set a specific seed for randomness"
     , Option []     ["debug-print-seed"] (NoArg DebugPrintSeed) "debug: set a specific seed for randomness"
@@ -286,7 +286,7 @@ runOn (sStorage, certStore) flags port hostname
                                             Just i  -> i
                 f acc _              = acc
 
-readNumber :: (Num a, Read a) => String -> Maybe a
+readNumber :: Read a => String -> Maybe a
 readNumber s
     | all isDigit s = Just $ read s
     | otherwise     = Nothing

--- a/debug/src/SimpleServer.hs
+++ b/debug/src/SimpleServer.hs
@@ -11,7 +11,6 @@ import System.Timeout
 import qualified Data.ByteString.Lazy.Char8 as LC
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString as B
-import Control.Exception
 import qualified Control.Exception as E
 import Control.Monad
 import System.Environment
@@ -23,7 +22,6 @@ import Data.Default.Class
 import Data.IORef
 import Data.Monoid
 import Data.Char (isDigit)
-import Data.X509.Validation
 
 import Numeric (showHex)
 
@@ -184,7 +182,7 @@ options =
     , Option []     ["bench-send"]   (NoArg BenchSend) "benchmark send path. only with compatible server"
     , Option []     ["bench-recv"]   (NoArg BenchRecv) "benchmark recv path. only with compatible server"
     , Option []     ["bench-data"] (ReqArg BenchData "amount") "amount of data to benchmark with"
-    , Option []     ["use-cipher"] (ReqArg UseCipher "cipher-id") "use a specific cipher" 
+    , Option []     ["use-cipher"] (ReqArg UseCipher "cipher-id") "use a specific cipher"
     , Option []     ["list-ciphers"] (NoArg ListCiphers) "list all ciphers supported and exit"
     , Option []     ["certificate"] (ReqArg Certificate "certificate") "certificate file"
     , Option []     ["debug-seed"] (ReqArg DebugSeed "debug-seed") "debug: set a specific seed for randomness"

--- a/debug/src/Stunnel.hs
+++ b/debug/src/Stunnel.hs
@@ -22,7 +22,6 @@ import Control.Monad (when, forever)
 import Data.Char (isDigit)
 import Data.Default.Class
 
-import Crypto.Random
 import Network.TLS
 import Network.TLS.Extra.Cipher
 


### PR DESCRIPTION
See https://github.com/vincenthz/hs-tls/issues/143

In particular:

>Here are the major changes I made (in no particular order):
>
>1. Fixed the `mempty` import for GHC versions lower than 7.10.
>2. Made `tls` to not be a dependency of itself. This was making the build fail when it should pass, due to the source on Hackage (which we are trying to update) failing to build.
>3. Installed the cloned `tls` in the local `cabal` as part of the Travis build. This ensures that `tls-debug` will use the current code, rather than trying to download the package from Hackage.
>4. Made (the locally installed) `tls` a dependency of its own test suite and benchmark.
>5. Made the travis build only install the necessary GHC and cabal-install versions.
>6. Changed the lower-bound of `base` to coincide with GHC 7.0.
>7. Cached the `.cabal` directory of the build, to speed things up significantly.