### PR TITLE
Enable sha384 ciphers

### DIFF
--- a/core/Network/TLS/Cipher.hs
+++ b/core/Network/TLS/Cipher.hs
@@ -125,6 +125,7 @@ data Cipher = Cipher
     , cipherBulk         :: Bulk
     , cipherKeyExchange  :: CipherKeyExchangeType
     , cipherMinVer       :: Maybe Version
+    , cipherPRFHash      :: Maybe Hash
     }
 
 cipherKeyBlockSize :: Cipher -> Int

--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -122,13 +122,16 @@ instance TLSParams ServerParams where
                         CipherKeyExchange_DHE_RSA     -> canSignRSA && canDHE
                         CipherKeyExchange_DHE_DSS     -> canSignDSS && canDHE
                         CipherKeyExchange_ECDHE_RSA   -> canSignRSA
-                        -- unimplemented: non ephemeral DH
+                        -- unimplemented: EC
+                        CipherKeyExchange_ECDHE_ECDSA -> False
+                        -- unimplemented: non ephemeral DH & ECDH.
+                        -- Note, these *should not* be implemented, and have
+                        -- (for example) been removed in OpenSSL 1.1.0
+                        --
                         CipherKeyExchange_DH_DSS      -> False
                         CipherKeyExchange_DH_RSA      -> False
-                        -- unimplemented: EC
                         CipherKeyExchange_ECDH_ECDSA  -> False
                         CipherKeyExchange_ECDH_RSA    -> False
-                        CipherKeyExchange_ECDHE_ECDSA -> False
 
                 canDHE        = isJust $ serverDHEParams sparams
                 canSignDSS    = SignatureDSS `elem` signingAlgs

--- a/core/Network/TLS/Extension.hs
+++ b/core/Network/TLS/Extension.hs
@@ -270,7 +270,7 @@ data BrainPoolCurve =
     deriving (Show,Eq)
 
 availableEllipticCurves :: [NamedCurve]
-availableEllipticCurves = [SEC SEC_p256r1, SEC SEC_p521r1]
+availableEllipticCurves = [SEC SEC_p256r1, SEC SEC_p384r1, SEC SEC_p521r1]
 
 instance EnumSafe16 NamedCurve where
     fromEnumSafe16 NamedCurve_arbitrary_explicit_prime_curves = 0xFF01

--- a/core/Network/TLS/Extra/Cipher.hs
+++ b/core/Network/TLS/Extra/Cipher.hs
@@ -260,6 +260,7 @@ cipher_null_MD5 = Cipher
     , cipherName         = "RSA-null-MD5"
     , cipherBulk         = bulk_null
     , cipherHash         = MD5
+    , cipherPRFHash      = Nothing
     , cipherKeyExchange  = CipherKeyExchange_RSA
     , cipherMinVer       = Nothing
     }
@@ -271,6 +272,7 @@ cipher_null_SHA1 = Cipher
     , cipherName         = "RSA-null-SHA1"
     , cipherBulk         = bulk_null
     , cipherHash         = SHA1
+    , cipherPRFHash      = Nothing
     , cipherKeyExchange  = CipherKeyExchange_RSA
     , cipherMinVer       = Nothing
     }
@@ -282,6 +284,7 @@ cipher_RC4_128_MD5 = Cipher
     , cipherName         = "RSA-rc4-128-md5"
     , cipherBulk         = bulk_rc4
     , cipherHash         = MD5
+    , cipherPRFHash      = Nothing
     , cipherKeyExchange  = CipherKeyExchange_RSA
     , cipherMinVer       = Nothing
     }
@@ -293,6 +296,7 @@ cipher_RC4_128_SHA1 = Cipher
     , cipherName         = "RSA-rc4-128-sha1"
     , cipherBulk         = bulk_rc4
     , cipherHash         = SHA1
+    , cipherPRFHash      = Nothing
     , cipherKeyExchange  = CipherKeyExchange_RSA
     , cipherMinVer       = Nothing
     }
@@ -304,6 +308,7 @@ cipher_AES128_SHA1 = Cipher
     , cipherName         = "RSA-AES128-SHA1"
     , cipherBulk         = bulk_aes128
     , cipherHash         = SHA1
