### PR TITLE
tls-debug cipher suites

### DIFF
--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -28,26 +28,6 @@ import Numeric (showHex)
 
 import HexDump
 
-ciphers :: [Cipher]
-ciphers =
-    [ cipher_DHE_RSA_AES256_SHA256
-    , cipher_DHE_RSA_AES128_SHA256
-    , cipher_DHE_RSA_AES256_SHA1
-    , cipher_DHE_RSA_AES128_SHA1
-    , cipher_DHE_DSS_AES256_SHA1
-    , cipher_DHE_DSS_AES128_SHA1
-    , cipher_AES128_SHA1
-    , cipher_AES256_SHA1
-    , cipher_RC4_128_MD5
-    , cipher_RC4_128_SHA1
-    , cipher_RSA_3DES_EDE_CBC_SHA1
-    , cipher_DHE_RSA_AES128GCM_SHA256
-    --, cipher_ECDHE_RSA_AES256GCM_SHA384
-    , cipher_ECDHE_RSA_AES256CBC_SHA
-    , cipher_ECDHE_RSA_AES128GCM_SHA256
-    , cipher_ECDHE_ECDSA_AES128GCM_SHA256
-    ]
-
 defaultBenchAmount = 1024 * 1024
 defaultTimeout = 2000
 
@@ -105,7 +85,7 @@ getDefaultParams flags host store sStorage certCredsRequest session =
                 | validateCert = def
                 | otherwise    = ValidationCache (\_ _ _ -> return ValidationCachePass)
                                                  (\_ _ _ -> return ())
-            myCiphers = foldl accBogusCipher (filter withUseCipher ciphers) flags
+            myCiphers = foldl accBogusCipher (filter withUseCipher ciphersuite_all) flags
               where accBogusCipher acc (BogusCipher c) =
                         case reads c of
                             [(v, "")] -> acc ++ [bogusCipher v]
@@ -298,7 +278,7 @@ printUsage =
 printCiphers = do
     putStrLn "Supported ciphers"
     putStrLn "====================================="
-    forM_ ciphers $ \c -> do
+    forM_ ciphersuite_all $ \c -> do
         putStrLn (pad 50 (cipherName c) ++ " = " ++ pad 5 (show $ cipherID c) ++ "  0x" ++ showHex (cipherID c) "")
   where
     pad n s

--- a/debug/src/SimpleServer.hs
+++ b/debug/src/SimpleServer.hs
@@ -28,22 +28,6 @@ import Numeric (showHex)
 
 import HexDump
 
-ciphers :: [Cipher]
-ciphers =
-    [ cipher_DHE_RSA_AES256_SHA256
-    , cipher_DHE_RSA_AES128_SHA256
-    , cipher_DHE_RSA_AES256_SHA1
-    , cipher_DHE_RSA_AES128_SHA1
-    , cipher_DHE_DSS_AES256_SHA1
-    , cipher_DHE_DSS_AES128_SHA1
-    , cipher_AES128_SHA1
-    , cipher_AES256_SHA1
-    , cipher_RC4_128_MD5
-    , cipher_RC4_128_SHA1
-    , cipher_RSA_3DES_EDE_CBC_SHA1
-    , cipher_DHE_RSA_AES128GCM_SHA256
-    ]
-
 defaultBenchAmount = 1024 * 1024
 defaultTimeout = 2000
 
@@ -109,7 +93,7 @@ getDefaultParams flags store sStorage cred session =
                 | otherwise    = ValidationCache (\_ _ _ -> return ValidationCachePass)
                                                  (\_ _ _ -> return ())
 
-            myCiphers = foldl accBogusCipher (filter withUseCipher ciphers) flags
+            myCiphers = foldl accBogusCipher (filter withUseCipher ciphersuite_default) flags
               where accBogusCipher acc (BogusCipher c) =
                         case reads c of
                             [(v, "")] -> acc ++ [bogusCipher v]
@@ -303,7 +287,7 @@ printUsage =
 printCiphers = do
     putStrLn "Supported ciphers"
     putStrLn "====================================="
-    forM_ ciphers $ \c -> do
+    forM_ ciphersuite_default $ \c -> do
         putStrLn (pad 50 (cipherName c) ++ " = " ++ pad 5 (show $ cipherID c) ++ "  0x" ++ showHex (cipherID c) "")
   where
     pad n s

--- a/debug/src/Stunnel.hs
+++ b/debug/src/Stunnel.hs
@@ -27,21 +27,6 @@ import Network.TLS.Extra.Cipher
 
 import qualified Crypto.PubKey.DH as DH ()
 
-ciphers :: [Cipher]
-ciphers =
-    [ cipher_DHE_RSA_AES256_SHA256
-    , cipher_DHE_RSA_AES128_SHA256
-    , cipher_DHE_RSA_AES256_SHA1
-    , cipher_DHE_RSA_AES128_SHA1
-    , cipher_DHE_DSS_AES128_SHA1
-    , cipher_DHE_DSS_AES256_SHA1
-    , cipher_DHE_DSS_RC4_SHA1
-    , cipher_AES128_SHA1
-    , cipher_AES256_SHA1
-    , cipher_RC4_128_MD5
-    , cipher_RC4_128_SHA1
-    ]
-
 loopUntil :: Monad m => m Bool -> m ()
 loopUntil f = f >>= \v -> if v then return () else loopUntil f
 
@@ -106,7 +91,7 @@ clientProcess dhParamsFile creds handle dsthandle dbg sessionStorage _ = do
             Just file -> (Just . read) `fmap` readFile file
 
     let serverstate = def
-            { serverSupported = def { supportedCiphers = ciphers }
+            { serverSupported = def { supportedCiphers = ciphersuite_default }
             , serverShared    = def { sharedCredentials = creds
                                     , sharedSessionManager = maybe noSessionManager (memSessionManager . MemSessionManager) sessionStorage
                                     }
@@ -182,7 +167,7 @@ doClient source destination@(Address a _) flags = do
                                 (\_ _ _ -> return ())
            | otherwise = def
     let clientstate = (defaultParamsClient a B.empty)
-                        { clientSupported = def { supportedCiphers = ciphers }
+                        { clientSupported = def { supportedCiphers = ciphersuite_all }
                         , clientShared    = def { sharedCAStore = store, sharedValidationCache = validateCache }
                         }
 


### PR DESCRIPTION
The reason for local cipher suites in tls-debug utilities looks historical.
To get accurate diagnostics from the utilities it is important keep the ciphers identical to what is commonly used.

This PR replaces the local lists with the usual ciphers from `Network.TLS.Extra.Cipher`:
* `ciphersuite_all` in clients (this is what is used in `connection` and dependent packages)
* `ciphersuite_default` in servers (a little more secure)
