### PR TITLE
Fixed 'ServerHooks.onUnverifiedClientCert' documentation. ...

### DIFF
--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -272,9 +272,8 @@ data ServerHooks = ServerHooks
       onClientCertificate :: CertificateChain -> IO CertificateUsage
 
       -- | This action is called when the client certificate
-      -- cannot be verified.  A 'Nothing' argument indicates a
-      -- wrong signature, a 'Just e' message signals a crypto
-      -- error.
+      -- cannot be verified. Return 'True' to accept the certificate
+      -- anyway, or 'False' to fail verification.
     , onUnverifiedClientCert :: IO Bool
 
       -- | Allow the server to choose the cipher relative to the


### PR DESCRIPTION
It seems like the code changed in a14b37d52815937d812a3808980b119b26ce24ca
but the documentation didn't change along with it.