### PR TITLE
Missing checks when resuming a session

### DIFF
--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -187,7 +187,9 @@ handshakeServerWith sparams ctx clientHello@(ClientHello clientVersion _ clientS
                 _                         -> throwCore $ Error_Protocol ("key exchange algorithm not implemented", True, HandshakeFailure)
 
     resumeSessionData <- case clientSession of
-            (Session (Just clientSessionId)) -> liftIO $ sessionResume (sharedSessionManager $ ctxShared ctx) clientSessionId
+            (Session (Just clientSessionId)) ->
+                let resume = liftIO $ sessionResume (sharedSessionManager $ ctxShared ctx) clientSessionId
+                 in validateSession serverName <$> resume
             (Session Nothing)                -> return Nothing
 
     maybe (return ()) (usingState_ ctx . setClientSNI) serverName
@@ -209,6 +211,19 @@ handshakeServerWith sparams ctx clientHello@(ClientHello clientVersion _ clientS
         commonCiphers   extra = filter (flip elem (commonCipherIDs extra) . cipherID) (ctxCiphers ctx extra)
         commonCompressions    = compressionIntersectID (supportedCompressions $ ctxSupported ctx) compressions
         usedCompression       = head commonCompressions
+
+        -- FIXME should also validate compression_methods and server_name
+        -- (see RFC 5246 at 7.4.1.2 and RFC 6066), but necessary parameters
+        -- are not stored in SessionData currently
+        validateSession _   Nothing                         = Nothing
+        validateSession _   m@(Just sd)
+            -- SessionData parameters are assumed to match the local server configuration
+            -- so we need to compare only to ClientHello inputs.  Abbreviated handshake
+            -- uses the same server_name than full handshake so the same
+            -- credentials (and thus ciphers) are available.
+            | clientVersion < sessionVersion sd             = Nothing
+            | sessionCipher sd `notElem` ciphers            = Nothing
+            | otherwise                                     = m
 
 
 handshakeServerWith _ _ _ = throwCore $ Error_Protocol ("unexpected handshake message received in handshakeServerWith", True, HandshakeFailure)

--- a/core/Tests/Certificate.hs
+++ b/core/Tests/Certificate.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Certificate
     ( arbitraryX509
     , arbitraryX509WithKey

--- a/core/Tests/Marshalling.hs
+++ b/core/Tests/Marshalling.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Marshalling where
 
 import Control.Monad

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -182,19 +182,6 @@ prop_handshake_renegociation = do
             bye ctx
             return ()
 
--- | simple session manager to store one session id and session data for a single thread.
--- a Real concurrent session manager would use an MVar and have multiples items.
-oneSessionManager :: IORef (Maybe (SessionID, SessionData)) -> SessionManager
-oneSessionManager ref = SessionManager
-    { sessionResume     = \myId     -> (>>= maybeResume myId) <$> readIORef ref
-    , sessionEstablish  = \myId dat -> writeIORef ref $ Just (myId, dat)
-    , sessionInvalidate = \_        -> return ()
-    }
-  where
-    maybeResume myId (sid, sdata)
-        | sid == myId = Just sdata
-        | otherwise   = Nothing
-
 prop_handshake_session_resumption :: PropertyM IO ()
 prop_handshake_session_resumption = do
     sessionRef <- run $ newIORef Nothing

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -141,7 +141,7 @@ Test-Suite test-tls
                    , x509
                    , x509-validation
                    , hourglass
-  ghc-options:       -Wall -fno-warn-unused-imports -fno-warn-orphans
+  ghc-options:       -Wall -fno-warn-unused-imports
 
 Benchmark bench-tls
   hs-source-dirs:    Benchmarks Tests
@@ -160,7 +160,7 @@ Benchmark bench-tls
                    , QuickCheck >= 2
                    , tasty-quickcheck
                    , tls
-  ghc-options:       -Wall -fno-warn-unused-imports -fno-warn-orphans
+  ghc-options:       -Wall -fno-warn-unused-imports
 
 source-repository head
   type: git

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -160,6 +160,7 @@ Benchmark bench-tls
                    , QuickCheck >= 2
                    , tasty-quickcheck
                    , tls
+  ghc-options:       -Wall -fno-warn-unused-imports -fno-warn-orphans
 
 source-repository head
   type: git


### PR DESCRIPTION
This adds tests related to information stored in SessionData.
It should give more compliance with RFCs: items are implemented when possible, or flagged with a FIXME when SessionData content is not available.

To put things in perspective I also added a session-resumption scenario in benchmarks.