### PR TITLE
Build fails for base < 4.6

### DIFF
--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -40,7 +40,7 @@ Flag hans
   Default:           False
 
 Library
-  Build-Depends:     base >= 4.6 && < 5
+  Build-Depends:     base >= 4.7 && < 5
                    , mtl >= 2
                    , transformers
                    , cereal >= 0.4

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -40,7 +40,7 @@ Flag hans
   Default:           False
 
 Library
-  Build-Depends:     base >= 4.3 && < 5
+  Build-Depends:     base >= 4.6 && < 5
                    , mtl >= 2
                    , transformers
                    , cereal >= 0.4


### PR DESCRIPTION
This affects GHC 7.4 and earlier.

The error is

```
Network/TLS/Handshake/Client.hs:275:13:
    Warning: Pattern match(es) are overlapped
             In a case alternative: _ -> ...
[47 of 52] Compiling Network.TLS.Handshake.Server ( Network/TLS/Handshake/Server.hs, /tmp/matrix-worker/1489475638/dist-newstyle/build/x86_64-linux/ghc-7.4.2/tls-1.3.10/build/Network/TLS/Handshake/Server.o )

Network/TLS/Handshake/Server.hs:37:18:
    Module `Data.Ord' does not export `Down(..)'
```

The other alternative is to use CPP to add

```haskell
-- | The 'Down' type allows you to reverse sort order conveniently.  A value of type
-- @'Down' a@ contains a value of type @a@ (represented as @'Down' a@).
-- If @a@ has an @'Ord'@ instance associated with it then comparing two
-- values thus wrapped will give you the opposite of their normal sort order.
-- This is particularly useful when sorting in generalised list comprehensions,
-- as in: @then sortWith by 'Down' x@
--
-- Provides 'Show' and 'Read' instances (/since: 4.7.0.0/).
--
-- @since 4.6.0.0
newtype Down a = Down a deriving (Eq, Show, Read)

instance Ord a => Ord (Down a) where
    compare (Down x) (Down y) = y `compare` x
```

to the failing file.