### PR TITLE
New debug options

### DIFF
--- a/debug/src/Common.hs
+++ b/debug/src/Common.hs
@@ -1,6 +1,8 @@
 module Common
-    ( printDHParams
+    ( printCiphers
+    , printDHParams
     , readNumber
+    , readCiphers
     , readDHParams
     ) where
 
@@ -11,6 +13,7 @@ import Data.Char (isDigit)
 import Numeric (showHex)
 
 import Network.TLS
+import Network.TLS.Extra.Cipher
 import Network.TLS.Extra.FFDHE
 
 namedDHParams :: [(String, DHParams)]
@@ -22,16 +25,45 @@ namedDHParams =
     , ("ffdhe8192", ffdhe8192)
     ]
 
+namedCiphersuites :: [(String, [CipherID])]
+namedCiphersuites =
+    [ ("all",       map cipherID ciphersuite_all)
+    , ("default",   map cipherID ciphersuite_default)
+    , ("medium",    map cipherID ciphersuite_medium)
+    , ("strong",    map cipherID ciphersuite_strong)
+    ]
+
 readNumber :: (Num a, Read a) => String -> Maybe a
 readNumber s
     | all isDigit s = Just $ read s
     | otherwise     = Nothing
+
+readCiphers :: String -> Maybe [CipherID]
+readCiphers s =
+    case lookup s namedCiphersuites of
+        Nothing -> (:[]) `fmap` readNumber s
+        just    -> just
 
 readDHParams :: String -> IO (Maybe DHParams)
 readDHParams s =
     case lookup s namedDHParams of
         Nothing -> (Just . read) `fmap` readFile s
         mparams -> return mparams
+
+printCiphers :: IO ()
+printCiphers = do
+    putStrLn "Supported ciphers"
+    putStrLn "====================================="
+    forM_ ciphersuite_all $ \c -> do
+        putStrLn (pad 50 (cipherName c) ++ " = " ++ pad 5 (show $ cipherID c) ++ "  0x" ++ showHex (cipherID c) "")
+    putStrLn ""
+    putStrLn "Ciphersuites"
+    putStrLn "====================================="
+    forM_ namedCiphersuites $ \(name, _) -> putStrLn name
+  where
+    pad n s
+        | length s < n = s ++ replicate (n - length s) ' '
+        | otherwise    = s
 
 printDHParams :: IO ()
 printDHParams = do

--- a/debug/src/Common.hs
+++ b/debug/src/Common.hs
@@ -1,5 +1,7 @@
 module Common
-    ( readNumber
+    ( printDHParams
+    , readNumber
+    , readDHParams
     ) where
 
 import Control.Monad
@@ -9,8 +11,31 @@ import Data.Char (isDigit)
 import Numeric (showHex)
 
 import Network.TLS
+import Network.TLS.Extra.FFDHE
+
+namedDHParams :: [(String, DHParams)]
+namedDHParams =
+    [ ("ffdhe2048", ffdhe2048)
+    , ("ffdhe3072", ffdhe3072)
+    , ("ffdhe4096", ffdhe4096)
+    , ("ffdhe6144", ffdhe6144)
+    , ("ffdhe8192", ffdhe8192)
+    ]
 
 readNumber :: (Num a, Read a) => String -> Maybe a
 readNumber s
     | all isDigit s = Just $ read s
     | otherwise     = Nothing
+
+readDHParams :: String -> IO (Maybe DHParams)
+readDHParams s =
+    case lookup s namedDHParams of
+        Nothing -> (Just . read) `fmap` readFile s
+        mparams -> return mparams
+
+printDHParams :: IO ()
+printDHParams = do
+    putStrLn "DH Parameters"
+    putStrLn "====================================="
+    forM_ namedDHParams $ \(name, _) -> putStrLn name
+    putStrLn "(or /path/to/dhparams)"

--- a/debug/src/Common.hs
+++ b/debug/src/Common.hs
@@ -4,6 +4,7 @@ module Common
     , readNumber
     , readCiphers
     , readDHParams
+    , printHandshakeInfo
     ) where
 
 import Control.Monad
@@ -71,3 +72,12 @@ printDHParams = do
     putStrLn "====================================="
     forM_ namedDHParams $ \(name, _) -> putStrLn name
     putStrLn "(or /path/to/dhparams)"
+
+printHandshakeInfo ctx = do
+    info <- contextGetInformation ctx
+    forM_ info $ \i -> do
+        putStrLn ("version: " ++ show (infoVersion i))
+        putStrLn ("cipher: " ++ show (infoCipher i))
+        putStrLn ("compression: " ++ show (infoCompression i))
+    sni <- getClientSNI ctx
+    forM_ sni $ \n -> putStrLn ("server name indication: " ++ n)