+    , cipherPRFHash      = Nothing
     , cipherKeyExchange  = CipherKeyExchange_RSA
     , cipherMinVer       = Just SSL3
     }
@@ -315,6 +320,7 @@ cipher_DHE_DSS_AES128_SHA1 = Cipher
     , cipherName         = "DHE-DSA-AES128-SHA1"
     , cipherBulk         = bulk_aes128
     , cipherHash         = SHA1
+    , cipherPRFHash      = Nothing
     , cipherKeyExchange  = CipherKeyExchange_DHE_DSS
     , cipherMinVer       = Nothing
     }
@@ -326,6 +332,7 @@ cipher_DHE_RSA_AES128_SHA1 = Cipher
     , cipherName         = "DHE-RSA-AES128-SHA1"
     , cipherBulk         = bulk_aes128
     , cipherHash         = SHA1
+    , cipherPRFHash      = Nothing
     , cipherKeyExchange  = CipherKeyExchange_DHE_RSA
     , cipherMinVer       = Nothing
     }
@@ -337,6 +344,7 @@ cipher_AES256_SHA1 = Cipher
     , cipherName         = "RSA-AES256-SHA1"
     , cipherBulk         = bulk_aes256
     , cipherHash         = SHA1
+    , cipherPRFHash      = Nothing
     , cipherKeyExchange  = CipherKeyExchange_RSA
     , cipherMinVer       = Just SSL3
     }
@@ -364,6 +372,7 @@ cipher_AES128_SHA256 = Cipher
     , cipherName         = "RSA-AES128-SHA256"
     , cipherBulk         = bulk_aes128
     , cipherHash         = SHA256
+    , cipherPRFHash      = Just SHA256
     , cipherKeyExchange  = CipherKeyExchange_RSA
     , cipherMinVer       = Just TLS12
     }
@@ -375,6 +384,7 @@ cipher_AES256_SHA256 = Cipher
     , cipherName         = "RSA-AES256-SHA256"
     , cipherBulk         = bulk_aes256
     , cipherHash         = SHA256
+    , cipherPRFHash      = Just SHA256
     , cipherKeyExchange  = CipherKeyExchange_RSA
     , cipherMinVer       = Just TLS12
     }
@@ -392,6 +402,7 @@ cipher_DHE_RSA_AES128_SHA256 = cipher_DHE_RSA_AES128_SHA1
     { cipherID           = 0x67
     , cipherName         = "DHE-RSA-AES128-SHA256"
     , cipherHash         = SHA256
+    , cipherPRFHash      = Just SHA256
     , cipherMinVer       = Just TLS12
     }
 
@@ -409,6 +420,7 @@ cipher_RSA_3DES_EDE_CBC_SHA1 = Cipher
     , cipherName         = "RSA-3DES-EDE-CBC-SHA1"
     , cipherBulk         = bulk_tripledes_ede
     , cipherHash         = SHA1
+    , cipherPRFHash      = Nothing
     , cipherKeyExchange  = CipherKeyExchange_RSA
     , cipherMinVer       = Nothing
     }
@@ -419,6 +431,7 @@ cipher_DHE_RSA_AES128GCM_SHA256 = Cipher
     , cipherName         = "DHE-RSA-AES128GCM-SHA256"
     , cipherBulk         = bulk_aes128gcm
     , cipherHash         = SHA256
+    , cipherPRFHash      = Just SHA256
     , cipherKeyExchange  = CipherKeyExchange_DHE_RSA
     , cipherMinVer       = Just TLS12 -- RFC 5288 Sec 4
     }
@@ -429,6 +442,7 @@ cipher_ECDHE_RSA_AES128CBC_SHA = Cipher
     , cipherName         = "ECDHE-RSA-AES128CBC-SHA"
     , cipherBulk         = bulk_aes128
     , cipherHash         = SHA1
+    , cipherPRFHash      = Nothing
     , cipherKeyExchange  = CipherKeyExchange_ECDHE_RSA
     , cipherMinVer       = Just TLS10
     }
@@ -439,6 +453,7 @@ cipher_ECDHE_RSA_AES256CBC_SHA = Cipher
     , cipherName         = "ECDHE-RSA-AES256CBC-SHA"
     , cipherBulk         = bulk_aes256
     , cipherHash         = SHA1
