### PR TITLE
Selecting a cipher based on "signature_algorithms"

### DIFF
--- a/core/Network/TLS/Credentials.hs
+++ b/core/Network/TLS/Credentials.hs
@@ -95,14 +95,14 @@ credentialsFindForDecrypting (Credentials l) = find forEncrypting l
 -- this change in future.
 credentialCanDecrypt :: Credential -> Maybe ()
 credentialCanDecrypt (chain, priv) =
-    case extensionGet (certExtensions cert) of
-        Nothing    -> Just ()
-        Just (ExtKeyUsage flags)
-            | KeyUsage_keyEncipherment `elem` flags ->
-                case (pub, priv) of
-                    (PubKeyRSA _, PrivKeyRSA _) -> Just ()
-                    _                           -> Nothing
-            | otherwise                         -> Nothing
+    case (pub, priv) of
+        (PubKeyRSA _, PrivKeyRSA _) ->
+            case extensionGet (certExtensions cert) of
+                Nothing                                     -> Just ()
+                Just (ExtKeyUsage flags)
+                    | KeyUsage_keyEncipherment `elem` flags -> Just ()
+                    | otherwise                             -> Nothing
+        _                           -> Nothing
     where cert   = signedObject $ getSigned signed
           pub    = certPubKey cert
           signed = getCertificateChainLeaf chain

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -247,6 +247,10 @@ sendClientData cparams ctx = sendCertificate >> sendClientKeyXchg >> sendCertifi
                     malg <- case usedVersion of
                         TLS12 -> do
                             Just (_, Just hashSigs, _) <- usingHState ctx $ getClientCertRequest
+                            -- The values in the "signature_algorithms" extension
+                            -- are in descending order of preference.
+                            -- However here the algorithms are selected according
+                            -- to client preference in 'supportedHashSignatures'.
                             let suppHashSigs = supportedHashSignatures $ ctxSupported ctx
                                 hashSigs' = filter (\ a -> a `elem` hashSigs) suppHashSigs
 

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -174,6 +174,7 @@ sendClientData cparams ctx = sendCertificate >> sendClientKeyXchg >> sendCertifi
                         Just (cc@(CertificateChain (c:_)), pk) -> do
                             case certPubKey $ getCertificate c of
                                 PubKeyRSA _ -> return ()
+                                PubKeyDSA _ -> return ()
                                 _           -> throwCore $ Error_Protocol ("no supported certificate type", True, HandshakeFailure)
                             usingHState ctx $ setPrivateKey pk
                             usingHState ctx $ setClientCertSent True
@@ -244,7 +245,9 @@ sendClientData cparams ctx = sendCertificate >> sendClientKeyXchg >> sendCertifi
             certSent <- usingHState ctx $ getClientCertSent
             case certSent of
                 True -> do
-                    malg <- case usedVersion of
+                    sigAlg <- getLocalSignatureAlg
+
+                    mhash <- case usedVersion of
                         TLS12 -> do
                             Just (_, Just hashSigs, _) <- usingHState ctx $ getClientCertRequest
                             -- The values in the "signature_algorithms" extension
@@ -252,19 +255,27 @@ sendClientData cparams ctx = sendCertificate >> sendClientKeyXchg >> sendCertifi
                             -- However here the algorithms are selected according
                             -- to client preference in 'supportedHashSignatures'.
                             let suppHashSigs = supportedHashSignatures $ ctxSupported ctx
