### PR TITLE
Fix ECDSA with TLS 1.0 / TLS 1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ install:
       cabal install --only-dependencies --enable-tests
     else
       cabal install --only-dependencies
+      cabal install random
     fi
     cabal install
  - cd ../debug

--- a/core/Network/TLS/Extra/Cipher.hs
+++ b/core/Network/TLS/Extra/Cipher.hs
@@ -526,7 +526,7 @@ cipher_ECDHE_ECDSA_AES128CBC_SHA = Cipher
     , cipherBulk         = bulk_aes128
     , cipherHash         = SHA1
     , cipherPRFHash      = Nothing
-    , cipherKeyExchange  = CipherKeyExchange_ECDHE_RSA
+    , cipherKeyExchange  = CipherKeyExchange_ECDHE_ECDSA
     , cipherMinVer       = Just TLS10
     }
 
@@ -537,7 +537,7 @@ cipher_ECDHE_ECDSA_AES256CBC_SHA = Cipher
     , cipherBulk         = bulk_aes256
     , cipherHash         = SHA1
     , cipherPRFHash      = Nothing
-    , cipherKeyExchange  = CipherKeyExchange_ECDHE_RSA
+    , cipherKeyExchange  = CipherKeyExchange_ECDHE_ECDSA
     , cipherMinVer       = Just TLS10
     }
 

--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -95,7 +95,7 @@ signatureHashData SignatureECDSA mhash =
         Just HashSHA384 -> SHA384
         Just HashSHA256 -> SHA256
         Just HashSHA1   -> SHA1
-        Nothing         -> SHA1_MD5
+        Nothing         -> SHA1
         Just hsh        -> error ("unimplemented ECDSA signature hash type: " ++ show hsh)
 signatureHashData sig _ = error ("unimplemented signature type: " ++ show sig)
 

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -55,7 +55,7 @@ Library
                    , x509 >= 1.6.5 && < 1.7.0
                    , x509-store >= 1.6
                    , x509-validation >= 1.6.5 && < 1.7.0
-                   , async
+                   , async >= 2.0
   if flag(network)
     Build-Depends:   network
     cpp-options:     -DINCLUDE_NETWORK


### PR DESCRIPTION
I see two explanations for TestClient failures in Travis builds:

* the default hash algorithm for ECDSA should be SHA-1 (just like for DSA)
  as described in RFC 4492 § 5.4

* what looks like a copy/paste mistake in the definition of two ECDSA ciphers