--- a/debug/src/Common.hs
+++ b/debug/src/Common.hs
@@ -1,0 +1,16 @@
+module Common
+    ( readNumber
+    ) where
+
+import Control.Monad
+
+import Data.Char (isDigit)
+
+import Numeric (showHex)
+
+import Network.TLS
+
+readNumber :: (Num a, Read a) => String -> Maybe a
+readNumber s
+    | all isDigit s = Just $ read s
+    | otherwise     = Nothing

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -21,7 +21,8 @@ import System.X509
 import Data.Default.Class
 import Data.IORef
 import Data.Monoid
-import Data.Maybe (isJust)
+import Data.List (find)
+import Data.Maybe (isJust, mapMaybe)
 
 import Common
 import HexDump
@@ -100,7 +101,7 @@ getDefaultParams flags host store sStorage certCredsRequest session =
             getSelectedCiphers =
                 case getUsedCipherIDs of
                     [] -> ciphersuite_all
-                    l  -> filter (\c -> cipherID c `elem` l) ciphersuite_all
+                    l  -> mapMaybe (\cid -> find ((== cid) . cipherID) ciphersuite_all) l
 
             getDebugSeed :: Maybe Seed -> Flag -> Maybe Seed
             getDebugSeed _   (DebugSeed seed) = seedFromInteger `fmap` readNumber seed

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -21,11 +21,11 @@ import System.X509
 import Data.Default.Class
 import Data.IORef
 import Data.Monoid
-import Data.Char (isDigit)
 import Data.Maybe (isJust)
 
 import Numeric (showHex)
 
+import Common
 import HexDump
 
 defaultBenchAmount = 1024 * 1024
@@ -266,11 +266,6 @@ runOn (sStorage, certStore) flags port hostname
                                             Nothing -> acc
                                             Just i  -> i
                 f acc _              = acc
-
-readNumber :: Read a => String -> Maybe a
-readNumber s
-    | all isDigit s = Just $ read s
-    | otherwise     = Nothing
 
 printUsage =
     putStrLn $ usageInfo "usage: simpleclient [opts] <hostname> [port]\n\n\t(port default to: 443)\noptions:\n" options

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -217,6 +217,7 @@ runOn (sStorage, certStore) flags port hostname
                    (IODebug `elem` flags)
                    (getDefaultParams flags hostname certStore sStorage certCredRequest sess) hostname port $ \ctx -> do
                 handshake ctx
+                when (Verbose `elem` flags) $ printHandshakeInfo ctx
                 sendData ctx $ query
                 loopRecv out ctx
                 bye ctx

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -63,7 +63,7 @@ sessionRef ref = SessionManager
     }
 
 getDefaultParams flags host store sStorage certCredsRequest session =
-    (defaultParamsClient host BC.empty)
+    (defaultParamsClient serverName BC.empty)
         { clientSupported = def { supportedVersions = supportedVers, supportedCiphers = myCiphers }
         , clientWantSessionResume = session
         , clientUseServerNameIndication = not (NoSNI `elem` flags)
@@ -80,6 +80,10 @@ getDefaultParams flags host store sStorage certCredsRequest session =
                             }
         }
     where
+            serverName = foldl f host flags
+              where f _   (SNI n) = n
+                    f acc _       = acc
+
             validateCache
                 | validateCert = def
                 | otherwise    = ValidationCache (\_ _ _ -> return ValidationCachePass)
@@ -121,6 +125,7 @@ getDefaultParams flags host store sStorage certCredsRequest session =
 
 data Flag = Verbose | Debug | IODebug | NoValidateCert | Session | Http11
           | Ssl3 | Tls10 | Tls11 | Tls12
+          | SNI String
           | NoSNI
           | Uri String
           | NoVersionDowngrade
@@ -151,6 +156,7 @@ options =
     , Option []     ["client-cert"] (ReqArg ClientCert "cert-file:key-file") "add a client certificate to use with the server"
     , Option []     ["http1.1"] (NoArg Http11) "use http1.1 instead of http1.0"
     , Option []     ["ssl3"]    (NoArg Ssl3) "use SSL 3.0"
+    , Option []     ["sni"]     (ReqArg SNI "server-name") "use non-default server name indication"
     , Option []     ["no-sni"]  (NoArg NoSNI) "don't use server name indication"
     , Option []     ["user-agent"] (ReqArg UserAgent "user-agent") "use a user agent"
     , Option []     ["tls10"]   (NoArg Tls10) "use TLS 1.0"

