### PR TITLE
Use strict version of Control.Monad.State

### DIFF
--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -80,7 +80,7 @@ import Network.TLS.RNG
 import Data.Maybe (isJust)
 
 import Control.Concurrent.MVar
-import Control.Monad.State
+import Control.Monad.State.Strict
 import Data.IORef
 import Data.Monoid (mappend)
 

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -69,7 +69,7 @@ import Network.TLS.Measurement
 import qualified Data.ByteString as B
 
 import Control.Concurrent.MVar
-import Control.Monad.State
+import Control.Monad.State.Strict
 import Control.Exception (throwIO, Exception())
 import Data.IORef
 import Data.Tuple

--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -43,7 +43,7 @@ import Data.ByteString.Char8 ()
 import qualified Data.ByteString.Lazy as L
 import qualified Control.Exception as E
 
-import Control.Monad.State
+import Control.Monad.State.Strict
 
 
 -- | notify the context that this side wants to close connection.

--- a/core/Network/TLS/Handshake.hs
+++ b/core/Network/TLS/Handshake.hs
@@ -22,7 +22,7 @@ import Network.TLS.Handshake.Common
 import Network.TLS.Handshake.Client
 import Network.TLS.Handshake.Server
 
-import Control.Monad.State
+import Control.Monad.State.Strict
 import Control.Exception (fromException)
 
 -- | Handshake for a new TLS connection

--- a/core/Network/TLS/Handshake/Certificate.hs
+++ b/core/Network/TLS/Handshake/Certificate.hs
@@ -13,7 +13,7 @@ module Network.TLS.Handshake.Certificate
 import Network.TLS.Context.Internal
 import Network.TLS.Struct
 import Network.TLS.X509
-import Control.Monad.State
+import Control.Monad.State.Strict
 import Control.Exception (SomeException)
 
 -- on certificate reject, throw an exception with the proper protocol alert error.

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -33,7 +33,7 @@ import Data.List (find, intersect)
 import qualified Data.ByteString as B
 import Data.ByteString.Char8 ()
 
-import Control.Monad.State
+import Control.Monad.State.Strict
 import Control.Exception (SomeException)
 
 import Network.TLS.Handshake.Common

--- a/core/Network/TLS/Handshake/Common.hs
+++ b/core/Network/TLS/Handshake/Common.hs
@@ -34,7 +34,7 @@ import Network.TLS.Util
 import Data.List (find)
 import Data.ByteString.Char8 ()
 
-import Control.Monad.State
+import Control.Monad.State.Strict
 import Control.Exception (throwIO)
 
 handshakeFailed :: TLSError -> IO ()

--- a/core/Network/TLS/Handshake/Process.hs
+++ b/core/Network/TLS/Handshake/Process.hs
@@ -14,7 +14,7 @@ module Network.TLS.Handshake.Process
     ) where
 
 import Control.Concurrent.MVar
-import Control.Monad.State (gets)
+import Control.Monad.State.Strict (gets)
 import Control.Monad
 import Control.Monad.IO.Class (liftIO)
 

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -42,7 +42,7 @@ import Data.List (sortBy)
 import Data.Ord (comparing)
 #endif
 
-import Control.Monad.State
+import Control.Monad.State.Strict
 
 import Network.TLS.Handshake.Signature
 import Network.TLS.Handshake.Common

--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -28,7 +28,7 @@ import Network.TLS.Handshake.State
 import Network.TLS.Handshake.Key
 import Network.TLS.Util
 
-import Control.Monad.State
+import Control.Monad.State.Strict
 
 signatureCompatible :: DigitalSignatureAlg -> HashAndSignatureAlgorithm -> Bool
 signatureCompatible RSA   (_, SignatureRSA)          = True

--- a/core/Network/TLS/Handshake/State.hs
+++ b/core/Network/TLS/Handshake/State.hs
@@ -58,7 +58,7 @@ import Network.TLS.Cipher
 import Network.TLS.Compression
 import Network.TLS.Types
 import Control.Applicative (Applicative, (<$>))
-import Control.Monad.State
+import Control.Monad.State.Strict
 import Data.X509 (CertificateChain)
 import Data.ByteArray (ByteArrayAccess)
 

--- a/core/Network/TLS/IO.hs
+++ b/core/Network/TLS/IO.hs
@@ -23,7 +23,7 @@ import qualified Data.ByteString as B
 import Data.ByteString.Char8 ()
 
 import Data.IORef
-import Control.Monad.State
+import Control.Monad.State.Strict
 import Control.Exception (throwIO)
 import System.IO.Error (mkIOError, eofErrorType)
 

--- a/core/Network/TLS/Receiving.hs
+++ b/core/Network/TLS/Receiving.hs
@@ -14,7 +14,7 @@ module Network.TLS.Receiving
     ( processPacket
     ) where
 
-import Control.Monad.State
+import Control.Monad.State.Strict
 import Control.Concurrent.MVar
 
 import Network.TLS.Context.Internal

--- a/core/Network/TLS/Record/Disengage.hs
+++ b/core/Network/TLS/Record/Disengage.hs
@@ -14,7 +14,7 @@ module Network.TLS.Record.Disengage
         ( disengageRecord
         ) where
 
-import Control.Monad.State
+import Control.Monad.State.Strict
 
 import Crypto.Cipher.Types (AuthTag(..))
 import Network.TLS.Struct

--- a/core/Network/TLS/Record/Engage.hs
+++ b/core/Network/TLS/Record/Engage.hs
@@ -14,7 +14,7 @@ module Network.TLS.Record.Engage
         ) where
 
 import Control.Applicative
-import Control.Monad.State
+import Control.Monad.State.Strict
 import Crypto.Cipher.Types (AuthTag(..))
 
 import Network.TLS.Cap

--- a/core/Network/TLS/Record/State.hs
+++ b/core/Network/TLS/Record/State.hs
@@ -26,7 +26,7 @@ module Network.TLS.Record.State
 
 import Data.Word
 import Control.Applicative
-import Control.Monad.State
+import Control.Monad.State.Strict
 import Network.TLS.Compression
 import Network.TLS.Cipher
 import Network.TLS.ErrT

--- a/core/Network/TLS/Sending.hs
+++ b/core/Network/TLS/Sending.hs
@@ -11,7 +11,7 @@
 module Network.TLS.Sending (writePacket) where
 
 import Control.Applicative
-import Control.Monad.State
+import Control.Monad.State.Strict
 import Control.Concurrent.MVar
 import Data.IORef
 

--- a/core/Network/TLS/State.hs
+++ b/core/Network/TLS/State.hs
@@ -58,7 +58,7 @@ import Network.TLS.Types (Role(..))
 import Network.TLS.Wire (GetContinuation)
 import Network.TLS.Extension
 import qualified Data.ByteString as B
-import Control.Monad.State
+import Control.Monad.State.Strict
 import Network.TLS.ErrT
 import Crypto.Random
 import Data.X509 (CertificateChain)


### PR DESCRIPTION
Don't see any good reason why the state shouldn't be strict.

`Control.Monad.State.Strict` is in `base` version 4.7 which is the lower bound of support according to the cabal file.