### PR TITLE
using ciphersuite_strong for tests.

### DIFF
--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -31,8 +31,14 @@ debug :: Bool
 debug = False
 
 knownCiphers :: [Cipher]
-knownCiphers = filter nonECDSA ciphersuite_strong
+knownCiphers = filter nonECDSA (ciphersuite_all ++ ciphersuite_weak)
   where
+    ciphersuite_weak = [
+        cipher_DHE_DSS_RC4_SHA1
+      , cipher_RC4_128_MD5
+      , cipher_null_MD5
+      , cipher_null_SHA1
+      ]
     -- arbitraryCredentialsOfEachType cannot generate ECDSA
     nonECDSA c = not ("ECDSA" `isInfixOf` cipherName c)
 

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -8,19 +8,13 @@ module Connection
     , setPairParamsSessionResuming
     , establishDataPipe
     , initiateDataPipe
-    , blockCipher
-    , blockCipherDHE_RSA
-    , blockCipherDHE_DSS
-    , blockCipherECDHE_RSA
-    , blockCipherECDHE_RSA_SHA384
-    , streamCipher
     ) where
 
 import Test.Tasty.QuickCheck
 import Certificate
 import PubKey
 import PipeChan
-import Network.TLS
+import Network.TLS as TLS
 import Network.TLS.Extra
 import Data.X509
 import Data.Default.Class
@@ -29,43 +23,18 @@ import Control.Applicative
 import Control.Concurrent.Chan
 import Control.Concurrent
 import qualified Control.Exception as E
-import Data.List (isPrefixOf, intersect)
+import Data.List (isInfixOf)
 
 import qualified Data.ByteString as B
 
 debug :: Bool
 debug = False
 
-blockCipher :: Cipher
-blockCipher = cipher_AES128_SHA1
-
-blockCipherDHE_RSA :: Cipher
-blockCipherDHE_RSA = cipher_DHE_RSA_AES128_SHA1
-
-blockCipherDHE_DSS :: Cipher
-blockCipherDHE_DSS = cipher_DHE_DSS_AES128_SHA1
-
-blockCipherECDHE_RSA :: Cipher
-blockCipherECDHE_RSA = cipher_ECDHE_RSA_AES128CBC_SHA
-
--- TLS 1.2 only
-blockCipherECDHE_RSA_SHA384 :: Cipher
-blockCipherECDHE_RSA_SHA384 = cipher_ECDHE_RSA_AES256GCM_SHA384
-
-streamCipher :: Cipher
-streamCipher = cipher_RC4_128_SHA1
-
 knownCiphers :: [Cipher]
-knownCiphers = [ blockCipher
-               , blockCipherDHE_RSA
-               , blockCipherDHE_DSS
-               , blockCipherECDHE_RSA
-               , blockCipherECDHE_RSA_SHA384
-               , streamCipher
-               ]
-
-isNonECCipher :: Cipher -> Bool
-isNonECCipher cipher = not ("EC" `isPrefixOf` cipherName cipher)
+knownCiphers = filter nonECDSA ciphersuite_strong
+  where
+    -- arbitraryCredentialsOfEachType cannot generate ECDSA
+    nonECDSA c = not ("ECDSA" `isInfixOf` cipherName c)
 
 knownVersions :: [Version]
 knownVersions = [SSL3,TLS10,TLS11,TLS12]
@@ -90,7 +59,7 @@ arbitraryCipherPair connectVersion = do
                                             maybe True (<= connectVersion) (cipherMinVer x) | x <- cs])
     return (clientCiphers, serverCiphers)
   where
-        arbitraryCiphers  = resize (length knownCiphers + 1) $ listOf1 (elements knownCiphers)
+        arbitraryCiphers  = listOf1 $ elements knownCiphers
 
 arbitraryPairParams :: Gen (ClientParams, ServerParams)
 arbitraryPairParams = do
@@ -103,17 +72,33 @@ arbitraryPairParams = do
     serAllowedVersions <- (:[]) `fmap` elements allowedVersions
     arbitraryPairParamsWithVersionsAndCiphers (allowedVersions, serAllowedVersions) (clientCiphers, serverCiphers)
 
