### PR TITLE
respecting the "signature_algorithms" extension. (#137)

### DIFF
--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -331,7 +331,7 @@ doHandshake sparams mcred ctx chosenVersion usedCipher usedCompression clientSes
                       cHashSigs = case extensionLookup extensionID_SignatureAlgorithms exts >>= extensionDecode False of
                           Just (SignatureAlgorithms hss) -> hss
                           Nothing                        -> []
-                      hashSigs = cHashSigs `intersect` sHashSigs
+                      hashSigs = sHashSigs `intersect` cHashSigs
                   case filter ((==) sigAlg . snd) hashSigs of
                       []  -> error ("no hash signature for " ++ show sigAlg)
                       x:_ -> return $ Just (fst x)

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -315,11 +315,19 @@ doHandshake sparams mcred ctx chosenVersion usedCipher usedCompression clientSes
             usingHState ctx $ setDHPrivate priv
             return serverParams
 
+        -- Choosing a hash algorithm to sign (EC)DHE parameters
+        -- in ServerKeyExchange. Hash algorithm is not suggested by
+        -- the chosen cipher suite. So, it should be selected based on
+        -- the "signature_algorithms" extension in a client hello.
+        -- If RSA is also used for key exchange, this function is
+        -- not called.
         decideHash sigAlg = do
             usedVersion <- usingState_ ctx getVersion
             case usedVersion of
               TLS12 -> do
                   let sHashSigs = supportedHashSignatures $ ctxSupported ctx
+                      -- The values in the "signature_algorithms" extension
+                      -- are in descending order of preference.
                       cHashSigs = case extensionLookup extensionID_SignatureAlgorithms exts >>= extensionDecode False of
                           Just (SignatureAlgorithms hss) -> hss
                           Nothing                        -> []

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -324,13 +324,14 @@ doHandshake sparams mcred ctx chosenVersion usedCipher usedCompression clientSes
         decideHash sigAlg = do
             usedVersion <- usingState_ ctx getVersion
             case usedVersion of
-              TLS12 -> case extensionLookup extensionID_SignatureAlgorithms exts >>= extensionDecode False of
-                -- According to Section 7.4.1.4.1 of RFC 5246,
-                -- SHA1 is assumed if the "signature_algorithms" extension
-                -- does not exist.
-                Nothing -> return $ Just HashSHA1
-                Just (SignatureAlgorithms cHashSigs) -> do
-                  let sHashSigs = supportedHashSignatures $ ctxSupported ctx
+              TLS12 -> do
+                  let cHashSigs = case extensionLookup extensionID_SignatureAlgorithms exts >>= extensionDecode False of
+                          -- See Section 7.4.1.4.1 of RFC 5246.
+                          Nothing -> [(HashSHA1, SignatureECDSA)
+                                     ,(HashSHA1, SignatureRSA)
+                                     ,(HashSHA1, SignatureDSS)]
+                          Just (SignatureAlgorithms sas) -> sas
+                      sHashSigs = supportedHashSignatures $ ctxSupported ctx
                       -- The values in the "signature_algorithms" extension
                       -- are in descending order of preference.
                       hashSigs = sHashSigs `intersect` cHashSigs

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -153,7 +153,8 @@ data Supported = Supported
       -- | supported compressions methods
     , supportedCompressions   :: [Compression]
       -- | All supported hash/signature algorithms pair for client
-      -- certificate verification, ordered by decreasing priority.
+      -- certificate verification and server signature in (EC)DHE,
+      -- ordered by decreasing priority.
     , supportedHashSignatures :: [HashAndSignatureAlgorithm]
       -- | Secure renegotiation defined in RFC5746.
       --   If 'True', clients send the renegotiation_info extension.


### PR DESCRIPTION
This patch uses the "signature_algorithms" extension in a client hello
when a server decides a signature hash algorithm for EC(DHE)
parameters to authenticate the server itself.

Problem:
Go tls client tells that it supports SHA256/SHA384 but not SHA512.
Haskell tls server uses SHA512 for EC(DHE).