### PR TITLE
closing the output file.

### DIFF
--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -22,6 +22,7 @@ import Data.Default.Class
 import Data.IORef
 import Data.Monoid
 import Data.Char (isDigit)
+import Data.Maybe (isJust)
 
 import Numeric (showHex)
 
@@ -239,6 +240,7 @@ runOn (sStorage, certStore) flags port hostname
                 sendData ctx $ query
                 loopRecv out ctx
                 bye ctx
+                when (isJust getOutput) $ hClose out
                 return ()
         loopRecv out ctx = do
             d <- timeout (timeoutMs * 1000) (recvData ctx) -- 2s per recv

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -232,7 +232,7 @@ runOn (sStorage, certStore) flags port hostname
                         ++ userAgent
                         ++ "\r\n\r\n")
             when (Verbose `elem` flags) (putStrLn "sending query:" >> LC.putStrLn query >> putStrLn "")
-            out <- maybe (return stdout) (flip openFile WriteMode) getOutput
+            out <- maybe (return stdout) (flip openFile AppendMode) getOutput
             runTLS (Debug `elem` flags)
                    (IODebug `elem` flags)
                    (getDefaultParams flags hostname certStore sStorage certCredRequest sess) hostname port $ \ctx -> do
@@ -240,8 +240,8 @@ runOn (sStorage, certStore) flags port hostname
                 sendData ctx $ query
                 loopRecv out ctx
                 bye ctx
-                when (isJust getOutput) $ hClose out
                 return ()
+            when (isJust getOutput) $ hClose out
         loopRecv out ctx = do
             d <- timeout (timeoutMs * 1000) (recvData ctx) -- 2s per recv
             case d of


### PR DESCRIPTION
A file lock error happens if an output file is specified AND
a session is resumed. This patch closes the output file
so that the resumed session can re-open it safely.