### PR TITLE
Session compression and SNI

### DIFF
--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -88,7 +88,9 @@ handshakeClient cparams ctx = do
                     usingState_ ctx $ setClientALPNSuggest protos
                     return $ Just $ toExtensionRaw $ ApplicationLayerProtocolNegotiation protos
         sniExtension = if clientUseServerNameIndication cparams
-                         then return $ Just $ toExtensionRaw $ ServerName [ServerNameHostName $ fst $ clientServerIdentification cparams]
+                         then do let sni = fst $ clientServerIdentification cparams
+                                 usingState_ ctx $ setClientSNI sni
+                                 return $ Just $ toExtensionRaw $ ServerName [ServerNameHostName sni]
                          else return Nothing
 
         curveExtension = return $ Just $ toExtensionRaw $ NegotiatedGroups ((supportedGroups $ ctxSupported ctx) `intersect` availableGroups)

--- a/core/Network/TLS/Types.hs
+++ b/core/Network/TLS/Types.hs
@@ -19,6 +19,8 @@ module Network.TLS.Types
 import Data.ByteString (ByteString)
 import Data.Word
 
+type HostName = String
+
 -- | Versions known to TLS
 --
 -- SSL2 is just defined, but this version is and will not be supported.
@@ -29,9 +31,11 @@ type SessionID = ByteString
 
 -- | Session data to resume
 data SessionData = SessionData
-    { sessionVersion :: Version
-    , sessionCipher  :: CipherID
-    , sessionSecret  :: ByteString
+    { sessionVersion     :: Version
+    , sessionCipher      :: CipherID
+    , sessionCompression :: CompressionID
+    , sessionClientSNI   :: Maybe HostName
+    , sessionSecret      :: ByteString
     } deriving (Show,Eq)
 
 -- | Cipher identification


### PR DESCRIPTION
Adds new information into SessionData to fully implements resumption checks. SNI is especially important because it may have an influence on credentials and therefore ciphers.

In the new code I left SNI test case-sensitive. It makes the code simpler and should not cause any issue. I don't think a client will write the hostname differently the second time and still expect resumption.

After this PR it becomes possible to reorganize the ServerHello code so that the resumption case skips most of it. But this likely conflicts with any other server work.