+    , cipherPRFHash      = Nothing
     , cipherKeyExchange  = CipherKeyExchange_ECDHE_RSA
     , cipherMinVer       = Just TLS10
     }
@@ -449,16 +464,18 @@ cipher_ECDHE_RSA_AES128CBC_SHA256 = Cipher
     , cipherName         = "ECDHE-RSA-AES128CBC-SHA256"
     , cipherBulk         = bulk_aes128
     , cipherHash         = SHA256
+    , cipherPRFHash      = Just SHA256
     , cipherKeyExchange  = CipherKeyExchange_ECDHE_RSA
     , cipherMinVer       = Just TLS12 -- RFC 5288 Sec 4
     }
 
 cipher_ECDHE_RSA_AES256CBC_SHA384 :: Cipher
 cipher_ECDHE_RSA_AES256CBC_SHA384 = Cipher
-    { cipherID           = 0xc027
+    { cipherID           = 0xc028
     , cipherName         = "ECDHE-RSA-AES256CBC-SHA384"
     , cipherBulk         = bulk_aes256
     , cipherHash         = SHA384
+    , cipherPRFHash      = Just SHA384
     , cipherKeyExchange  = CipherKeyExchange_ECDHE_RSA
     , cipherMinVer       = Just TLS12 -- RFC 5288 Sec 4
     }
@@ -469,6 +486,7 @@ cipher_ECDHE_ECDSA_AES128GCM_SHA256 = Cipher
     , cipherName         = "ECDHE-ECDSA-AES128GCM-SHA256"
     , cipherBulk         = bulk_aes128gcm
     , cipherHash         = SHA256
+    , cipherPRFHash      = Just SHA256
     , cipherKeyExchange  = CipherKeyExchange_ECDHE_ECDSA
     , cipherMinVer       = Just TLS12 -- RFC 5289
     }
@@ -479,6 +497,7 @@ cipher_ECDHE_RSA_AES128GCM_SHA256 = Cipher
     , cipherName         = "ECDHE-RSA-AES128GCM-SHA256"
     , cipherBulk         = bulk_aes128gcm
     , cipherHash         = SHA256
+    , cipherPRFHash      = Just SHA256
     , cipherKeyExchange  = CipherKeyExchange_ECDHE_RSA
     , cipherMinVer       = Just TLS12 -- RFC 5288 Sec 4
     }
@@ -486,9 +505,10 @@ cipher_ECDHE_RSA_AES128GCM_SHA256 = Cipher
 cipher_ECDHE_RSA_AES256GCM_SHA384 :: Cipher
 cipher_ECDHE_RSA_AES256GCM_SHA384 = Cipher
     { cipherID           = 0xc030
-    , cipherName         = "ECDHE-RSA-AES256GCM-SHA256"
+    , cipherName         = "ECDHE-RSA-AES256GCM-SHA384"
     , cipherBulk         = bulk_aes256gcm
     , cipherHash         = SHA384
+    , cipherPRFHash      = Just SHA384
     , cipherKeyExchange  = CipherKeyExchange_ECDHE_RSA
     , cipherMinVer       = Just TLS12 -- RFC 5289
     }

--- a/core/Network/TLS/Extra/Cipher.hs
+++ b/core/Network/TLS/Extra/Cipher.hs
@@ -18,29 +18,38 @@ module Network.TLS.Extra.Cipher
     , ciphersuite_dhe_dss
     -- * individual ciphers
     , cipher_null_SHA1
-    , cipher_null_MD5
-    , cipher_RC4_128_MD5
-    , cipher_RC4_128_SHA1
     , cipher_AES128_SHA1
     , cipher_AES256_SHA1
     , cipher_AES128_SHA256
     , cipher_AES256_SHA256
-    , cipher_RSA_3DES_EDE_CBC_SHA1
+    , cipher_AES128GCM_SHA256
+    , cipher_AES256GCM_SHA384
     , cipher_DHE_RSA_AES128_SHA1
     , cipher_DHE_RSA_AES256_SHA1
     , cipher_DHE_RSA_AES128_SHA256
     , cipher_DHE_RSA_AES256_SHA256
     , cipher_DHE_DSS_AES128_SHA1
     , cipher_DHE_DSS_AES256_SHA1
