### PR TITLE
Sni late checks

### DIFF
--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -161,8 +161,8 @@ contextNew backend params = liftIO $ do
         st   = newTLSState rng role
         ciphers = getCiphers params
 
---  we still might get ciphers from SNI calback
--- maybe if just could only bail on protocols which require the main cert??
+--  we still might get some ciphers from SNI callback
+--  If we could bail only on protocols which require the main cert??
 --    when (null (ciphers mempty)) $ error "no ciphers available with those parameters"
 
     stvar <- newMVar st

--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -81,7 +81,7 @@ import Data.Maybe (isJust)
 import Control.Concurrent.MVar
 import Control.Monad.State
 import Data.IORef
-import Data.Monoid ((<>))
+import Data.Monoid (mappend)
 
 -- deprecated imports
 #ifdef INCLUDE_NETWORK
@@ -136,7 +136,7 @@ instance TLSParams ServerParams where
                 canEncryptRSA = isJust $ credentialsFindForDecrypting creds
                 signingAlgs   = credentialsListSigningAlgorithms creds
                 serverCreds   = sharedCredentials $ serverShared sparams
-                creds         = extraCreds <> serverCreds
+                creds         = extraCreds `mappend` serverCreds
     doHandshake = handshakeServer
     doHandshakeWith = handshakeServerWith
 

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -57,6 +57,7 @@ module Network.TLS.Context.Internal
 import Network.TLS.Backend
 import Network.TLS.Extension
 import Network.TLS.Cipher
+import Network.TLS.Credentials (Credentials)
 import Network.TLS.Struct
 import Network.TLS.Compression (Compression)
 import Network.TLS.State
@@ -89,7 +90,8 @@ data Context = Context
     { ctxConnection       :: Backend   -- ^ return the backend object associated with this context
     , ctxSupported        :: Supported
     , ctxShared           :: Shared
-    , ctxCiphers          :: [Cipher]  -- ^ prepared list of allowed ciphers according to parameters
+    , ctxCiphers          :: Credentials -> [Cipher]  -- ^ list of allowed ciphers according to parameters
+                                                      -- and additional credentials
     , ctxState            :: MVar TLSState
     , ctxMeasurement      :: IORef Measurement
     , ctxEOF_             :: IORef Bool    -- ^ has the handle EOFed or not.

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -111,7 +111,7 @@ handshakeClient cparams ctx = do
             startHandshake ctx highestVer crand
             usingState_ ctx $ setVersionIfUnset highestVer
             sendPacket ctx $ Handshake
-                [ ClientHello highestVer crand clientSession (map cipherID ciphers)
+                [ ClientHello highestVer crand clientSession (map cipherID (ciphers mempty))
                               (map compressionID compressions) extensions Nothing
                 ]
             return $ map (\(ExtensionRaw i _) -> i) extensions
@@ -291,7 +291,7 @@ onServerHello ctx cparams sentExts (ServerHello rver serverRan serverSession cip
         Nothing -> throwCore $ Error_Protocol ("server version " ++ show rver ++ " is not supported", True, ProtocolVersion)
         Just _  -> return ()
     -- find the compression and cipher methods that the server want to use.
-    cipherAlg <- case find ((==) cipher . cipherID) (ctxCiphers ctx) of
+    cipherAlg <- case find ((==) cipher . cipherID) (ctxCiphers ctx mempty) of
                      Nothing  -> throwCore $ Error_Protocol ("server choose unknown cipher", True, HandshakeFailure)
                      Just alg -> return alg
     compressAlg <- case find ((==) compression . compressionID) (supportedCompressions $ ctxSupported ctx) of


### PR DESCRIPTION
This allows to create list of supported ciphers after we have answer from SNI hook.
Technically SNI is always called so if our callback supports `Nothing`  we cover all cases and, really not need the main certificate.
It is possible that additional credentials will support different ciphers than the main one so we need to retest it after we know which ciphers we actually have.