### PR TITLE
Fix for intermittent BadRecordMac problem during handshaking when usi…

### DIFF
--- a/core/Network/TLS/Cipher.hs
+++ b/core/Network/TLS/Cipher.hs
@@ -29,6 +29,7 @@ module Network.TLS.Cipher
     , cipherExchangeNeedMoreData
     , hasMAC
     , hasRecordIV
+    , shouldTrimPreMasterSecret
     ) where
 
 import Crypto.Cipher.Types (AuthTag)
@@ -156,3 +157,16 @@ cipherExchangeNeedMoreData CipherKeyExchange_DH_RSA      = False
 cipherExchangeNeedMoreData CipherKeyExchange_ECDH_ECDSA  = True
 cipherExchangeNeedMoreData CipherKeyExchange_ECDH_RSA    = True
 cipherExchangeNeedMoreData CipherKeyExchange_ECDHE_ECDSA = True
+
+shouldTrimPreMasterSecret :: Version -> Cipher -> Bool
+shouldTrimPreMasterSecret version cipher = (isTrimPreMasterSecretVersion version) && (isTrimPreMasterSecretCipher cipher)
+
+isTrimPreMasterSecretCipher :: Cipher -> Bool
+isTrimPreMasterSecretCipher Cipher { cipherKeyExchange = CipherKeyExchange_DHE_DSS } = True
+isTrimPreMasterSecretCipher Cipher { cipherKeyExchange = CipherKeyExchange_DHE_RSA } = True
+isTrimPreMasterSecretCipher _                                                        = False
+
+isTrimPreMasterSecretVersion :: Version -> Bool
+isTrimPreMasterSecretVersion TLS11 = True
+isTrimPreMasterSecretVersion TLS12 = True
+isTrimPreMasterSecretVersion _     = False


### PR DESCRIPTION
…ng DHE key exchange and TLS 1.1 or TLS 1.2

This fixes issue https://github.com/vincenthz/hs-tls/issues/124.

There was a change between the TLS 1.0 RFC and the TLS 1.1 RFC that specifies that
leading 0 bytes of the pre-master-secret should be stripped before using it to derive
the master secret. The hs-tls library was not doing this which lead to 1 out of 256
handshakes to fail when using Diffie-Hellman key exchange and TLS 1.1 or TLS 1.2 when
communicating with an RFC compliant peer. Note that because the same logic is used in
both client and server contexts, this affected both clients and servers but would
not have affected a client and server both using this library.

See section 8.1.2 of the relevant RFCs for details:
https://tools.ietf.org/html/rfc2246#section-8.1.2
https://tools.ietf.org/html/rfc4346#section-8.1.2
https://tools.ietf.org/html/rfc5246#section-8.1.2