-    , cipher_DHE_DSS_RC4_SHA1
     , cipher_DHE_RSA_AES128GCM_SHA256
+    , cipher_DHE_RSA_AES256GCM_SHA384
     , cipher_ECDHE_RSA_AES128GCM_SHA256
     , cipher_ECDHE_RSA_AES256GCM_SHA384
     , cipher_ECDHE_RSA_AES128CBC_SHA256
     , cipher_ECDHE_RSA_AES128CBC_SHA
     , cipher_ECDHE_RSA_AES256CBC_SHA
     , cipher_ECDHE_RSA_AES256CBC_SHA384
+    , cipher_ECDHE_ECDSA_AES128CBC_SHA
+    , cipher_ECDHE_ECDSA_AES256CBC_SHA
+    , cipher_ECDHE_ECDSA_AES128CBC_SHA256
+    , cipher_ECDHE_ECDSA_AES256CBC_SHA384
     , cipher_ECDHE_ECDSA_AES128GCM_SHA256
+    , cipher_ECDHE_ECDSA_AES256GCM_SHA384
+    -- * obsolete and non-standard ciphers
+    , cipher_RSA_3DES_EDE_CBC_SHA1
+    , cipher_RC4_128_MD5
+    , cipher_RC4_128_SHA1
+    , cipher_null_MD5
+    , cipher_DHE_DSS_RC4_SHA1
     ) where
 
 import qualified Data.ByteString as B
@@ -389,6 +398,31 @@ cipher_AES256_SHA256 = Cipher
     , cipherMinVer       = Just TLS12
     }
 
+-- | AESGCM cipher (128 bit key), RSA key exchange.
+-- The SHA256 digest is used as a PRF, not as a MAC.
+cipher_AES128GCM_SHA256 :: Cipher
+cipher_AES128GCM_SHA256 = Cipher
+    { cipherID           = 0x9c
+    , cipherName         = "RSA-AES128GCM-SHA256"
+    , cipherBulk         = bulk_aes128gcm
+    , cipherHash         = SHA256
+    , cipherPRFHash      = Just SHA256
+    , cipherKeyExchange  = CipherKeyExchange_RSA
+    , cipherMinVer       = Just TLS12
+    }
+
+-- | AESGCM cipher (256 bit key), RSA key exchange.
+-- The SHA384 digest is used as a PRF, not as a MAC.
+cipher_AES256GCM_SHA384 :: Cipher
+cipher_AES256GCM_SHA384 = Cipher
+    { cipherID           = 0x9d
+    , cipherName         = "RSA-AES256GCM-SHA384"
+    , cipherBulk         = bulk_aes256gcm
+    , cipherHash         = SHA384
+    , cipherPRFHash      = Just SHA384
+    , cipherKeyExchange  = CipherKeyExchange_RSA
+    , cipherMinVer       = Just TLS12
+    }
 
 cipher_DHE_DSS_RC4_SHA1 :: Cipher
 cipher_DHE_DSS_RC4_SHA1 = cipher_DHE_DSS_AES128_SHA1
@@ -436,6 +470,39 @@ cipher_DHE_RSA_AES128GCM_SHA256 = Cipher
     , cipherMinVer       = Just TLS12 -- RFC 5288 Sec 4
     }
 
