### PR TITLE
Making import minimum.

### DIFF
--- a/core/Network/TLS/Cipher.hs
+++ b/core/Network/TLS/Cipher.hs
@@ -32,8 +32,7 @@ module Network.TLS.Cipher
     ) where
 
 import Crypto.Cipher.Types (AuthTag)
-import Network.TLS.Types (CipherID)
-import Network.TLS.Struct (Version(..))
+import Network.TLS.Types (CipherID, Version(..))
 import Network.TLS.Crypto (Hash(..), hashDigestSize)
 
 import qualified Data.ByteString as B

--- a/core/Network/TLS/Extra/Cipher.hs
+++ b/core/Network/TLS/Extra/Cipher.hs
@@ -54,7 +54,7 @@ module Network.TLS.Extra.Cipher
 
 import qualified Data.ByteString as B
 
-import Network.TLS (Version(..))
+import Network.TLS.Types (Version(..))
 import Network.TLS.Cipher
 import Data.Tuple (swap)
 


### PR DESCRIPTION
When I'm implement TLS 1.3, I sometime suffer from cyclic imports. This is because the current imports are unnecessarily large. This patch reduces this issue.