-                                hashSigs' = filter (\ a -> a `elem` hashSigs) suppHashSigs
+                                matchHashSigs = filter (\ a -> snd a == sigAlg) suppHashSigs
+                                hashSigs' = filter (\ a -> a `elem` hashSigs) matchHashSigs
 
                             when (null hashSigs') $
-                                throwCore $ Error_Protocol ("no hash/signature algorithms in common with the server", True, HandshakeFailure)
-                            return $ Just $ head hashSigs'
+                                throwCore $ Error_Protocol ("no " ++ show sigAlg ++ " hash algorithm in common with the server", True, HandshakeFailure)
+                            return $ Just $ fst $ head hashSigs'
                         _     -> return Nothing
 
                     -- Fetch all handshake messages up to now.
                     msgs   <- usingHState ctx $ B.concat <$> getHandshakeMessages
-                    sigDig <- certificateVerifyCreate ctx usedVersion malg msgs
+                    sigDig <- certificateVerifyCreate ctx usedVersion sigAlg mhash msgs
                     sendPacket ctx $ Handshake [CertVerify sigDig]
 
                 _ -> return ()
+
+        getLocalSignatureAlg = do
+            pk <- usingHState ctx getLocalPrivateKey
+            case pk of
+                PrivKeyRSA _   -> return SignatureRSA
+                PrivKeyDSA _   -> return SignatureDSS
+                _              -> throwCore $ Error_Protocol ("unsupported local private key type", True, HandshakeFailure)
 
 processServerExtension :: ExtensionRaw -> TLSSt ()
 processServerExtension (ExtensionRaw 0xff01 content) = do

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -131,10 +131,51 @@ handshakeServerWith sparams ctx clientHello@(ClientHello clientVersion _ clientS
 
     extraCreds <- (onServerNameIndication $ serverHooks sparams) serverName
 
+    -- When selecting a cipher we must ensure that it is allowed for the
+    -- TLS version but also that all its key-exchange requirements
+    -- will be met.
+
+    -- Some ciphers require a signature and a hash.  With TLS 1.2 the hash
+    -- algorithm is selected from a combination of server configuration and
+    -- the client "supported_signatures" extension.  So we cannot pick
+    -- such a cipher if no hash is available for it.  It's best to skip this
+    -- cipher and pick another one (with another key exchange).
+
+    -- FIXME ciphers should also be checked for other requirements
+    -- (i.e. elliptic curves and D-H groups)
+    let cipherAllowed cipher = case chosenVersion of
+           TLS12 -> let -- Build a list of all signature algorithms with at least
+                        -- one hash algorithm common between client and server.
+                        -- May contain duplicates, as it is only used for `elem`.
+                        sigAlgExt = extensionLookup extensionID_SignatureAlgorithms exts >>= extensionDecode False
+                        cHashSigs =
+                            case sigAlgExt of
+                                -- See Section 7.4.1.4.1 of RFC 5246.
+                                Nothing -> [(HashSHA1, SignatureECDSA)
+                                           ,(HashSHA1, SignatureRSA)
+                                           ,(HashSHA1, SignatureDSS)]
+                                Just (SignatureAlgorithms sas) -> sas
+                        sHashSigs = supportedHashSignatures (ctxSupported ctx)
+                        possibleSigAlgs = map snd (sHashSigs `intersect` cHashSigs)
+
+                        -- Check that a candidate cipher with a signature requiring
+                        -- a hash will have at least one hash available.  This avoids
+                        -- a failure later in 'decideHash'.
+                        hasSigningRequirements =
+                            case cipherKeyExchange cipher of
+                                CipherKeyExchange_DHE_RSA      -> SignatureRSA   `elem` possibleSigAlgs
+                                CipherKeyExchange_DHE_DSS      -> SignatureDSS   `elem` possibleSigAlgs
+                                CipherKeyExchange_ECDHE_RSA    -> SignatureRSA   `elem` possibleSigAlgs
+                                CipherKeyExchange_ECDHE_ECDSA  -> SignatureECDSA `elem` possibleSigAlgs
+                                _                              -> True -- signature not used
+
+                     in cipherAllowedForVersion chosenVersion cipher && hasSigningRequirements
+           _     -> cipherAllowedForVersion chosenVersion cipher
+
     -- The shared cipherlist can become empty after filtering for compatible
     -- creds, check now before calling onCipherChoosing, which does not handle
     -- empty lists.
-    let ciphersFilteredVersion = filter (cipherAllowedForVersion chosenVersion) (commonCiphers extraCreds)
+    let ciphersFilteredVersion = filter cipherAllowed (commonCiphers extraCreds)
     when (null ciphersFilteredVersion) $ throwCore $
         Error_Protocol ("no cipher in common with the client", True, HandshakeFailure)
 

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -347,6 +347,8 @@ doHandshake sparams mcred ctx chosenVersion usedCipher usedCompression clientSes
                       sHashSigs = supportedHashSignatures $ ctxSupported ctx
                       -- The values in the "signature_algorithms" extension
                       -- are in descending order of preference.
+                      -- However here the algorithms are selected according
+                      -- to server preference in 'supportedHashSignatures'.
                       hashSigs = sHashSigs `intersect` cHashSigs
                   case filter ((==) sigAlg . snd) hashSigs of
                       []  -> error ("no hash signature for " ++ show sigAlg)

--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -20,7 +20,8 @@ import Network.TLS.Crypto
 import Network.TLS.Context.Internal
 import Network.TLS.Struct
 import Network.TLS.Imports
-import Network.TLS.Packet (generateCertificateVerify_SSL, encodeSignedDHParams, encodeSignedECDHParams)
+import Network.TLS.Packet (generateCertificateVerify_SSL, generateCertificateVerify_SSL_DSS,
+                           encodeSignedDHParams, encodeSignedECDHParams)
 import Network.TLS.State
 import Network.TLS.Handshake.State
 import Network.TLS.Handshake.Key
@@ -30,49 +31,56 @@ import Control.Monad.State
 
 certificateVerifyCheck :: Context
                        -> Version
-                       -> Maybe HashAndSignatureAlgorithm
+                       -> SignatureAlgorithm
                        -> Bytes
                        -> DigitallySigned
                        -> IO Bool
-certificateVerifyCheck ctx usedVersion malg msgs dsig =
-    prepareCertificateVerifySignatureData ctx usedVersion malg msgs >>=
-    signatureVerifyWithHashDescr ctx SignatureRSA dsig
+certificateVerifyCheck ctx usedVersion sigAlgExpected msgs digSig@(DigitallySigned hashSigAlg _) =
+    case (usedVersion, hashSigAlg) of
+        (TLS12, Nothing)    -> return False
+        (TLS12, Just (h,s)) | s == sigAlgExpected -> doVerify (Just h)
+                            | otherwise           -> return False
+        (_,     Nothing)    -> doVerify Nothing
+        (_,     Just _)     -> return False
+  where
+    doVerify mhash =
+        prepareCertificateVerifySignatureData ctx usedVersion sigAlgExpected mhash msgs >>=
+        signatureVerifyWithHashDescr ctx sigAlgExpected digSig
 
 certificateVerifyCreate :: Context
                         -> Version
-                        -> Maybe HashAndSignatureAlgorithm
+                        -> SignatureAlgorithm
+                        -> Maybe HashAlgorithm -- TLS12 only
                         -> Bytes
                         -> IO DigitallySigned
-certificateVerifyCreate ctx usedVersion malg msgs =
-    prepareCertificateVerifySignatureData ctx usedVersion malg msgs >>=
-    signatureCreateWithHashDescr ctx malg
-
-getHashAndASN1 :: MonadIO m => (HashAlgorithm, SignatureAlgorithm) -> m Hash
-getHashAndASN1 hashSig = case hashSig of
-    (HashSHA1,   SignatureRSA) -> return SHA1
-    (HashSHA224, SignatureRSA) -> return SHA224
-    (HashSHA256, SignatureRSA) -> return SHA256
-    (HashSHA384, SignatureRSA) -> return SHA384
-    (HashSHA512, SignatureRSA) -> return SHA512
-    _                          -> throwCore $ Error_Misc "unsupported hash/sig algorithm"
+certificateVerifyCreate ctx usedVersion sigAlg mhash msgs =
+    prepareCertificateVerifySignatureData ctx usedVersion sigAlg mhash msgs >>=
+    signatureCreateWithHashDescr ctx (toAlg `fmap` mhash)
+  where
+    toAlg hashAlg = (hashAlg, sigAlg)
 
 type CertVerifyData = (Hash, Bytes)
 
 prepareCertificateVerifySignatureData :: Context
                                       -> Version
-                                      -> Maybe HashAndSignatureAlgorithm
+                                      -> SignatureAlgorithm
+                                      -> Maybe HashAlgorithm -- TLS12 only
                                       -> Bytes
                                       -> IO CertVerifyData
-prepareCertificateVerifySignatureData ctx usedVersion malg msgs
+prepareCertificateVerifySignatureData ctx usedVersion sigAlg mhash msgs
     | usedVersion == SSL3 = do
+        (h, generateCV_SSL) <-
+            case sigAlg of
+                SignatureRSA -> return (SHA1_MD5, generateCertificateVerify_SSL)
+                SignatureDSS -> return (SHA1, generateCertificateVerify_SSL_DSS)
+                _            -> throwCore $ Error_Misc ("unsupported CertificateVerify signature for SSL3: " ++ show sigAlg)
         Just masterSecret <- usingHState ctx $ gets hstMasterSecret
-        return (SHA1_MD5, generateCertificateVerify_SSL masterSecret (hashUpdate (hashInit SHA1_MD5) msgs))
-    | usedVersion == TLS10 || usedVersion == TLS11 = do
-        return (SHA1_MD5, hashFinal $ hashUpdate (hashInit SHA1_MD5) msgs)
-    | otherwise = do
-        let Just hashSig = malg
-        hsh <- getHashAndASN1 hashSig
-        return (hsh, msgs)
+        return (h, generateCV_SSL masterSecret (hashUpdate (hashInit h) msgs))
+    | usedVersion == TLS10 || usedVersion == TLS11 =
+        case signatureHashData sigAlg Nothing of
+            SHA1_MD5 -> return (SHA1_MD5, hashFinal $ hashUpdate (hashInit SHA1_MD5) msgs)
+            alg      -> return (alg, msgs)
+    | otherwise = return (signatureHashData sigAlg mhash, msgs)
 
 signatureHashData :: SignatureAlgorithm -> Maybe HashAlgorithm -> Hash
 signatureHashData SignatureRSA mhash =

--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -21,7 +21,6 @@ import Network.TLS.Context.Internal
 import Network.TLS.Struct
 import Network.TLS.Imports
 import Network.TLS.Packet (generateCertificateVerify_SSL, encodeSignedDHParams, encodeSignedECDHParams)
-import Network.TLS.Parameters (supportedHashSignatures)
 import Network.TLS.State
 import Network.TLS.Handshake.State
 import Network.TLS.Handshake.Key
@@ -155,7 +154,7 @@ digitallySignParams ctx signatureData sigAlg mhash = do
 digitallySignDHParams :: Context
                       -> ServerDHParams
                       -> SignatureAlgorithm
-                      -> Maybe HashAlgorithm
+                      -> Maybe HashAlgorithm -- TLS12 only
                       -> IO DigitallySigned
 digitallySignDHParams ctx serverParams sigAlg mhash = do
     dhParamsData <- withClientAndServerRandom ctx $ encodeSignedDHParams serverParams
@@ -164,7 +163,7 @@ digitallySignDHParams ctx serverParams sigAlg mhash = do
 digitallySignECDHParams :: Context
                         -> ServerECDHParams
                         -> SignatureAlgorithm
-                        -> Maybe HashAlgorithm
+                        -> Maybe HashAlgorithm -- TLS12 only
                         -> IO DigitallySigned
 digitallySignECDHParams ctx serverParams sigAlg mhash = do
     ecdhParamsData <- withClientAndServerRandom ctx $ encodeSignedECDHParams serverParams

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -155,6 +155,12 @@ data Supported = Supported
       -- | All supported hash/signature algorithms pair for client
       -- certificate verification and server signature in (EC)DHE,
       -- ordered by decreasing priority.
+      --
+      -- This list is sent to the peer as part of the signature_algorithms
+      -- extension.  It is also used to restrict the choice of hash and
+      -- signature algorithm, but only when the TLS version is 1.2 or above.
+      -- In order to disable SHA-1 one must then also disable earlier protocol
+      -- versions in 'supportedVersions'.
     , supportedHashSignatures :: [HashAndSignatureAlgorithm]
       -- | Secure renegotiation defined in RFC5746.
       --   If 'True', clients send the renegotiation_info extension.


### PR DESCRIPTION
This extends #177 so that the "signature_algorithms" extension impacts cipher selection as discussed in #191.

I added a new test case specific to TLS 1.2 where handshake can either succeed or fail depending on client and server `supportedHashSignatures`. This could be further extended to test more TLS 1.2 extensions like "supported_groups" when we implement it.

I also added code for DSA certificates, so that the QuickCheck properties can test more combinations.