-arbitraryGroupPair :: ([Cipher], [Cipher]) -> Gen ([Group], [Group])
-arbitraryGroupPair (clientCiphers, serverCiphers) = do
-    groupServer <- sublistOf availableGroups
-    groupClient <- sublistOf availableGroups
-    common <- elements availableGroups
-    if hasNonEC then return (groupClient, groupServer)
-                else return (groupClient ++ [common], groupServer ++ [common])
+arbitraryGroupPair :: Gen ([Group], [Group])
+arbitraryGroupPair = do
+    serverGroups <- arbitraryGroups
+    clientGroups <- oneof [arbitraryGroups] `suchThat`
+                         (\gs -> or [x `elem` serverGroups | x <- gs])
+    return (clientGroups, serverGroups)
   where
-    commonCiphers = serverCiphers `intersect` clientCiphers
-    hasNonEC = any isNonECCipher commonCiphers
     availableGroups = [P256,P384,P521,X25519,X448]
+    arbitraryGroups = listOf1 $ elements availableGroups
+
+arbitraryHashSignaturePair :: Gen ([HashAndSignatureAlgorithm], [HashAndSignatureAlgorithm])
+arbitraryHashSignaturePair = do
+    serverHashSignatures <- shuffle availableHashSignatures
+    clientHashSignatures <- shuffle availableHashSignatures
+    return (clientHashSignatures, serverHashSignatures)
+  where
+    availableHashSignatures =
+        [ (TLS.HashTLS13,  SignatureRSApssSHA256)
+        , (TLS.HashSHA512, SignatureRSA)
+        , (TLS.HashSHA512, SignatureECDSA)
+        , (TLS.HashSHA384, SignatureRSA)
+        , (TLS.HashSHA384, SignatureECDSA)
+        , (TLS.HashSHA256, SignatureRSA)
+        , (TLS.HashSHA256, SignatureECDSA)
+        , (TLS.HashSHA1,   SignatureRSA)
+        , (TLS.HashSHA1,   SignatureDSS)
+        ]
 
 arbitraryPairParamsWithVersionsAndCiphers :: ([Version], [Version])
                                           -> ([Cipher], [Cipher])
