### PR TITLE
Follow-up to #205 and #216

### DIFF
--- a/core/Benchmarks/Benchmarks.hs
+++ b/core/Benchmarks/Benchmarks.hs
@@ -15,6 +15,25 @@ import Data.IORef
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as L
 
+blockCipher :: Cipher
+blockCipher = Cipher
+    { cipherID   = 0xff12
+    , cipherName = "rsa-id-const"
+    , cipherBulk = Bulk
+        { bulkName      = "id"
+        , bulkKeySize   = 16
+        , bulkIVSize    = 16
+        , bulkExplicitIV= 0
+        , bulkAuthTagLen= 0
+        , bulkBlockSize = 16
+        , bulkF         = BulkBlockF $ \_ _ _ -> (\m -> (m, B.empty))
+        }
+    , cipherHash        = MD5
+    , cipherPRFHash     = Nothing
+    , cipherKeyExchange = CipherKeyExchange_RSA
+    , cipherMinVer      = Nothing
+    }
+
 recvDataNonNull :: Context -> IO B.ByteString
 recvDataNonNull ctx = recvData ctx >>= \l -> if B.null l then recvDataNonNull ctx else return l
 

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -48,7 +48,7 @@ Library
                    , data-default-class
                    -- crypto related
                    , memory
-                   , cryptonite >= 0.21
+                   , cryptonite >= 0.23
                    -- certificate related
                    , asn1-types >= 0.2.0
                    , asn1-encoding

--- a/debug/tls-debug.cabal
+++ b/debug/tls-debug.cabal
@@ -24,7 +24,7 @@ Executable           tls-stunnel
                    , bytestring
                    , x509-system >= 1.0
                    , data-default-class
-                   , cryptonite >= 0.21
+                   , cryptonite >= 0.23
                    , tls >= 1.3.0 && < 1.4
   if os(windows)
     Buildable:       False

--- a/test-scripts/tls-test.cabal
+++ b/test-scripts/tls-test.cabal
@@ -21,7 +21,7 @@ Executable           TestClient
                    , bytestring
                    , x509-system >= 1.0
                    , data-default-class
-                   , cryptonite >= 0.21
+                   , cryptonite >= 0.23
                    , directory
                    , random
                    , async


### PR DESCRIPTION
- use at least cryptonite-0.23 to prevent any segmentation fault with P256
- fix benchmark compilation

I thought about compiling benchmarks in the Travis script but stepped back because of criterion many dependencies.