--- a/debug/src/SimpleServer.hs
+++ b/debug/src/SimpleServer.hs
@@ -244,6 +244,7 @@ runOn (sStorage, certStore) flags port
                    (IODebug `elem` flags)
                    params port $ \ctx -> do
                 handshake ctx
+                when (Verbose `elem` flags) $ printHandshakeInfo ctx
                 loopRecv out ctx
                 --sendData ctx $ query
                 bye ctx

--- a/debug/src/SimpleServer.hs
+++ b/debug/src/SimpleServer.hs
@@ -139,7 +139,6 @@ getDefaultParams flags store sStorage cred _session = do
 
 data Flag = Verbose | Debug | IODebug | NoValidateCert | Session | Http11
           | Ssl3 | Tls10 | Tls11 | Tls12
-          | NoSNI
           | NoVersionDowngrade
           | AllowRenegotiation
           | Output String
@@ -170,7 +169,6 @@ options =
     , Option []     ["no-validation"] (NoArg NoValidateCert) "disable certificate validation"
     , Option []     ["http1.1"] (NoArg Http11) "use http1.1 instead of http1.0"
     , Option []     ["ssl3"]    (NoArg Ssl3) "use SSL 3.0"
-    , Option []     ["no-sni"]  (NoArg NoSNI) "don't use server name indication"
     , Option []     ["tls10"]   (NoArg Tls10) "use TLS 1.0"
     , Option []     ["tls11"]   (NoArg Tls11) "use TLS 1.1"
     , Option []     ["tls12"]   (NoArg Tls12) "use TLS 1.2 (default)"

--- a/debug/src/SimpleServer.hs
+++ b/debug/src/SimpleServer.hs
@@ -71,7 +71,7 @@ getDefaultParams :: [Flag] -> CertificateStore -> IORef (SessionID, SessionData)
 getDefaultParams flags store sStorage cred _session = do
     dhParams <- case getDHParams flags of
         Nothing   -> return Nothing
-        Just file -> (Just . read) `fmap` readFile file
+        Just name -> readDHParams name
 
     return ServerParams
         { serverWantClientCert = False
@@ -150,6 +150,7 @@ data Flag = Verbose | Debug | IODebug | NoValidateCert | Session | Http11
           | BenchData String
           | UseCipher String
           | ListCiphers
+          | ListDHParams
           | Certificate String
           | Key String
           | DHParams String
@@ -182,11 +183,12 @@ options =
     , Option []     ["bench-data"] (ReqArg BenchData "amount") "amount of data to benchmark with"
     , Option []     ["use-cipher"] (ReqArg UseCipher "cipher-id") "use a specific cipher"
     , Option []     ["list-ciphers"] (NoArg ListCiphers) "list all ciphers supported and exit"
+    , Option []     ["list-dhparams"] (NoArg ListDHParams) "list all DH parameters supported and exit"
     , Option []     ["certificate"] (ReqArg Certificate "certificate") "certificate file"
     , Option []     ["debug-seed"] (ReqArg DebugSeed "debug-seed") "debug: set a specific seed for randomness"
     , Option []     ["debug-print-seed"] (NoArg DebugPrintSeed) "debug: set a specific seed for randomness"
     , Option []     ["key"] (ReqArg Key "key") "certificate file"
-    , Option []     ["dhparams"] (ReqArg DHParams "dhparams") "DH parameter file"
+    , Option []     ["dhparams"] (ReqArg DHParams "dhparams") "DH parameters (name or file)"
     ]
 
 noSession = Nothing
@@ -317,6 +319,10 @@ main = do
 
     when (ListCiphers `elem` opts) $ do
         printCiphers
+        exitSuccess
+
+    when (ListDHParams `elem` opts) $ do
+        printDHParams
         exitSuccess
 
     certStore <- getSystemCertificateStore

--- a/debug/src/SimpleServer.hs
+++ b/debug/src/SimpleServer.hs
@@ -20,7 +20,8 @@ import Data.X509.CertificateStore
 import Data.Default.Class
 import Data.IORef
 import Data.Monoid
-import Data.Maybe (isJust)
+import Data.List (find)
+import Data.Maybe (isJust, mapMaybe)
 
 import Common
 import HexDump
@@ -113,7 +114,7 @@ getDefaultParams flags store sStorage cred _session = do
             getSelectedCiphers =
                 case getUsedCipherIDs of
                     [] -> ciphersuite_default
-                    l  -> filter (\c -> cipherID c `elem` l) ciphersuite_all
+                    l  -> mapMaybe (\cid -> find ((== cid) . cipherID) ciphersuite_all) l
 
             getDHParams opts = foldl accf Nothing opts
               where accf _   (DHParams file) = Just file

