### PR TITLE
removing ffdhe4096, ffdhe6144 and ffdhe8192 from tests.

### DIFF
--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -122,7 +122,7 @@ arbitraryPairParams = do
                                      maybe True (<= v) (cipherMinVer x) | x <- clientCiphers ]]
     serAllowedVersions <- (:[]) `fmap` elements allowedVersions
     secNeg             <- arbitrary
-    dhparams           <- elements [dhParams,ffdhe2048,ffdhe3072,ffdhe4096,ffdhe6144,ffdhe8192]
+    dhparams           <- elements [dhParams,ffdhe2048,ffdhe3072]
 
     let serverState = def
             { serverSupported = def { supportedCiphers  = serverCiphers


### PR DESCRIPTION
These values make test much slower.
Since 128 bit security is good enough to around 2050,
testing up to ffdhe3072 (125 bit security) is sufficient.