### PR TITLE
RSA signature in CertificateVerify with TLS < 1.2

### DIFF
--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -1,6 +1,7 @@
 module Connection
     ( newPairContext
     , arbitraryPairParams
+    , arbitraryClientCredential
     , setPairParamsSessionManager
     , setPairParamsSessionResuming
     , establishDataPipe
@@ -146,6 +147,11 @@ arbitraryPairParams = do
     return (clientState, serverState)
   where
         arbitraryCiphers  = resize (length knownCiphers + 1) $ listOf1 (elements knownCiphers)
+
+arbitraryClientCredential = do
+    let (pubKey, privKey) = getGlobalRSAPair
+    cert <- arbitraryX509WithKey (PubKeyRSA pubKey, PrivKeyRSA privKey)
+    return (CertificateChain [cert], PrivKeyRSA privKey)
 
 setPairParamsSessionManager :: SessionManager -> (ClientParams, ServerParams) -> (ClientParams, ServerParams)
 setPairParamsSessionManager manager (clientState, serverState) = (nc,ns)


### PR DESCRIPTION
This is a fix for the scenario with client certificate reported in #111.

Steps to reproduce:
```shell
# Prepare a self-signed certificate to be used by client & server
cd /tmp
openssl req -x509 -new -subj /CN=localhost -nodes -text -out cert.pem

# Launch TLS server in terminal 1
openssl s_server -key /tmp/privkey.pem -cert /tmp/cert.pem -www \
        -verify 1 -CAfile /tmp/cert.pem

# Launch TLS client in terminal 2
tls-simpleclient --tls11 --no-validation --use-cipher=47 \
        --client-cert=/tmp/cert.pem:/tmp/privkey.pem \
        localhost 4433
```
