### PR TITLE
Supporting RSAPSS defined in TLS 1.3

### DIFF
--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -66,6 +66,7 @@ import Network.TLS.Backend
 import Network.TLS.Context.Internal
 import Network.TLS.Struct
 import Network.TLS.Cipher (Cipher(..), CipherKeyExchangeType(..))
+import Network.TLS.Crypto.Types
 import Network.TLS.Credentials
 import Network.TLS.State
 import Network.TLS.Hooks
@@ -134,8 +135,8 @@ instance TLSParams ServerParams where
                         CipherKeyExchange_ECDH_RSA    -> False
 
                 canDHE        = isJust $ serverDHEParams sparams
-                canSignDSS    = SignatureDSS `elem` signingAlgs
-                canSignRSA    = SignatureRSA `elem` signingAlgs
+                canSignDSS    = DSS `elem` signingAlgs
+                canSignRSA    = RSA `elem` signingAlgs
                 canEncryptRSA = isJust $ credentialsFindForDecrypting creds
                 signingAlgs   = credentialsListSigningAlgorithms creds
                 serverCreds   = sharedCredentials $ serverShared sparams

--- a/core/Network/TLS/Crypto/Types.hs
+++ b/core/Network/TLS/Crypto/Types.hs
@@ -13,3 +13,8 @@ data Group = P256 | P384 | P521 | X25519 | X448
 
 availableGroups :: [Group]
 availableGroups = [P256,P384,P521,X25519,X448]
+
+-- Digital signature algorithm, in close relation to public/private key types
+-- and cipher key exchange.
+data DigitalSignatureAlg = RSA | DSS | ECDSA | Ed25519 | Ed448
+                           deriving (Show, Eq)

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -261,7 +261,7 @@ sendClientData cparams ctx = sendCertificate >> sendClientKeyXchg >> sendCertifi
 
                     -- Fetch all handshake messages up to now.
                     msgs   <- usingHState ctx $ B.concat <$> getHandshakeMessages
-                    sigDig <- certificateVerifyCreate ctx usedVersion sigAlg mhashSig msgs
+                    sigDig <- createCertificateVerify ctx usedVersion sigAlg mhashSig msgs
                     sendPacket ctx $ Handshake [CertVerify sigDig]
 
                 _ -> return ()

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -243,7 +243,7 @@ sendClientData cparams ctx = sendCertificate >> sendClientKeyXchg >> sendCertifi
                 True -> do
                     sigAlg <- getLocalSignatureAlg
 
-                    mhash <- case usedVersion of
+                    mhashSig <- case usedVersion of
                         TLS12 -> do
                             Just (_, Just hashSigs, _) <- usingHState ctx $ getClientCertRequest
                             -- The values in the "signature_algorithms" extension
