### PR TITLE
Restore ability to renegotiate

### DIFF
--- a/core/Network/TLS/Handshake/Process.hs
+++ b/core/Network/TLS/Handshake/Process.hs
@@ -120,10 +120,8 @@ processClientFinished ctx fdata = do
     usingState_ ctx $ updateVerifiedData ServerRole fdata
     return ()
 
+-- initialize a new Handshake context (initial handshake or renegotiations)
 startHandshake :: Context -> Version -> ClientRandom -> IO ()
-startHandshake ctx ver crand = do
-    -- FIXME check if handshake is already not null
-    liftIO $ modifyMVar_ (ctxHandshake ctx) $ \hs ->
-        case hs of
-            Nothing -> return $ Just $ newEmptyHandshake ver crand
-            Just _  -> return hs
+startHandshake ctx ver crand =
+    let hs = Just $ newEmptyHandshake ver crand
+    in liftIO $ void $ swapMVar (ctxHandshake ctx) hs

--- a/debug/src/SimpleServer.hs
+++ b/debug/src/SimpleServer.hs
@@ -83,7 +83,9 @@ getDefaultParams flags store sStorage cred _session = do
                              , sharedCredentials     = Credentials [cred]
                              }
         , serverHooks = def
-        , serverSupported = def { supportedVersions = supportedVers, supportedCiphers = myCiphers }
+        , serverSupported = def { supportedVersions = supportedVers
+                                , supportedCiphers = myCiphers
+                                , supportedClientInitiatedRenegotiation = allowRenegotiation }
         , serverDebug = def { debugSeed      = foldl getDebugSeed Nothing flags
                             , debugPrintSeed = if DebugPrintSeed `elem` flags
                                                     then (\seed -> putStrLn ("seed: " ++ show (seedToInteger seed)))
@@ -133,11 +135,13 @@ getDefaultParams flags store sStorage cred _session = do
                 | otherwise = filter (<= tlsConnectVer) allVers
             allVers = [SSL3, TLS10, TLS11, TLS12]
             validateCert = not (NoValidateCert `elem` flags)
+            allowRenegotiation = AllowRenegotiation `elem` flags
 
 data Flag = Verbose | Debug | IODebug | NoValidateCert | Session | Http11
           | Ssl3 | Tls10 | Tls11 | Tls12
           | NoSNI
           | NoVersionDowngrade
+          | AllowRenegotiation
           | Output String
           | Timeout String
           | BogusCipher String
@@ -171,6 +175,7 @@ options =
     , Option []     ["tls12"]   (NoArg Tls12) "use TLS 1.2 (default)"
     , Option []     ["bogocipher"] (ReqArg BogusCipher "cipher-id") "add a bogus cipher id for testing"
     , Option ['x']  ["no-version-downgrade"] (NoArg NoVersionDowngrade) "do not allow version downgrade"
+    , Option []     ["allow-renegotiation"] (NoArg AllowRenegotiation) "allow client-initiated renegotiation"
     , Option ['h']  ["help"]    (NoArg Help) "request help"
     , Option []     ["bench-send"]   (NoArg BenchSend) "benchmark send path. only with compatible server"
     , Option []     ["bench-recv"]   (NoArg BenchRecv) "benchmark recv path. only with compatible server"


### PR DESCRIPTION
This is a fix for #161.

The handshake behaviour is slightly modified because the implementation will now accept to start a second handshake replacing a first handshake that is not finished yet. I don’t think this can cause any harm, especially with secure renegotiations. But if required it should also be possible to use more complex logic or add new state to discriminate between finished and on-going handshake cases.  
