### PR TITLE
Add ClientConfig module

### DIFF
--- a/core/Network/TLS/ClientConfig.hs
+++ b/core/Network/TLS/ClientConfig.hs
@@ -13,6 +13,7 @@ module Network.TLS.ClientConfig (
   defaultParamsClient,
   setCiphers,
   setCA,
+  setServerValidator,
   -- * Ciphers
   Cipher,
   module Network.TLS.Extra.Cipher,
@@ -26,7 +27,7 @@ module Network.TLS.ClientConfig (
   ServerValidator
 ) where
 
-import Network.TLS.Parameters (ClientParams(..), defaultParamsClient, Shared(..), Supported(..))
+import Network.TLS.Parameters (ClientParams(..), defaultParamsClient, Shared(..), Supported(..), ClientHooks(..))
 import Network.TLS.Cipher (Cipher(..))
 import Network.TLS.Extra.Cipher
 import Data.X509 (SignedCertificate, CertificateChain)
@@ -48,6 +49,13 @@ setCiphers ciphers cp = cp { clientSupported = (clientSupported cp) { supportedC
 -- Because 'CertificateStore' is a "Monoid", you can 'mappend' them.
 setCA :: CertificateStore -> ClientParams -> ClientParams
 setCA certs cp = cp { clientShared = (clientShared cp) { sharedCAStore = certs } }
+
+-- | Set the validator of the TLS server.
+-- 
+-- Usually you don't need to call this function, because
+-- 'defaultParamsClient' set a validator appropriate for normal uses.
+setServerValidator :: ServerValidator -> ClientParams -> ClientParams
+setServerValidator validator cp = cp { clientHooks = (clientHooks cp) { onServerCertificate = validator } }
 
 -- | Read a list of certificate files to create a 'CertificateStore'.
 readCertificateStore :: [FilePath] -> IO CertificateStore

--- a/core/Network/TLS/ClientConfig.hs
+++ b/core/Network/TLS/ClientConfig.hs
@@ -21,15 +21,18 @@ module Network.TLS.ClientConfig (
   readCertificateStore,
   makeCertificateStore, listCertificates,
   SignedCertificate,
-  readSignedObject
+  readSignedObject,
+  -- * Server validator
+  ServerValidator
 ) where
 
 import Network.TLS.Parameters (ClientParams(..), defaultParamsClient, Shared(..), Supported(..))
 import Network.TLS.Cipher (Cipher(..))
 import Network.TLS.Extra.Cipher
+import Data.X509 (SignedCertificate, CertificateChain)
 import Data.X509.CertificateStore (CertificateStore, makeCertificateStore, listCertificates)
 import Data.X509.File (readSignedObject)
-import Data.X509 (SignedCertificate)
+import Data.X509.Validation (ValidationCache, ServiceID, FailedReason)
 
 -- | Set ciphers that the client supports. Normally, you can just set
 -- 'ciphersuite_all', which is exported by this module.
@@ -49,3 +52,6 @@ setCA cp certs = cp { clientShared = (clientShared cp) { sharedCAStore = certs }
 -- | Read a list of certificate files to create a 'CertificateStore'.
 readCertificateStore :: [FilePath] -> IO CertificateStore
 readCertificateStore files = fmap (makeCertificateStore . concat) $ mapM readSignedObject files
+
+-- | An action to validate the TLS server.
+type ServerValidator = CertificateStore -> ValidationCache -> ServiceID -> CertificateChain -> IO [FailedReason]

--- a/core/Network/TLS/ClientConfig.hs
+++ b/core/Network/TLS/ClientConfig.hs
@@ -36,8 +36,8 @@ import Data.X509.Validation (ValidationCache, ServiceID, FailedReason)
 
 -- | Set ciphers that the client supports. Normally, you can just set
 -- 'ciphersuite_all', which is exported by this module.
-setCiphers :: ClientParams -> [Cipher] -> ClientParams
-setCiphers cp ciphers = cp { clientSupported = (clientSupported cp) { supportedCiphers = ciphers } }
+setCiphers :: [Cipher] -> ClientParams -> ClientParams
+setCiphers ciphers cp = cp { clientSupported = (clientSupported cp) { supportedCiphers = ciphers } }
 
 -- | Set CA (Certification Authority) the client trusts.
 -- 
@@ -46,8 +46,8 @@ setCiphers cp ciphers = cp { clientSupported = (clientSupported cp) { supportedC
 -- from files, use 'readCertificateStore'.
 --
 -- Because 'CertificateStore' is a "Monoid", you can 'mappend' them.
-setCA :: ClientParams -> CertificateStore -> ClientParams
-setCA cp certs = cp { clientShared = (clientShared cp) { sharedCAStore = certs } }
+setCA :: CertificateStore -> ClientParams -> ClientParams
+setCA certs cp = cp { clientShared = (clientShared cp) { sharedCAStore = certs } }
 
 -- | Read a list of certificate files to create a 'CertificateStore'.
 readCertificateStore :: [FilePath] -> IO CertificateStore

--- a/core/Network/TLS/ClientConfig.hs
+++ b/core/Network/TLS/ClientConfig.hs
@@ -39,9 +39,10 @@ setCiphers cp ciphers = cp { clientSupported = (clientSupported cp) { supportedC
 -- | Set CA (Certification Authority) the client trusts.
 -- 
 -- To load the system-wide CA, use
--- 'System.X509.getSystemCertificateStore'.
+-- 'System.X509.getSystemCertificateStore'.  To load CA certificates
+-- from files, use 'readCertificateStore'.
 --
--- To load CA certificates from files, use 'readCertificateStore'
+-- Because 'CertificateStore' is a "Monoid", you can 'mappend' them.
 setCA :: ClientParams -> CertificateStore -> ClientParams
 setCA cp certs = cp { clientShared = (clientShared cp) { sharedCAStore = certs } }
 

--- a/core/Network/TLS/ClientConfig.hs
+++ b/core/Network/TLS/ClientConfig.hs
@@ -13,22 +13,34 @@ module Network.TLS.ClientConfig (
   defaultParamsClient,
   setCiphers,
   setCA,
-  -- * Re-exports
+  -- * Re-exports (Cipher)
   Cipher(..),
   module Network.TLS.Extra.Cipher,
-  CertificateStore
+  -- * Re-exports (Certificates)
+  CertificateStore,
+  makeCertificateStore, listCertificates,
+  SignedCertificate,
+  readSignedObject
 ) where
 
 import Network.TLS.Parameters (ClientParams(..), defaultParamsClient)
 import Network.TLS.Cipher (Cipher(..))
 import Network.TLS.Extra.Cipher
-import Data.X509.CertificateStore (CertificateStore)
+import Data.X509.CertificateStore (CertificateStore, makeCertificateStore, listCertificates)
+import Data.X509.File (readSignedObject)
+import Data.X509 (SignedCertificate)
 
--- | Set ciphers that the client supports.
+-- | Set ciphers that the client supports. Normally, you can just set
+-- 'ciphersuite_all', which is exported by this module.
 setCiphers :: ClientParams -> [Cipher] -> ClientParams
 setCiphers = undefined
 
--- | Set CA (Certification Authority) the client trusts. To load the
--- system-wide CA, use 'getSystemCertificateStore' from "System.X509".
+-- | Set CA (Certification Authority) the client trusts.
+-- 
+-- To load the system-wide CA, use
+-- 'System.X509.getSystemCertificateStore'.
+--
+-- To load CA certificates from files, use 'readSignedObject' and
+-- 'makeCertificateStore', which are exported by this module.
 setCA :: ClientParams -> CertificateStore -> ClientParams
 setCA = undefined

--- a/core/Network/TLS/ClientConfig.hs
+++ b/core/Network/TLS/ClientConfig.hs
@@ -72,7 +72,7 @@ readCertificateStore files = fmap (makeCertificateStore . concat) $ mapM readSig
 type ServerValidator = CertificateStore -> ValidationCache -> ServiceID -> CertificateChain -> IO [FailedReason]
 
 -- | Make a 'ServerValidator'. You can use 'def' to get
--- 'ValidationChecks' and 'ValidationChecks' appropriate for normal
+-- 'ValidationHooks' and 'ValidationChecks' appropriate for normal
 -- uses.
 makeValidator :: ValidationHooks -> ValidationChecks -> ServerValidator
 makeValidator = validate HashSHA256

--- a/core/Network/TLS/ClientConfig.hs
+++ b/core/Network/TLS/ClientConfig.hs
@@ -1,10 +1,34 @@
 -- |
--- Module      : Network.TLS.Parameters
+-- Module      : Network.TLS.ClientConfig
 -- License     : BSD-style
 -- Maintainer  : Vincent Hanquez <vincent@snarc.org>, Toshio Ito <debug.ito@gmail.com>
 -- Stability   : experimental
 -- Portability : unknown
---
+-- 
+-- This module defines and exports functions useful to configure 'ClientParams'.
 module Network.TLS.ClientConfig (
-  
+  -- * The ClientParams
+  ClientParams(..),
+  -- * Constructors and setters
+  defaultParamsClient,
+  setCiphers,
+  setCA,
+  -- * Re-exports
+  Cipher(..),
+  module Network.TLS.Extra.Cipher,
+  CertificateStore
 ) where
+
+import Network.TLS.Parameters (ClientParams(..), defaultParamsClient)
+import Network.TLS.Cipher (Cipher(..))
+import Network.TLS.Extra.Cipher
+import Data.X509.CertificateStore (CertificateStore)
+
+-- | Set ciphers that the client supports.
+setCiphers :: ClientParams -> [Cipher] -> ClientParams
+setCiphers = undefined
+
+-- | Set CA (Certification Authority) the client trusts. To load the
+-- system-wide CA, use 'getSystemCertificateStore' from "System.X509".
+setCA :: ClientParams -> CertificateStore -> ClientParams
+setCA = undefined

--- a/core/Network/TLS/ClientConfig.hs
+++ b/core/Network/TLS/ClientConfig.hs
@@ -1,0 +1,10 @@
+-- |
+-- Module      : Network.TLS.Parameters
+-- License     : BSD-style
+-- Maintainer  : Vincent Hanquez <vincent@snarc.org>, Toshio Ito <debug.ito@gmail.com>
+-- Stability   : experimental
+-- Portability : unknown
+--
+module Network.TLS.ClientConfig (
+  
+) where

--- a/core/Network/TLS/ClientConfig.hs
+++ b/core/Network/TLS/ClientConfig.hs
@@ -18,6 +18,7 @@ module Network.TLS.ClientConfig (
   module Network.TLS.Extra.Cipher,
   -- * Certificates
   CertificateStore,
+  readCertificateStore,
   makeCertificateStore, listCertificates,
   SignedCertificate,
   readSignedObject
@@ -40,7 +41,10 @@ setCiphers cp ciphers = cp { clientSupported = (clientSupported cp) { supportedC
 -- To load the system-wide CA, use
 -- 'System.X509.getSystemCertificateStore'.
 --
--- To load CA certificates from files, use 'readSignedObject' and
--- 'makeCertificateStore', which are exported by this module.
+-- To load CA certificates from files, use 'readCertificateStore'
 setCA :: ClientParams -> CertificateStore -> ClientParams
 setCA cp certs = cp { clientShared = (clientShared cp) { sharedCAStore = certs } }
+
+-- | Read a list of certificate files to create a 'CertificateStore'.
+readCertificateStore :: [FilePath] -> IO CertificateStore
+readCertificateStore files = fmap (makeCertificateStore . concat) $ mapM readSignedObject files

--- a/core/Network/TLS/ClientConfig.hs
+++ b/core/Network/TLS/ClientConfig.hs
@@ -13,10 +13,10 @@ module Network.TLS.ClientConfig (
   defaultParamsClient,
   setCiphers,
   setCA,
-  -- * Re-exports (Cipher)
-  Cipher(..),
+  -- * Ciphers
+  Cipher,
   module Network.TLS.Extra.Cipher,
-  -- * Re-exports (Certificates)
+  -- * Certificates
   CertificateStore,
   makeCertificateStore, listCertificates,
   SignedCertificate,

--- a/core/Network/TLS/ClientConfig.hs
+++ b/core/Network/TLS/ClientConfig.hs
@@ -23,7 +23,7 @@ module Network.TLS.ClientConfig (
   readSignedObject
 ) where
 
-import Network.TLS.Parameters (ClientParams(..), defaultParamsClient)
+import Network.TLS.Parameters (ClientParams(..), defaultParamsClient, Shared(..), Supported(..))
 import Network.TLS.Cipher (Cipher(..))
 import Network.TLS.Extra.Cipher
 import Data.X509.CertificateStore (CertificateStore, makeCertificateStore, listCertificates)
@@ -33,7 +33,7 @@ import Data.X509 (SignedCertificate)
 -- | Set ciphers that the client supports. Normally, you can just set
 -- 'ciphersuite_all', which is exported by this module.
 setCiphers :: ClientParams -> [Cipher] -> ClientParams
-setCiphers = undefined
+setCiphers cp ciphers = cp { clientSupported = (clientSupported cp) { supportedCiphers = ciphers } }
 
 -- | Set CA (Certification Authority) the client trusts.
 -- 
@@ -43,4 +43,4 @@ setCiphers = undefined
 -- To load CA certificates from files, use 'readSignedObject' and
 -- 'makeCertificateStore', which are exported by this module.
 setCA :: ClientParams -> CertificateStore -> ClientParams
-setCA = undefined
+setCA cp certs = cp { clientShared = (clientShared cp) { sharedCAStore = certs } }

--- a/core/Network/TLS/ClientConfig.hs
+++ b/core/Network/TLS/ClientConfig.hs
@@ -24,16 +24,23 @@ module Network.TLS.ClientConfig (
   SignedCertificate,
   readSignedObject,
   -- * Server validator
-  ServerValidator
+  ServerValidator,
+  makeValidator,
+  ValidationChecks(..),
+  ValidationHooks(..),
+  -- * Default value
+  Default(def)
 ) where
 
 import Network.TLS.Parameters (ClientParams(..), defaultParamsClient, Shared(..), Supported(..), ClientHooks(..))
 import Network.TLS.Cipher (Cipher(..))
 import Network.TLS.Extra.Cipher
-import Data.X509 (SignedCertificate, CertificateChain)
+import Data.X509 (SignedCertificate, CertificateChain, HashALG(HashSHA256))
 import Data.X509.CertificateStore (CertificateStore, makeCertificateStore, listCertificates)
 import Data.X509.File (readSignedObject)
-import Data.X509.Validation (ValidationCache, ServiceID, FailedReason)
+import Data.X509.Validation (ValidationCache, ServiceID, FailedReason, validate,
+                             ValidationChecks(..), ValidationHooks(..))
+import Data.Default.Class (Default(def))
 
 -- | Set ciphers that the client supports. Normally, you can just set
 -- 'ciphersuite_all', which is exported by this module.
@@ -63,3 +70,9 @@ readCertificateStore files = fmap (makeCertificateStore . concat) $ mapM readSig
 
 -- | An action to validate the TLS server.
 type ServerValidator = CertificateStore -> ValidationCache -> ServiceID -> CertificateChain -> IO [FailedReason]
+
+-- | Make a 'ServerValidator'. You can use 'def' to get
+-- 'ValidationChecks' and 'ValidationChecks' appropriate for normal
+-- uses.
+makeValidator :: ValidationHooks -> ValidationChecks -> ServerValidator
+makeValidator = validate HashSHA256

--- a/core/Network/TLS/ClientConfig.hs
+++ b/core/Network/TLS/ClientConfig.hs
@@ -42,12 +42,14 @@ import Data.X509.Validation (ValidationCache, ServiceID, FailedReason, validate,
                              ValidationChecks(..), ValidationHooks(..))
 import Data.Default.Class (Default(def))
 
--- | Set ciphers that the client supports. Normally, you can just set
--- 'ciphersuite_all', which is exported by this module.
+-- | Set ciphers that the client supports. This sets 'supportedCiphers' in 'clientSupported' in 'ClientParams'.
+--
+-- Normally, you can just set 'ciphersuite_all', which is exported by
+-- this module.
 setCiphers :: [Cipher] -> ClientParams -> ClientParams
 setCiphers ciphers cp = cp { clientSupported = (clientSupported cp) { supportedCiphers = ciphers } }
 
--- | Set CA (Certification Authority) the client trusts.
+-- | Set CA (Certification Authority) the client trusts. This sets 'sharedCAStore' in 'clientShared' in 'ClientParams'.
 -- 
 -- To load the system-wide CA, use
 -- 'System.X509.getSystemCertificateStore'.  To load CA certificates

--- a/core/Network/TLS/ClientConfig.hs
+++ b/core/Network/TLS/ClientConfig.hs
@@ -77,4 +77,4 @@ type ServerValidator = CertificateStore -> ValidationCache -> ServiceID -> Certi
 -- 'ValidationHooks' and 'ValidationChecks' appropriate for normal
 -- uses.
 makeValidator :: ValidationHooks -> ValidationChecks -> ServerValidator
-makeValidator = validate HashSHA256
+makeValidator = validate HashSHA256  -- See 'Data.X509.Validation.validateDefault'

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -94,6 +94,11 @@ data ClientParams = ClientParams
     } deriving (Show)
 
 -- | Create a 'ClientParams' with default values.
+--
+-- Note that this default 'ClientParams' is __practically useless__
+-- because it has no CA certificates or supported ciphers. At least
+-- you have to set 'sharedCAStore' in 'clientShared' and
+-- 'supportedCiphers' in 'clientSupported'.
 defaultParamsClient :: HostName -- ^ server name in 'clientServerIdentification'.
                     -> Bytes -- ^ service identification in 'clientServerIdentification'.
                     -> ClientParams

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -92,7 +92,10 @@ data ClientParams = ClientParams
     , clientDebug                     :: DebugParams
     } deriving (Show)
 
-defaultParamsClient :: HostName -> Bytes -> ClientParams
+-- | Create a 'ClientParams' with default values.
+defaultParamsClient :: HostName -- ^ server name in 'clientServerIdentification'.
+                    -> Bytes -- ^ service identification in 'clientServerIdentification'.
+                    -> ClientParams
 defaultParamsClient serverName serverId = ClientParams
     { clientWantSessionResume    = Nothing
     , clientUseMaxFragmentLength = Nothing

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -69,6 +69,7 @@ instance Show DebugParams where
 instance Default DebugParams where
     def = defaultDebugParams
 
+-- | Parameters to configure a TLS client. For light-weight configuration, see also "Network.TLS.ClientConfig".
 data ClientParams = ClientParams
     { clientUseMaxFragmentLength    :: Maybe MaxFragmentEnum
       -- | Define the name of the server, along with an extra service identification blob.

--- a/core/Tests/ClientConfig.hs
+++ b/core/Tests/ClientConfig.hs
@@ -1,17 +1,22 @@
 module ClientConfig (
   prop_setCiphers,
-  prop_setCA
+  prop_setCA,
+  prop_setServerValidator
 ) where
 
 import Control.Applicative ((<$>), (<*>))
+import Data.Monoid (mempty)
 import qualified Data.ByteString.Char8 as BC
 import Network.TLS.ClientConfig (
   Cipher, ciphersuite_all, ClientParams(..), Default(def),
   defaultParamsClient,
-  setCiphers, setCA,
+  setCiphers, setCA, setServerValidator,
   makeCertificateStore, listCertificates)
 import qualified Network.TLS as TLS
-import Test.QuickCheck (Arbitrary(arbitrary), elements)
+import Test.QuickCheck (Arbitrary(arbitrary), elements, oneof)
+import Test.QuickCheck.Monadic (PropertyM, run, pick, assert)
+import Data.X509.Validation (FailedReason(..))
+import Data.X509 (CertificateChain(..))
 
 instance Arbitrary Cipher where
   arbitrary = elements ciphersuite_all
@@ -22,8 +27,36 @@ instance Arbitrary BC.ByteString where
 instance Arbitrary ClientParams where
   arbitrary = defaultParamsClient <$> arbitrary <*> arbitrary
 
+instance Arbitrary FailedReason where
+  arbitrary = oneof $ map return [
+    UnknownCriticalExtension,
+    Expired,
+    InFuture,
+    SelfSigned,
+    UnknownCA,
+    NotAllowedToSign,
+    NotAnAuthority,
+    AuthorityTooDeep,
+    NoCommonName,
+    InvalidWildcard,
+    LeafKeyUsageNotAllowed,
+    LeafKeyPurposeNotAllowed,
+    LeafNotV3,
+    EmptyChain
+    ] ++ map (<$> arbitrary) [InvalidName, NameMismatch, CacheSaysNo]
+
+
 prop_setCiphers :: [Cipher] -> ClientParams -> Bool
 prop_setCiphers ciphers cp = ciphers == (TLS.supportedCiphers $ clientSupported $ setCiphers ciphers cp)
 
 prop_setCA :: ClientParams -> Bool
 prop_setCA cp = [] == (listCertificates $ TLS.sharedCAStore $ clientShared $ setCA (makeCertificateStore []) cp)
+
+prop_setServerValidator :: PropertyM IO ()
+prop_setServerValidator = do
+  exp_reasons <- pick $ arbitrary
+  cp <- pick $ arbitrary
+  let input_validator = \_ _ _ _ -> return exp_reasons
+      got_validator = (TLS.onServerCertificate $ clientHooks $ setServerValidator input_validator cp)
+  got_reasons <- run $ got_validator mempty def (mempty, mempty) (CertificateChain [])
+  assert (got_reasons == exp_reasons)

--- a/core/Tests/ClientConfig.hs
+++ b/core/Tests/ClientConfig.hs
@@ -1,0 +1,20 @@
+module ClientConfig (
+  prop_setCiphers
+) where
+
+import Control.Applicative ((<$>), (<*>))
+import Network.TLS.ClientConfig (
+  Cipher, ciphersuite_all, ClientParams(..), Default(def),
+  defaultParamsClient,
+  setCiphers)
+import qualified Network.TLS as TLS
+import Test.QuickCheck (Arbitrary(arbitrary), elements)
+
+instance Arbitrary Cipher where
+  arbitrary = elements ciphersuite_all
+
+instance Arbitrary ClientParams where
+  arbitrary = defaultParamsClient <$> arbitrary <*> arbitrary
+
+prop_setCiphers :: [Cipher] -> ClientParams -> Bool
+prop_setCiphers ciphers cp = (TLS.supportedCiphers $ clientSupported $ setCiphers ciphers cp) == ciphers

--- a/core/Tests/ClientConfig.hs
+++ b/core/Tests/ClientConfig.hs
@@ -1,5 +1,6 @@
 module ClientConfig (
-  prop_setCiphers
+  prop_setCiphers,
+  prop_setCA
 ) where
 
 import Control.Applicative ((<$>), (<*>))
@@ -7,7 +8,8 @@ import qualified Data.ByteString.Char8 as BC
 import Network.TLS.ClientConfig (
   Cipher, ciphersuite_all, ClientParams(..), Default(def),
   defaultParamsClient,
-  setCiphers)
+  setCiphers, setCA,
+  makeCertificateStore, listCertificates)
 import qualified Network.TLS as TLS
 import Test.QuickCheck (Arbitrary(arbitrary), elements)
 
@@ -21,4 +23,7 @@ instance Arbitrary ClientParams where
   arbitrary = defaultParamsClient <$> arbitrary <*> arbitrary
 
 prop_setCiphers :: [Cipher] -> ClientParams -> Bool
-prop_setCiphers ciphers cp = (TLS.supportedCiphers $ clientSupported $ setCiphers ciphers cp) == ciphers
+prop_setCiphers ciphers cp = ciphers == (TLS.supportedCiphers $ clientSupported $ setCiphers ciphers cp)
+
+prop_setCA :: ClientParams -> Bool
+prop_setCA cp = [] == (listCertificates $ TLS.sharedCAStore $ clientShared $ setCA (makeCertificateStore []) cp)

--- a/core/Tests/ClientConfig.hs
+++ b/core/Tests/ClientConfig.hs
@@ -3,6 +3,7 @@ module ClientConfig (
 ) where
 
 import Control.Applicative ((<$>), (<*>))
+import qualified Data.ByteString.Char8 as BC
 import Network.TLS.ClientConfig (
   Cipher, ciphersuite_all, ClientParams(..), Default(def),
   defaultParamsClient,
@@ -12,6 +13,9 @@ import Test.QuickCheck (Arbitrary(arbitrary), elements)
 
 instance Arbitrary Cipher where
   arbitrary = elements ciphersuite_all
+
+instance Arbitrary BC.ByteString where
+  arbitrary = BC.pack <$> arbitrary
 
 instance Arbitrary ClientParams where
   arbitrary = defaultParamsClient <$> arbitrary <*> arbitrary

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -8,6 +8,7 @@ import PipeChan
 import Connection
 import Marshalling
 import Ciphers
+import qualified ClientConfig
 
 import Data.Maybe
 
@@ -169,6 +170,7 @@ main = defaultMain $ testGroup "tls"
     [ tests_marshalling
     , tests_ciphers
     , tests_handshake
+    , tests_clientconfig
     ]
   where -- lowlevel tests to check the packet marshalling.
         tests_marshalling = testGroup "Marshalling"
@@ -186,3 +188,9 @@ main = defaultMain $ testGroup "tls"
             , testProperty "renegociation" (monadicIO prop_handshake_renegociation)
             , testProperty "resumption" (monadicIO prop_handshake_session_resumption)
             ]
+
+        -- tests for ClientConfig module
+        tests_clientconfig = testGroup "ClientConfig"
+            [ testProperty "setCiphers" prop_setCiphers
+            ]
+

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -192,5 +192,6 @@ main = defaultMain $ testGroup "tls"
         -- tests for ClientConfig module
         tests_clientconfig = testGroup "ClientConfig"
             [ testProperty "setCiphers" ClientConfig.prop_setCiphers
+            , testProperty "setCA" ClientConfig.prop_setCA
             ]
 

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -193,5 +193,6 @@ main = defaultMain $ testGroup "tls"
         tests_clientconfig = testGroup "ClientConfig"
             [ testProperty "setCiphers" ClientConfig.prop_setCiphers
             , testProperty "setCA" ClientConfig.prop_setCA
+            , testProperty "setServerValidator" (monadicIO ClientConfig.prop_setServerValidator)
             ]
 

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -191,6 +191,6 @@ main = defaultMain $ testGroup "tls"
 
         -- tests for ClientConfig module
         tests_clientconfig = testGroup "ClientConfig"
-            [ testProperty "setCiphers" prop_setCiphers
+            [ testProperty "setCiphers" ClientConfig.prop_setCiphers
             ]
 

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -68,6 +68,7 @@ Library
                      Network.TLS.Internal
                      Network.TLS.Extra
                      Network.TLS.Extra.Cipher
+                     Network.TLS.ClientConfig
   other-modules:     Network.TLS.Cap
                      Network.TLS.Struct
                      Network.TLS.Core


### PR DESCRIPTION
This patch adds a new module `Network.TLS.ClientConfig`, which helps users configure their client-side TLS settings.

I think `Network.TLS` module is too difficult for some users. Even a simple customization (such as adding a CA certificate to `ClientParams`) requires traversing its nested structures, looking for the right field to modify, consulting other modules and importing necessary symbols from them. This is so time consuming.

`Network.TLS.ClientConfig` module is the one-stop module to configure `ClientParams`. It defines some setter functions for fields that I think many users want to customize. It also re-exports data types from other modules, so users don't need to import them one by one.
