### PR TITLE
using GHC 8.0.2 on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ matrix:
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,libssl-dev], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.3
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,libssl-dev], sources: [hvr-ghc]}}
-    - env: CABALVER=1.24 GHCVER=8.0.1 RUNTEST=0
-      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,libssl-dev], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.2 RUNTEST=0
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,libssl-dev], sources: [hvr-ghc]}}
     - env: CABALVER=head GHCVER=head RUNTEST=0
       addons: {apt: {packages: [cabal-install-head,ghc-head,libssl-dev], sources: [hvr-ghc]}}
 


### PR DESCRIPTION
@alanz kindly pointed out that we should use 8.0.2 instead of 8.0.1 on Travis.