@@ -256,12 +256,12 @@ sendClientData cparams ctx = sendCertificate >> sendClientKeyXchg >> sendCertifi
 
                             when (null hashSigs') $
                                 throwCore $ Error_Protocol ("no " ++ show sigAlg ++ " hash algorithm in common with the server", True, HandshakeFailure)
-                            return $ Just $ fst $ head hashSigs'
+                            return $ Just $ head hashSigs'
                         _     -> return Nothing
 
                     -- Fetch all handshake messages up to now.
                     msgs   <- usingHState ctx $ B.concat <$> getHandshakeMessages
-                    sigDig <- certificateVerifyCreate ctx usedVersion sigAlg mhash msgs
+                    sigDig <- certificateVerifyCreate ctx usedVersion sigAlg mhashSig msgs
                     sendPacket ctx $ Handshake [CertVerify sigDig]
 
                 _ -> return ()

--- a/core/Network/TLS/Handshake/Key.hs
+++ b/core/Network/TLS/Handshake/Key.hs
@@ -38,13 +38,13 @@ encryptRSA ctx content = do
             Left err       -> fail ("rsa encrypt failed: " ++ show err)
             Right econtent -> return econtent
 
-signPrivate :: Context -> Role -> Hash -> ByteString -> IO ByteString
-signPrivate ctx _ hsh content = do
+signPrivate :: Context -> Role -> SignatureParams -> ByteString -> IO ByteString
+signPrivate ctx _ params content = do
     privateKey <- usingHState ctx getLocalPrivateKey
     usingState_ ctx $ do
-        r <- withRNG $ kxSign privateKey hsh content
+        r <- withRNG $ kxSign privateKey params content
         case r of
-            Left err       -> fail ("rsa sign failed: " ++ show err)
+            Left err       -> fail ("sign failed: " ++ show err)
             Right econtent -> return econtent
 
 decryptRSA :: Context -> ByteString -> IO (Either KxError ByteString)
@@ -55,10 +55,10 @@ decryptRSA ctx econtent = do
         let cipher = if ver < TLS10 then econtent else B.drop 2 econtent
         withRNG $ kxDecrypt privateKey cipher
 
-verifyPublic :: Context -> Role -> Hash -> ByteString -> ByteString -> IO Bool
-verifyPublic ctx _ hsh econtent sign = do
+verifyPublic :: Context -> Role -> SignatureParams -> ByteString -> ByteString -> IO Bool
+verifyPublic ctx _ params econtent sign = do
     publicKey <- usingHState ctx getRemotePublicKey
-    return $ kxVerify publicKey hsh econtent sign
+    return $ kxVerify publicKey params econtent sign
 
 generateDHE :: Context -> DHParams -> IO (DHPrivate, DHPublic)
 generateDHE ctx dhp = usingState_ ctx $ withRNG $ dhGenerateKeyPair dhp

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -180,12 +180,12 @@ handshakeServerWith sparams ctx clientHello@(ClientHello clientVersion _ clientS
         creds = extraCreds `mappend` sharedCredentials (ctxShared ctx)
 
     cred <- case cipherKeyExchange usedCipher of
-                CipherKeyExchange_RSA     -> return $ credentialsFindForDecrypting creds
-                CipherKeyExchange_DH_Anon -> return $ Nothing
-                CipherKeyExchange_DHE_RSA -> return $ credentialsFindForSigning SignatureRSA creds
-                CipherKeyExchange_DHE_DSS -> return $ credentialsFindForSigning SignatureDSS creds
-                CipherKeyExchange_ECDHE_RSA -> return $ credentialsFindForSigning SignatureRSA creds
-                _                         -> throwCore $ Error_Protocol ("key exchange algorithm not implemented", True, HandshakeFailure)
+                CipherKeyExchange_RSA       -> return $ credentialsFindForDecrypting creds
+                CipherKeyExchange_DH_Anon   -> return $ Nothing
+                CipherKeyExchange_DHE_RSA   -> return $ credentialsFindForSigning RSA creds
+                CipherKeyExchange_DHE_DSS   -> return $ credentialsFindForSigning DSS creds
+                CipherKeyExchange_ECDHE_RSA -> return $ credentialsFindForSigning RSA creds
+                _                           -> throwCore $ Error_Protocol ("key exchange algorithm not implemented", True, HandshakeFailure)
 
     resumeSessionData <- case clientSession of
             (Session (Just clientSessionId)) -> liftIO $ sessionResume (sharedSessionManager $ ctxShared ctx) clientSessionId

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -153,17 +153,17 @@ handshakeServerWith sparams ctx clientHello@(ClientHello clientVersion _ clientS
                         -- one hash algorithm in common between client and server.
                         -- May contain duplicates, as it is only used for `elem`.
                         possibleHashSigAlgs = hashAndSignaturesInCommon ctx exts
-                        possibleSigAlgs = map snd possibleHashSigAlgs
 
+                        isCommon sig = any (sig `signatureCompatible`) possibleHashSigAlgs
                         -- Check that a candidate cipher with a signature requiring
                         -- a hash will have at least one hash available.  This avoids
                         -- a failure later in 'decideHash'.
                         hasSigningRequirements =
                             case cipherKeyExchange cipher of
-                                CipherKeyExchange_DHE_RSA      -> any (RSA `signatureCompatible`) possibleHashSigAlgs
-                                CipherKeyExchange_DHE_DSS      -> SignatureDSS   `elem` possibleSigAlgs
-                                CipherKeyExchange_ECDHE_RSA    -> any (RSA `signatureCompatible`) possibleHashSigAlgs
-                                CipherKeyExchange_ECDHE_ECDSA  -> SignatureECDSA `elem` possibleSigAlgs
+                                CipherKeyExchange_DHE_RSA      -> isCommon RSA
+                                CipherKeyExchange_DHE_DSS      -> isCommon DSS
+                                CipherKeyExchange_ECDHE_RSA    -> isCommon RSA
+                                CipherKeyExchange_ECDHE_ECDSA  -> isCommon ECDSA
                                 _                              -> True -- signature not used
 
                      in cipherAllowedForVersion chosenVersion cipher && hasSigningRequirements && hasCommonGroup cipher

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -31,7 +31,7 @@ import Network.TLS.Handshake.Process
 import Network.TLS.Handshake.Key
 import Network.TLS.Measurement
 import Data.Maybe (isJust, listToMaybe, mapMaybe)
-import Data.List (intersect, find)
+import Data.List (intersect, any)
 import qualified Data.ByteString as B
 import Data.ByteString.Char8 ()
 import Data.Ord (Down(..))
@@ -160,9 +160,9 @@ handshakeServerWith sparams ctx clientHello@(ClientHello clientVersion _ clientS
                         -- a failure later in 'decideHash'.
                         hasSigningRequirements =
                             case cipherKeyExchange cipher of
-                                CipherKeyExchange_DHE_RSA      -> isJust $ find (RSA `signatureCompatible`) possibleHashSigAlgs
+                                CipherKeyExchange_DHE_RSA      -> any (RSA `signatureCompatible`) possibleHashSigAlgs
                                 CipherKeyExchange_DHE_DSS      -> SignatureDSS   `elem` possibleSigAlgs
-                                CipherKeyExchange_ECDHE_RSA    -> isJust $ find (RSA `signatureCompatible`) possibleHashSigAlgs
+                                CipherKeyExchange_ECDHE_RSA    -> any (RSA `signatureCompatible`) possibleHashSigAlgs
                                 CipherKeyExchange_ECDHE_ECDSA  -> SignatureECDSA `elem` possibleSigAlgs
                                 _                              -> True -- signature not used
 

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -464,7 +464,7 @@ recvClientData sparams ctx = runRecvState ctx (RecvStateHandshake processClientC
 
             -- FIXME should check certificate is allowed for signing
 
-            verif <- certificateVerifyCheck ctx usedVersion sigAlgExpected msgs dsig
+            verif <- checkCertificateVerify ctx usedVersion sigAlgExpected msgs dsig
 
             case verif of
                 True -> do

--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -9,7 +9,7 @@
 module Network.TLS.Handshake.Signature
     (
       DigitalSignatureAlg(..)
-    , certificateVerifyCreate
+    , createCertificateVerify
     , certificateVerifyCheck
     , digitallySignDHParams
     , digitallySignECDHParams
@@ -59,13 +59,13 @@ certificateVerifyCheck ctx usedVersion sigAlgExpected msgs digSig@(DigitallySign
         prepareCertificateVerifySignatureData ctx usedVersion sigAlgExpected hashSigAlg msgs >>=
         signatureVerifyWithHashDescr ctx digSig
 
-certificateVerifyCreate :: Context
+createCertificateVerify :: Context
                         -> Version
                         -> DigitalSignatureAlg
                         -> Maybe HashAndSignatureAlgorithm -- TLS12 only
                         -> Bytes
                         -> IO DigitallySigned
-certificateVerifyCreate ctx usedVersion sigAlg hashSigAlg msgs =
+createCertificateVerify ctx usedVersion sigAlg hashSigAlg msgs =
     prepareCertificateVerifySignatureData ctx usedVersion sigAlg hashSigAlg msgs >>=
     signatureCreateWithHashDescr ctx hashSigAlg
 

--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -8,8 +8,7 @@
 --
 module Network.TLS.Handshake.Signature
     (
-      DigitalSignatureAlg(..)
-    , createCertificateVerify
+      createCertificateVerify
     , checkCertificateVerify
     , digitallySignDHParams
     , digitallySignECDHParams
@@ -30,11 +29,6 @@ import Network.TLS.Handshake.Key
 import Network.TLS.Util
 
 import Control.Monad.State
-
--- Digital signature algorithm, in close relation to public/private key types
--- and cipher key exchange.
-data DigitalSignatureAlg = RSA | DSS | ECDSA | Ed25519 | Ed448
-                           deriving (Show, Eq)
 
 signatureCompatible :: DigitalSignatureAlg -> HashAndSignatureAlgorithm -> Bool
 signatureCompatible RSA   (_, SignatureRSA)          = True

--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -33,7 +33,8 @@ import Control.Monad.State
 
 -- Digital signature algorithm, in close relation to public/private key types
 -- and cipher key exchange.
-data DigitalSignatureAlg = RSA | DSS | ECDSA deriving (Show, Eq)
+data DigitalSignatureAlg = RSA | DSS | ECDSA | Ed25519 | Ed448
+                           deriving (Show, Eq)
 
 signatureCompatible :: DigitalSignatureAlg -> HashAndSignatureAlgorithm -> Bool
 signatureCompatible RSA   (_, SignatureRSA)          = True
@@ -127,6 +128,7 @@ signatureParams ECDSA hashSigAlg =
         Nothing                           -> ECDSAParams SHA1
         Just (hsh       , SignatureECDSA) -> error ("unimplemented ECDSA signature hash type: " ++ show hsh)
         Just (_         , sigAlg)         -> error ("signature algorithm is incompatible with ECDSA: " ++ show sigAlg)
+signatureParams sig _ = error ("unimplemented signature type: " ++ show sig)
 
 signatureCreateWithCertVerifyData :: Context
                                   -> Maybe HashAndSignatureAlgorithm

--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -10,7 +10,7 @@ module Network.TLS.Handshake.Signature
     (
       DigitalSignatureAlg(..)
     , createCertificateVerify
-    , certificateVerifyCheck
+    , checkCertificateVerify
     , digitallySignDHParams
     , digitallySignECDHParams
     , digitallySignDHParamsVerify
@@ -41,13 +41,13 @@ signatureCompatible DSS   (_, SignatureDSS)   = True
 signatureCompatible ECDSA (_, SignatureECDSA) = True
 signatureCompatible _     (_, _)              = False
 
-certificateVerifyCheck :: Context
+checkCertificateVerify :: Context
                        -> Version
                        -> DigitalSignatureAlg
                        -> Bytes
                        -> DigitallySigned
                        -> IO Bool
-certificateVerifyCheck ctx usedVersion sigAlgExpected msgs digSig@(DigitallySigned hashSigAlg _) =
+checkCertificateVerify ctx usedVersion sigAlgExpected msgs digSig@(DigitallySigned hashSigAlg _) =
     case (usedVersion, hashSigAlg) of
         (TLS12, Nothing)    -> return False
         (TLS12, Just hs) | sigAlgExpected `signatureCompatible` hs -> doVerify

--- a/core/Network/TLS/Struct.hs
+++ b/core/Network/TLS/Struct.hs
@@ -113,6 +113,11 @@ data SignatureAlgorithm =
     | SignatureRSA
     | SignatureDSS
     | SignatureECDSA
+    | SignatureRSApssSHA256
+    | SignatureRSApssSHA384
+    | SignatureRSApssSHA512
+    | SignatureEd25519
+    | SignatureEd448
     | SignatureOther Word8
     deriving (Show,Eq)
 
@@ -534,16 +539,26 @@ instance TypeValuable HashAlgorithm where
     valToType i = Just (HashOther i)
 
 instance TypeValuable SignatureAlgorithm where
-    valOfType SignatureAnonymous = 0
-    valOfType SignatureRSA       = 1
-    valOfType SignatureDSS       = 2
-    valOfType SignatureECDSA     = 3
-    valOfType (SignatureOther i) = i
+    valOfType SignatureAnonymous    = 0
+    valOfType SignatureRSA          = 1
+    valOfType SignatureDSS          = 2
+    valOfType SignatureECDSA        = 3
+    valOfType SignatureRSApssSHA256 = 4
+    valOfType SignatureRSApssSHA384 = 5
+    valOfType SignatureRSApssSHA512 = 6
+    valOfType SignatureEd25519      = 7
+    valOfType SignatureEd448        = 8
+    valOfType (SignatureOther i)    = i
 
     valToType 0 = Just SignatureAnonymous
     valToType 1 = Just SignatureRSA
     valToType 2 = Just SignatureDSS
     valToType 3 = Just SignatureECDSA
+    valToType 4 = Just SignatureRSApssSHA256
+    valToType 5 = Just SignatureRSApssSHA384
+    valToType 6 = Just SignatureRSApssSHA512
+    valToType 7 = Just SignatureEd25519
+    valToType 8 = Just SignatureEd448
     valToType i = Just (SignatureOther i)
 
 instance EnumSafe16 Group where

--- a/core/Network/TLS/Struct.hs
+++ b/core/Network/TLS/Struct.hs
@@ -104,6 +104,7 @@ data HashAlgorithm =
     | HashSHA256
     | HashSHA384
     | HashSHA512
+    | HashTLS13
     | HashOther Word8
     deriving (Show,Eq)
 
@@ -519,6 +520,7 @@ instance TypeValuable HashAlgorithm where
     valOfType HashSHA256    = 4
     valOfType HashSHA384    = 5
     valOfType HashSHA512    = 6
+    valOfType HashTLS13     = 8
     valOfType (HashOther i) = i
 
     valToType 0 = Just HashNone
@@ -528,6 +530,7 @@ instance TypeValuable HashAlgorithm where
     valToType 4 = Just HashSHA256
     valToType 5 = Just HashSHA384
     valToType 6 = Just HashSHA512
+    valToType 8 = Just HashTLS13
     valToType i = Just (HashOther i)
 
 instance TypeValuable SignatureAlgorithm where

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -110,7 +110,8 @@ prop_handshake_initiate_tls12 = do
     if shouldFail
         then runTLSInitFailure (clientParam',serverParam')
         else runTLSPipeSimple  (clientParam',serverParam')
-  where someHashSignatures = sublistOf [ (HashSHA512, SignatureRSA)
+  where someHashSignatures = sublistOf [ (HashTLS13, SignatureRSApssSHA256)
+                                       , (HashSHA512, SignatureRSA)
                                        , (HashSHA384, SignatureRSA)
                                        , (HashSHA256, SignatureRSA)
                                        , (HashSHA1,   SignatureRSA)

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -114,7 +114,7 @@ Library
                      Network.TLS.Types
                      Network.TLS.Wire
                      Network.TLS.X509
-  ghc-options:       -Wall -fno-warn-unused-imports
+  ghc-options:       -Wall
   if flag(compat)
     cpp-options:     -DSSLV2_COMPATIBLE
 


### PR DESCRIPTION
This implements #206.

Since TLS 1.3 flattens the structure of (Hash, Signature) and Hash 0x08 is a magic word for TLS 1.3, implementation is not straightforward and a little bit tricky.