+cipher_DHE_RSA_AES256GCM_SHA384 :: Cipher
+cipher_DHE_RSA_AES256GCM_SHA384 = Cipher
+    { cipherID           = 0x9f
+    , cipherName         = "DHE-RSA-AES256GCM-SHA384"
+    , cipherBulk         = bulk_aes256gcm
+    , cipherHash         = SHA384
+    , cipherPRFHash      = Just SHA384
+    , cipherKeyExchange  = CipherKeyExchange_DHE_RSA
+    , cipherMinVer       = Just TLS12
+    }
+
+cipher_ECDHE_ECDSA_AES128CBC_SHA :: Cipher
+cipher_ECDHE_ECDSA_AES128CBC_SHA = Cipher
+    { cipherID           = 0xc009
+    , cipherName         = "ECDHE-ECDSA-AES128CBC-SHA"
+    , cipherBulk         = bulk_aes128
+    , cipherHash         = SHA1
+    , cipherPRFHash      = Nothing
+    , cipherKeyExchange  = CipherKeyExchange_ECDHE_RSA
+    , cipherMinVer       = Just TLS10
+    }
+
+cipher_ECDHE_ECDSA_AES256CBC_SHA :: Cipher
+cipher_ECDHE_ECDSA_AES256CBC_SHA = Cipher
+    { cipherID           = 0xc00A
+    , cipherName         = "ECDHE-ECDSA-AES256CBC-SHA"
+    , cipherBulk         = bulk_aes256
+    , cipherHash         = SHA1
+    , cipherPRFHash      = Nothing
+    , cipherKeyExchange  = CipherKeyExchange_ECDHE_RSA
+    , cipherMinVer       = Just TLS10
+    }
+
 cipher_ECDHE_RSA_AES128CBC_SHA :: Cipher
 cipher_ECDHE_RSA_AES128CBC_SHA = Cipher
     { cipherID           = 0xc013
@@ -480,6 +547,28 @@ cipher_ECDHE_RSA_AES256CBC_SHA384 = Cipher
     , cipherMinVer       = Just TLS12 -- RFC 5288 Sec 4
     }
 
+cipher_ECDHE_ECDSA_AES128CBC_SHA256 :: Cipher
+cipher_ECDHE_ECDSA_AES128CBC_SHA256 = Cipher
+    { cipherID           = 0xc023
+    , cipherName         = "ECDHE-ECDSA-AES128CBC-SHA256"
+    , cipherBulk         = bulk_aes128
+    , cipherHash         = SHA256
+    , cipherPRFHash      = Just SHA256
+    , cipherKeyExchange  = CipherKeyExchange_ECDHE_ECDSA
+    , cipherMinVer       = Just TLS12 -- RFC 5289
+    }
+
+cipher_ECDHE_ECDSA_AES256CBC_SHA384 :: Cipher
+cipher_ECDHE_ECDSA_AES256CBC_SHA384 = Cipher
+    { cipherID           = 0xc024
+    , cipherName         = "ECDHE-ECDSA-AES256CBC-SHA384"
+    , cipherBulk         = bulk_aes256
+    , cipherHash         = SHA384
+    , cipherPRFHash      = Just SHA384
+    , cipherKeyExchange  = CipherKeyExchange_ECDHE_ECDSA
+    , cipherMinVer       = Just TLS12 -- RFC 5289
+    }
+
 cipher_ECDHE_ECDSA_AES128GCM_SHA256 :: Cipher
 cipher_ECDHE_ECDSA_AES128GCM_SHA256 = Cipher
     { cipherID           = 0xc02b
@@ -487,6 +576,17 @@ cipher_ECDHE_ECDSA_AES128GCM_SHA256 = Cipher
     , cipherBulk         = bulk_aes128gcm
     , cipherHash         = SHA256
     , cipherPRFHash      = Just SHA256
+    , cipherKeyExchange  = CipherKeyExchange_ECDHE_ECDSA
+    , cipherMinVer       = Just TLS12 -- RFC 5289
+    }
+
+cipher_ECDHE_ECDSA_AES256GCM_SHA384 :: Cipher
+cipher_ECDHE_ECDSA_AES256GCM_SHA384 = Cipher
+    { cipherID           = 0xc02c
+    , cipherName         = "ECDHE-ECDSA-AES256GCM-SHA384"
+    , cipherBulk         = bulk_aes256gcm
+    , cipherHash         = SHA384
+    , cipherPRFHash      = Just SHA384
     , cipherKeyExchange  = CipherKeyExchange_ECDHE_ECDSA
     , cipherMinVer       = Just TLS12 -- RFC 5289
     }
@@ -545,6 +645,9 @@ CipherSuite TLS_DH_anon_EXPORT_WITH_DES40_CBC_SHA = { 0x00,0x19 };
 CipherSuite TLS_DH_anon_WITH_DES_CBC_SHA          = { 0x00,0x1A };
 CipherSuite TLS_DH_anon_WITH_3DES_EDE_CBC_SHA     = { 0x00,0x1B };
 
+TLS-RSA-WITH-AES-128-GCM-SHA256    {0x00,0x9C}
+TLS-RSA-WITH-AES-256-GCM-SHA384    {0x00,0x9D}
+
 TLS-DHE-RSA-WITH-AES-128-CBC-SHA     {0x00,0x33}
 TLS-DHE-RSA-WITH-AES-256-CBC-SHA     {0x00,0x39}
 TLS-DHE-RSA-WITH-AES-128-CBC-SHA256   {0x00,0x67}