@@ -123,12 +108,14 @@ arbitraryPairParamsWithVersionsAndCiphers (clientVersions, serverVersions) (clie
     dhparams           <- elements [dhParams,ffdhe2048,ffdhe3072]
 
     creds              <- arbitraryCredentialsOfEachType
-    (groupClient, groupServer) <- arbitraryGroupPair (clientCiphers, serverCiphers)
+    (clientGroups, serverGroups) <- arbitraryGroupPair
+    (clientHashSignatures, serverHashSignatures) <- arbitraryHashSignaturePair
     let serverState = def
             { serverSupported = def { supportedCiphers  = serverCiphers
                                     , supportedVersions = serverVersions
                                     , supportedSecureRenegotiation = secNeg
-                                    , supportedGroups   = groupServer
+                                    , supportedGroups   = serverGroups
+                                    , supportedHashSignatures = serverHashSignatures
                                     }
             , serverDHEParams = Just dhparams
             , serverShared = def { sharedCredentials = Credentials creds }
@@ -137,7 +124,8 @@ arbitraryPairParamsWithVersionsAndCiphers (clientVersions, serverVersions) (clie
             { clientSupported = def { supportedCiphers  = clientCiphers
                                     , supportedVersions = clientVersions
                                     , supportedSecureRenegotiation = secNeg
-                                    , supportedGroups   = groupClient
+                                    , supportedGroups   = clientGroups
+                                    , supportedHashSignatures = clientHashSignatures
                                     }
             , clientShared = def { sharedValidationCache = ValidationCache
                                         { cacheAdd = \_ _ _ -> return ()

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -99,8 +99,8 @@ prop_handshake_initiate_hashsignatures = do
     (clientParam,serverParam) <- pick $ arbitraryPairParamsWithVersionsAndCiphers
                                             (clientVersions, serverVersions)
                                             (ciphers, ciphers)
-    clientHashSigs <- pick someHashSignatures
-    serverHashSigs <- pick someHashSignatures
+    clientHashSigs <- pick arbitraryHashSignatures
+    serverHashSigs <- pick arbitraryHashSignatures
     let clientParam' = clientParam { clientSupported = (clientSupported clientParam)
                                        { supportedHashSignatures = clientHashSigs }
                                    }
@@ -111,14 +111,6 @@ prop_handshake_initiate_hashsignatures = do
     if shouldFail
         then runTLSInitFailure (clientParam',serverParam')
         else runTLSPipeSimple  (clientParam',serverParam')
-  where someHashSignatures = sublistOf [ (HashTLS13, SignatureRSApssSHA256)
-                                       , (HashSHA512, SignatureRSA)
-                                       , (HashSHA384, SignatureRSA)
-                                       , (HashSHA256, SignatureRSA)
-                                       , (HashSHA1,   SignatureRSA)
-                                       , (HashSHA1,   SignatureDSS)
-                                       ]
-
 
 prop_handshake_client_auth_initiate :: PropertyM IO ()
 prop_handshake_client_auth_initiate = do

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -87,8 +87,8 @@ prop_handshake_initiate = do
     params  <- pick arbitraryPairParams
     runTLSPipeSimple params
 
-prop_handshake_initiate_hashsignatures :: PropertyM IO ()
-prop_handshake_initiate_hashsignatures = do
+prop_handshake_hashsignatures :: PropertyM IO ()
+prop_handshake_hashsignatures = do
     let clientVersions = [TLS12]
         serverVersions = [TLS12]
         ciphers = [ cipher_ECDHE_RSA_AES256GCM_SHA384
@@ -112,8 +112,8 @@ prop_handshake_initiate_hashsignatures = do
         then runTLSInitFailure (clientParam',serverParam')
         else runTLSPipeSimple  (clientParam',serverParam')
 
-prop_handshake_initiate_groups :: PropertyM IO ()
-prop_handshake_initiate_groups = do
+prop_handshake_groups :: PropertyM IO ()
+prop_handshake_groups = do
     let clientVersions = [TLS12]
         serverVersions = [TLS12]
         ciphers = [ cipher_ECDHE_RSA_AES256GCM_SHA384
@@ -135,8 +135,8 @@ prop_handshake_initiate_groups = do
         then runTLSInitFailure (clientParam',serverParam')
         else runTLSPipeSimple  (clientParam',serverParam')
 
-prop_handshake_client_auth_initiate :: PropertyM IO ()
-prop_handshake_client_auth_initiate = do
+prop_handshake_client_auth :: PropertyM IO ()
+prop_handshake_client_auth = do
     (clientParam,serverParam) <- pick arbitraryPairParams
     cred <- pick arbitraryClientCredential
     let clientParam' = clientParam { clientHooks = (clientHooks clientParam)
@@ -151,8 +151,8 @@ prop_handshake_client_auth_initiate = do
             | chain == fst cred = return CertificateUsageAccept
             | otherwise         = return (CertificateUsageReject CertificateRejectUnknownCA)
 
-prop_handshake_alpn_initiate :: PropertyM IO ()
-prop_handshake_alpn_initiate = do
+prop_handshake_alpn :: PropertyM IO ()
+prop_handshake_alpn = do
     (clientParam,serverParam) <- pick arbitraryPairParams
     let clientParam' = clientParam { clientHooks = (clientHooks clientParam)
                                        { onSuggestALPN = return $ Just ["h2", "http/1.1"] }
@@ -243,12 +243,12 @@ main = defaultMain $ testGroup "tls"
 
         -- high level tests between a client and server with fake ciphers.
         tests_handshake = testGroup "Handshakes"
-            [ testProperty "setup" (monadicIO prop_pipe_work)
-            , testProperty "initiate" (monadicIO prop_handshake_initiate)
-            , testProperty "initiate hash and signatures" (monadicIO prop_handshake_initiate_hashsignatures)
-            , testProperty "groups" (monadicIO prop_handshake_initiate_groups)
-            , testProperty "clientAuthInitiate" (monadicIO prop_handshake_client_auth_initiate)
-            , testProperty "alpnInitiate" (monadicIO prop_handshake_alpn_initiate)
-            , testProperty "renegotiation" (monadicIO prop_handshake_renegotiation)
-            , testProperty "resumption" (monadicIO prop_handshake_session_resumption)
+            [ testProperty "Setup" (monadicIO prop_pipe_work)
+            , testProperty "Initiation" (monadicIO prop_handshake_initiate)
+            , testProperty "Hash and signatures" (monadicIO prop_handshake_hashsignatures)
+            , testProperty "Groups" (monadicIO prop_handshake_groups)
+            , testProperty "Client authentication" (monadicIO prop_handshake_client_auth)
+            , testProperty "ALPN" (monadicIO prop_handshake_alpn)
+            , testProperty "Renegotiation" (monadicIO prop_handshake_renegotiation)
+            , testProperty "Resumption" (monadicIO prop_handshake_session_resumption)
             ]


### PR DESCRIPTION
Since ECDHE would be an only common cipher, client/server groups
should always have a common group.

prop_handshake_initiate_tls12 is removed since no common hash-signature
does not always cause a handshake error. Rather, supportedHashSignatures
is specified with available hash-signatures shuffled.