--- a/debug/src/SimpleServer.hs
+++ b/debug/src/SimpleServer.hs
@@ -20,11 +20,11 @@ import Data.X509.CertificateStore
 import Data.Default.Class
 import Data.IORef
 import Data.Monoid
-import Data.Char (isDigit)
 import Data.Maybe (isJust)
 
 import Numeric (showHex)
 
+import Common
 import HexDump
 
 defaultBenchAmount = 1024 * 1024
@@ -290,11 +290,6 @@ runOn (sStorage, certStore) flags port
                                             Nothing -> acc
                                             Just i  -> i
                 f acc _              = acc
-
-readNumber :: (Num a, Read a) => String -> Maybe a
-readNumber s
-    | all isDigit s = Just $ read s
-    | otherwise     = Nothing
 
 printUsage =
     putStrLn $ usageInfo "usage: simpleserver [opts] [port]\n\n\t(port default to: 443)\noptions:\n" options

--- a/debug/src/Stunnel.hs
+++ b/debug/src/Stunnel.hs
@@ -90,7 +90,7 @@ clientProcess dhParamsFile creds handle dsthandle dbg sessionStorage _ = do
 
     dhParams <- case dhParamsFile of
             Nothing   -> return Nothing
-            Just file -> (Just . read) `fmap` readFile file
+            Just name -> readDHParams name
 
     let serverstate = def
             { serverSupported = def { supportedCiphers = ciphersuite_default }
@@ -236,6 +236,7 @@ data Flag =
     | DestinationType String
     | Debug
     | Help
+    | ListDHParams
     | Certificate String
     | Key String
     | DHParams String
@@ -251,9 +252,10 @@ options =
     , Option []     ["destination-type"] (ReqArg DestinationType "source-type") "type of source (tcp, unix, fd)"
     , Option []     ["debug"]   (NoArg Debug) "debug the TLS protocol printing debugging to stdout"
     , Option ['h']  ["help"]    (NoArg Help) "request help"
+    , Option []     ["list-dhparams"] (NoArg ListDHParams) "list all DH parameters supported and exit"
     , Option []     ["certificate"] (ReqArg Certificate "certificate") "certificate file"
     , Option []     ["key"] (ReqArg Key "key") "certificate file"
-    , Option []     ["dhparams"] (ReqArg DHParams "dhparams") "DH parameter file"
+    , Option []     ["dhparams"] (ReqArg DHParams "dhparams") "DH parameters (name or file)"
     , Option []     ["no-session"] (NoArg NoSession) "disable support for session"
     , Option []     ["no-cert-validation"] (NoArg NoCertValidation) "disable certificate validation"
     ]
@@ -300,6 +302,10 @@ main = do
 
     when (Help `elem` opts) $ do
         printUsage
+        exitSuccess
+
+    when (ListDHParams `elem` opts) $ do
+        printDHParams
         exitSuccess
 
     let source      = getSource opts

--- a/debug/src/Stunnel.hs
+++ b/debug/src/Stunnel.hs
@@ -27,6 +27,8 @@ import Network.TLS.Extra.Cipher
 
 import qualified Crypto.PubKey.DH as DH ()
 
+import Common
+
 loopUntil :: Monad m => m Bool -> m ()
 loopUntil f = f >>= \v -> if v then return () else loopUntil f
 

--- a/debug/tls-debug.cabal
+++ b/debug/tls-debug.cabal
@@ -18,6 +18,7 @@ extra-source-files:  src/HexDump.hs
 
 Executable           tls-stunnel
   Main-is:           Stunnel.hs
+  Other-modules:     Common
   Hs-Source-Dirs:    src
   Build-Depends:     base >= 4 && < 5
                    , network
@@ -62,7 +63,8 @@ Executable           tls-retrievecertificate
 
 Executable           tls-simpleclient
   Main-is:           SimpleClient.hs
-  Other-modules:     HexDump
+  Other-modules:     Common
+                   , HexDump
   Hs-Source-Dirs:    src
   Build-Depends:     base >= 4 && < 5
                    , network
@@ -76,7 +78,8 @@ Executable           tls-simpleclient
 
 Executable           tls-simpleserver
   Main-is:           SimpleServer.hs
-  Other-modules:     HexDump
+  Other-modules:     Common
+                   , HexDump
   Hs-Source-Dirs:    src
   Build-Depends:     base >= 4 && < 5
                    , network


### PR DESCRIPTION
Adds new features to tls-debug:
- ability to use named cipher suites (i.e. `--use-cipher=strong`) and named DH groups (i.e. `--dhparams=ffdhe4096`)
- new option to override SNI (i.e. `--sni=server-name`)
- honors order of `--use-cipher` options
- verbose mode prints some handshake information like selected version and cipher