@@ -573,6 +676,13 @@ TLS-ECDHE-RSA-WITH-CAMELLIA-256-GCM-SHA384    {0xC0,0x8B}
 TLS-ECDHE-RSA-WITH-3DES-EDE-CBC-SHA  {0xC0,0x12}
 TLS-ECDHE-RSA-WITH-RC4-128-SHA    {0xC0,0x11}
 TLS-ECDHE-RSA-WITH-NULL-SHA  {0xC0,0x10}
+
+TLS-ECDHE-ECDSA-WITH-AES-128-CBC-SHA    {0xC0,0x09}
+TLS-ECDHE-ECDSA-WITH-AES-256-CBC-SHA    {0xC0,0x0A}
+TLS-ECDHE-ECDSA-WITH-AES-128-CBC-SHA256 {0xC0,0x23}
+TLS-ECDHE-ECDSA-WITH-AES-256-CBC-SHA384 {0xC0,0x24}
+TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256 {0xC0,0x2B}
+TLS-ECDHE-ECDSA-WITH-AES-256-GCM-SHA384 {0xC0,0x2C}
 
 TLS-PSK-WITH-RC4-128-SHA    {0x00,0x8A}
 TLS-PSK-WITH-3DES-EDE-CBC-SHA      {0x00,0x8B}

--- a/core/Network/TLS/Handshake/Key.hs
+++ b/core/Network/TLS/Handshake/Key.hs
@@ -9,9 +9,9 @@
 --
 module Network.TLS.Handshake.Key
     ( encryptRSA
-    , signRSA
+    , signPrivate
     , decryptRSA
-    , verifyRSA
+    , verifyPublic
     , generateDHE
     , generateECDHE
     ) where
@@ -37,8 +37,8 @@ encryptRSA ctx content = do
             Left err       -> fail ("rsa encrypt failed: " ++ show err)
             Right econtent -> return econtent
 
-signRSA :: Context -> Role -> Hash -> ByteString -> IO ByteString
-signRSA ctx _ hsh content = do
+signPrivate :: Context -> Role -> Hash -> ByteString -> IO ByteString
+signPrivate ctx _ hsh content = do
     privateKey <- usingHState ctx getLocalPrivateKey
     usingState_ ctx $ do
         r <- withRNG $ kxSign privateKey hsh content
@@ -54,8 +54,8 @@ decryptRSA ctx econtent = do
         let cipher = if ver < TLS10 then econtent else B.drop 2 econtent
         withRNG $ kxDecrypt privateKey cipher
 
-verifyRSA :: Context -> Role -> Hash -> ByteString -> ByteString -> IO Bool
-verifyRSA ctx _ hsh econtent sign = do
+verifyPublic :: Context -> Role -> Hash -> ByteString -> ByteString -> IO Bool
+verifyPublic ctx _ hsh econtent sign = do
     publicKey <- usingHState ctx getRemotePublicKey
     return $ kxVerify publicKey hsh econtent sign
 

--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -107,7 +107,7 @@ signatureCreate ctx malg (hashAlg, toSign) = do
             case (malg, hashAlg) of
                 (Nothing, SHA1_MD5) -> hashFinal $ hashUpdate (hashInit SHA1_MD5) toSign
                 _                   -> toSign
-    DigitallySigned malg <$> signRSA ctx cc hashAlg signData
+    DigitallySigned malg <$> signPrivate ctx cc hashAlg signData
 
 signatureVerify :: Context -> DigitallySigned -> SignatureAlgorithm -> Bytes -> IO Bool
 signatureVerify ctx digSig@(DigitallySigned hashSigAlg _) sigAlgExpected toVerifyData = do
@@ -133,9 +133,9 @@ signatureVerifyWithHashDescr :: Context
 signatureVerifyWithHashDescr ctx sigAlgExpected (DigitallySigned _ bs) (hashDescr, toVerify) = do
     cc <- usingState_ ctx $ isClientContext
     case sigAlgExpected of
-        SignatureRSA   -> verifyRSA ctx cc hashDescr toVerify bs
-        SignatureDSS   -> verifyRSA ctx cc hashDescr toVerify bs
-        SignatureECDSA -> verifyRSA ctx cc hashDescr toVerify bs
+        SignatureRSA   -> verifyPublic ctx cc hashDescr toVerify bs
+        SignatureDSS   -> verifyPublic ctx cc hashDescr toVerify bs
+        SignatureECDSA -> verifyPublic ctx cc hashDescr toVerify bs
         _              -> error "signature verification not implemented yet"
 
 digitallySignParams :: Context -> Bytes -> SignatureAlgorithm -> IO DigitallySigned

--- a/core/Network/TLS/MAC.hs
+++ b/core/Network/TLS/MAC.hs
@@ -11,10 +11,12 @@ module Network.TLS.MAC
     , prf_MD5
     , prf_SHA1
     , prf_SHA256
+    , prf_TLS
     , prf_MD5SHA1
     ) where
 
 import Network.TLS.Crypto
+import Network.TLS.Types
 import qualified Data.ByteString as B
 import Data.ByteString (ByteString)
 import Data.Bits (xor)
@@ -71,3 +73,9 @@ prf_MD5SHA1 secret seed len =
 
 prf_SHA256 :: ByteString -> ByteString -> Int -> ByteString
 prf_SHA256 secret seed len = B.concat $ hmacIter (hmac SHA256) secret seed seed len
+
+-- | For now we ignore the version, but perhaps some day the PRF will depend
+-- not only on the cipher PRF algorithm, but also on the protocol version.
+prf_TLS :: Version -> Hash -> ByteString -> ByteString -> Int -> ByteString
+prf_TLS _ halg secret seed len =
+    B.concat $ hmacIter (hmac halg) secret seed seed len

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -88,6 +88,8 @@ data ClientParams = ClientParams
     , clientWantSessionResume         :: Maybe (SessionID, SessionData)
     , clientShared                    :: Shared
     , clientHooks                     :: ClientHooks
+      -- | In this element, you'll  need to override the default empty value of
+      -- of 'supportedCiphers' with a suitable cipherlist.
     , clientSupported                 :: Supported
     , clientDebug                     :: DebugParams
     } deriving (Show)
@@ -144,7 +146,9 @@ data Supported = Supported
       -- On the client side, the highest version will be used to establish the connection.
       -- On the server side, the highest version that is less or equal than the client version will be chosed.
       supportedVersions       :: [Version]
-      -- | Supported cipher methods
+      -- | Supported cipher methods.  The default is empty, specify a suitable
+      -- cipher list.  'Network.TLS.Extra.Cipher.ciphersuite_default' is often
+      -- a good choice.
     , supportedCiphers        :: [Cipher]
       -- | supported compressions methods
     , supportedCompressions   :: [Compression]

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -186,9 +186,11 @@ defaultSupported = Supported
     , supportedCiphers        = []
     , supportedCompressions   = [nullCompression]
     , supportedHashSignatures = [ (Struct.HashSHA512, SignatureRSA)
+                                , (Struct.HashSHA512, SignatureECDSA)
                                 , (Struct.HashSHA384, SignatureRSA)
+                                , (Struct.HashSHA384, SignatureECDSA)
                                 , (Struct.HashSHA256, SignatureRSA)
-                                , (Struct.HashSHA224, SignatureRSA)
+                                , (Struct.HashSHA256, SignatureECDSA)
                                 , (Struct.HashSHA1,   SignatureRSA)
                                 , (Struct.HashSHA1,   SignatureDSS)
                                 ]

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -38,6 +38,7 @@ blockCipher = Cipher
         , bulkF         = BulkBlockF $ \_ _ _ -> (\m -> (m, B.empty))
         }
     , cipherHash        = MD5
+    , cipherPRFHash     = Nothing
     , cipherKeyExchange = CipherKeyExchange_RSA
     , cipherMinVer      = Nothing
     }


### PR DESCRIPTION
This PR implements support for TLS12 ciphersuites with SHA384 (or other, though none yet in use) PRFs.
It also adds some new cipher code points that fill existing gaps.
With this done ECDSA signature algorithms are enabled, and secp384r1 is added to the supported curves.  See individual commit logs for more detail.