### PR TITLE
Change Bytes to ByteString

### DIFF
--- a/core/Network/TLS.hs
+++ b/core/Network/TLS.hs
@@ -136,7 +136,6 @@ import Network.TLS.Struct ( TLSError(..), TLSException(..)
                           , Header(..), ProtocolType(..), CertificateType(..)
                           , AlertDescription(..)
                           , ClientRandom(..), ServerRandom(..)
-                          , Bytes
                           , Handshake)
 import Network.TLS.Crypto (KxError(..), DHParams, Group(..))
 import Network.TLS.Cipher
@@ -152,3 +151,7 @@ import Network.TLS.X509
 import Network.TLS.Types
 import Data.X509 (PubKey(..), PrivKey(..))
 import Data.X509.Validation
+import Data.ByteString as B
+
+{-# DEPRECATED Bytes "Use Data.ByteString.Bytestring instead of Bytes." #-}
+type Bytes = B.ByteString

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -66,6 +66,7 @@ import Network.TLS.Hooks
 import Network.TLS.Record.State
 import Network.TLS.Parameters
 import Network.TLS.Measurement
+import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 
 import Control.Concurrent.MVar
@@ -80,7 +81,7 @@ data Information = Information
     { infoVersion      :: Version
     , infoCipher       :: Cipher
     , infoCompression  :: Compression
-    , infoMasterSecret :: Maybe Bytes
+    , infoMasterSecret :: Maybe ByteString
     , infoClientRandom :: Maybe ClientRandom
     , infoServerRandom :: Maybe ServerRandom
     } deriving (Show,Eq)
@@ -141,10 +142,10 @@ contextGetInformation ctx = do
         (Just v, Just c) -> return $ Just $ Information v c comp ms cr sr
         _                -> return Nothing
 
-contextSend :: Context -> Bytes -> IO ()
+contextSend :: Context -> ByteString -> IO ()
 contextSend c b = updateMeasure c (addBytesSent $ B.length b) >> (backendSend $ ctxConnection c) b
 
-contextRecv :: Context -> Int -> IO Bytes
+contextRecv :: Context -> Int -> IO ByteString
 contextRecv c sz = updateMeasure c (addBytesReceived sz) >> (backendRecv $ ctxConnection c) sz
 
 ctxEOF :: Context -> IO Bool
@@ -218,7 +219,7 @@ runRxState ctx f = do
             Left err         -> return (st, Left err)
             Right (a, newSt) -> return (newSt, Right a)
 
-getStateRNG :: Context -> Int -> IO Bytes
+getStateRNG :: Context -> Int -> IO ByteString
 getStateRNG ctx n = usingState_ ctx $ genRandom n
 
 withReadLock :: Context -> IO a -> IO a

--- a/core/Network/TLS/Credentials.hs
+++ b/core/Network/TLS/Credentials.hs
@@ -22,7 +22,6 @@ import Data.Monoid
 import Data.Maybe (catMaybes)
 import Data.List (find)
 import Network.TLS.Crypto.Types
-import Network.TLS.Struct
 import Network.TLS.X509
 import Data.X509.File
 import Data.X509.Memory

--- a/core/Network/TLS/Credentials.hs
+++ b/core/Network/TLS/Credentials.hs
@@ -17,6 +17,7 @@ module Network.TLS.Credentials
     , credentialsListSigningAlgorithms
     ) where
 
+import Data.ByteString (ByteString)
 import Data.Monoid
 import Data.Maybe (catMaybes)
 import Data.List (find)
@@ -45,8 +46,8 @@ credentialLoadX509 certFile = credentialLoadX509Chain certFile []
 
 -- | similar to 'credentialLoadX509' but take the certificate
 -- and private key from memory instead of from the filesystem.
-credentialLoadX509FromMemory :: Bytes
-                  -> Bytes
+credentialLoadX509FromMemory :: ByteString
+                  -> ByteString
                   -> Either String Credential
 credentialLoadX509FromMemory certData =
   credentialLoadX509ChainFromMemory certData []
@@ -68,9 +69,9 @@ credentialLoadX509Chain certFile chainFiles privateFile = do
 
 -- | similar to 'credentialLoadX509FromMemory' but also allow
 -- specifying chain certificates.
-credentialLoadX509ChainFromMemory :: Bytes
-                  -> [Bytes]
-                  -> Bytes
+credentialLoadX509ChainFromMemory :: ByteString
+                  -> [ByteString]
+                  -> ByteString
                   -> Either String Credential
 credentialLoadX509ChainFromMemory certData chainData privateData = do
     let x509   = readSignedObjectFromMemory certData

--- a/core/Network/TLS/Crypto/IES.hs
+++ b/core/Network/TLS/Crypto/IES.hs
@@ -154,7 +154,7 @@ calcShared params pub pri = SharedSecret share
   where
     SharedKey share = getShared params pri pub
 
-encodeGroupPublic :: GroupPublic -> Bytes
+encodeGroupPublic :: GroupPublic -> ByteString
 encodeGroupPublic (GroupPub_P256 p) = encodePoint p256 p
 encodeGroupPublic (GroupPub_P384 p) = encodePoint p384 p
 encodeGroupPublic (GroupPub_P521 p) = encodePoint p521 p
@@ -166,10 +166,10 @@ encodeGroupPublic (GroupPub_FFDHE4096 p) = enc ffdhe4096 p
 encodeGroupPublic (GroupPub_FFDHE6144 p) = enc ffdhe6144 p
 encodeGroupPublic (GroupPub_FFDHE8192 p) = enc ffdhe8192 p
 
-enc :: Params -> PublicNumber -> Bytes
+enc :: Params -> PublicNumber -> ByteString
 enc params (PublicNumber p) = i2ospOf_ ((params_bits params + 7) `div` 8) p
 
-decodeGroupPublic :: Group -> Bytes -> Either CryptoError GroupPublic
+decodeGroupPublic :: Group -> ByteString -> Either CryptoError GroupPublic
 decodeGroupPublic P256   bs = eitherCryptoError $ GroupPub_P256 <$> decodePoint p256 bs
 decodeGroupPublic P384   bs = eitherCryptoError $ GroupPub_P384 <$> decodePoint p384 bs
 decodeGroupPublic P521   bs = eitherCryptoError $ GroupPub_P521 <$> decodePoint p521 bs

--- a/core/Network/TLS/Handshake/Common.hs
+++ b/core/Network/TLS/Handshake/Common.hs
@@ -33,7 +33,7 @@ import Network.TLS.Types
 import Network.TLS.Cipher
 import Network.TLS.Util
 import Data.List (find)
-import Data.ByteString.Char8 ()
+import Data.ByteString.Char8 (ByteString)
 
 import Control.Monad.State.Strict
 import Control.Exception (throwIO)
@@ -137,6 +137,6 @@ getSessionData ctx = do
                         , sessionSecret      = ms
                         }
 
-extensionLookup :: ExtensionID -> [ExtensionRaw] -> Maybe Bytes
+extensionLookup :: ExtensionID -> [ExtensionRaw] -> Maybe ByteString
 extensionLookup toFind = fmap (\(ExtensionRaw _ content) -> content)
                        . find (\(ExtensionRaw eid _) -> eid == toFind)

--- a/core/Network/TLS/IO.hs
+++ b/core/Network/TLS/IO.hs
@@ -20,7 +20,7 @@ import Network.TLS.Hooks
 import Network.TLS.Sending
 import Network.TLS.Receiving
 import qualified Data.ByteString as B
-import Data.ByteString.Char8 ()
+import Data.ByteString.Char8 (ByteString)
 
 import Data.IORef
 import Control.Monad.State.Strict
@@ -34,7 +34,7 @@ checkValid ctx = do
     eofed <- ctxEOF ctx
     when eofed $ throwIO $ mkIOError eofErrorType "data" Nothing Nothing
 
-readExact :: Context -> Int -> IO (Either TLSError Bytes)
+readExact :: Context -> Int -> IO (Either TLSError ByteString)
 readExact ctx sz = do
     hdrbs <- contextRecv ctx sz
     if B.length hdrbs == sz
@@ -83,7 +83,7 @@ recvRecord compatSSLv2 ctx
                         either (return . Left) (flip getRecord content) $ decodeDeprecatedHeader readlen content
 #endif
               maximumSizeExceeded = Error_Protocol ("record exceeding maximum size", True, RecordOverflow)
-              getRecord :: Header -> Bytes -> IO (Either TLSError (Record Plaintext))
+              getRecord :: Header -> ByteString -> IO (Either TLSError (Record Plaintext))
               getRecord header content = do
                     withLog ctx $ \logging -> loggingIORecv logging header content
                     runRxState ctx $ disengageRecord $ rawToRecord header (fragmentCiphertext content)

--- a/core/Network/TLS/Imports.hs
+++ b/core/Network/TLS/Imports.hs
@@ -14,7 +14,6 @@ module Network.TLS.Imports
     , (Control.Applicative.<$>)
     , Data.Monoid.Monoid(..)
     -- project definition
-    , Bytes
     , showBytesHex
     ) where
 
@@ -22,11 +21,8 @@ import qualified Control.Applicative
 import qualified Data.Monoid
 
 import           Data.ByteString (ByteString)
-import qualified Data.ByteString as B
 import           Data.ByteArray.Encoding as B
 import qualified Prelude
-
-type Bytes = B.ByteString
 
 showBytesHex :: ByteString -> Prelude.String
 showBytesHex bs = Prelude.show (B.convertToBase B.Base16 bs :: ByteString)

--- a/core/Network/TLS/Imports.hs
+++ b/core/Network/TLS/Imports.hs
@@ -9,7 +9,8 @@
 module Network.TLS.Imports
     (
     -- generic exports
-      Control.Applicative.Applicative(..)
+      ByteString
+    , Control.Applicative.Applicative(..)
     , (Control.Applicative.<$>)
     , Data.Monoid.Monoid(..)
     -- project definition
@@ -20,11 +21,12 @@ module Network.TLS.Imports
 import qualified Control.Applicative
 import qualified Data.Monoid
 
+import           Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import           Data.ByteArray.Encoding as B
 import qualified Prelude
 
 type Bytes = B.ByteString
 
-showBytesHex :: Bytes -> Prelude.String
-showBytesHex bs = Prelude.show (B.convertToBase B.Base16 bs :: Bytes)
+showBytesHex :: ByteString -> Prelude.String
+showBytesHex bs = Prelude.show (B.convertToBase B.Base16 bs :: ByteString)

--- a/core/Network/TLS/MAC.hs
+++ b/core/Network/TLS/MAC.hs
@@ -17,8 +17,8 @@ module Network.TLS.MAC
 
 import Network.TLS.Crypto
 import Network.TLS.Types
-import qualified Data.ByteString as B
 import Data.ByteString (ByteString)
+import qualified Data.ByteString as B
 import Data.Bits (xor)
 
 type HMAC = ByteString -> ByteString -> ByteString

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -37,6 +37,7 @@ import Network.TLS.Credentials
 import Network.TLS.X509
 import Network.TLS.RNG (Seed)
 import Data.Default.Class
+import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 #if __GLASGOW_HASKELL__ < 710
 import Data.Monoid (mempty)
@@ -79,7 +80,7 @@ data ClientParams = ClientParams
       -- The extra blob is useful to differentiate services running on the same host, but that
       -- might have different certificates given. It's only used as part of the X509 validation
       -- infrastructure.
-    , clientServerIdentification      :: (HostName, Bytes)
+    , clientServerIdentification      :: (HostName, ByteString)
       -- | Allow the use of the Server Name Indication TLS extension during handshake, which allow
       -- the client to specify which host name, it's trying to access. This is useful to distinguish
       -- CNAME aliasing (e.g. web virtual host).
@@ -94,7 +95,7 @@ data ClientParams = ClientParams
     , clientDebug                     :: DebugParams
     } deriving (Show)
 
-defaultParamsClient :: HostName -> Bytes -> ClientParams
+defaultParamsClient :: HostName -> ByteString -> ClientParams
 defaultParamsClient serverName serverId = ClientParams
     { clientWantSessionResume    = Nothing
     , clientUseMaxFragmentLength = Nothing

--- a/core/Network/TLS/Record/Disengage.hs
+++ b/core/Network/TLS/Record/Disengage.hs
@@ -69,7 +69,7 @@ getCipherData (Record pt ver _) cdata = do
 
     return $ cipherDataContent cdata
 
-decryptData :: Version -> Record Ciphertext -> Bytes -> RecordState -> RecordM Bytes
+decryptData :: Version -> Record Ciphertext -> ByteString -> RecordState -> RecordM ByteString
 decryptData ver record econtent tst = decryptOf (cstKey cst)
   where cipher     = fromJust "cipher" $ stCipher tst
         bulk       = cipherBulk cipher
@@ -82,7 +82,7 @@ decryptData ver record econtent tst = decryptOf (cstKey cst)
 
         sanityCheckError = throwError (Error_Packet "encrypted content too small for encryption parameters")
 
-        decryptOf :: BulkState -> RecordM Bytes
+        decryptOf :: BulkState -> RecordM ByteString
         decryptOf (BulkStateBlock decryptF) = do
             let minContent = (if explicitIV then bulkIVSize bulk else 0) + max (macSize + 1) blockSize
 

--- a/core/Network/TLS/Struct.hs
+++ b/core/Network/TLS/Struct.hs
@@ -11,8 +11,7 @@
 --
 {-# LANGUAGE CPP #-}
 module Network.TLS.Struct
-    ( Bytes
-    , Version(..)
+    ( Version(..)
     , ConnectionEnd(..)
     , CipherType(..)
     , CipherData(..)

--- a/core/Network/TLS/Struct.hs
+++ b/core/Network/TLS/Struct.hs
@@ -80,9 +80,9 @@ data ConnectionEnd = ConnectionServer | ConnectionClient
 data CipherType = CipherStream | CipherBlock | CipherAEAD
 
 data CipherData = CipherData
-    { cipherDataContent :: Bytes
-    , cipherDataMAC     :: Maybe Bytes
-    , cipherDataPadding :: Maybe Bytes
+    { cipherDataContent :: ByteString
+    , cipherDataMAC     :: Maybe ByteString
+    , cipherDataPadding :: Maybe ByteString
     } deriving (Show,Eq)
 
 data CertificateType =
@@ -123,7 +123,7 @@ data SignatureAlgorithm =
 
 type HashAndSignatureAlgorithm = (HashAlgorithm, SignatureAlgorithm)
 
-type Signature = Bytes
+type Signature = ByteString
 
 data DigitallySigned = DigitallySigned (Maybe HashAndSignatureAlgorithm) Signature
     deriving (Show,Eq)
@@ -178,26 +178,26 @@ data Packet =
 
 data Header = Header ProtocolType Version Word16 deriving (Show,Eq)
 
-newtype ServerRandom = ServerRandom { unServerRandom :: Bytes } deriving (Show, Eq)
-newtype ClientRandom = ClientRandom { unClientRandom :: Bytes } deriving (Show, Eq)
+newtype ServerRandom = ServerRandom { unServerRandom :: ByteString } deriving (Show, Eq)
+newtype ClientRandom = ClientRandom { unClientRandom :: ByteString } deriving (Show, Eq)
 newtype Session = Session (Maybe SessionID) deriving (Show, Eq)
 
-type FinishedData = Bytes
+type FinishedData = ByteString
 type ExtensionID  = Word16
 
-data ExtensionRaw = ExtensionRaw ExtensionID Bytes
+data ExtensionRaw = ExtensionRaw ExtensionID ByteString
     deriving (Eq)
 
 instance Show ExtensionRaw where
     show (ExtensionRaw eid bs) = "ExtensionRaw " ++ show eid ++ " " ++ showBytesHex bs ++ ""
 
-constrRandom32 :: (Bytes -> a) -> Bytes -> Maybe a
+constrRandom32 :: (ByteString -> a) -> ByteString -> Maybe a
 constrRandom32 constr l = if B.length l == 32 then Just (constr l) else Nothing
 
-serverRandom :: Bytes -> Maybe ServerRandom
+serverRandom :: ByteString -> Maybe ServerRandom
 serverRandom l = constrRandom32 ServerRandom l
 
-clientRandom :: Bytes -> Maybe ClientRandom
+clientRandom :: ByteString -> Maybe ClientRandom
 clientRandom l = constrRandom32 ClientRandom l
 
 data AlertLevel =
@@ -250,7 +250,7 @@ data HandshakeType =
     | HandshakeType_Finished
     deriving (Show,Eq)
 
-newtype BigNum = BigNum Bytes
+newtype BigNum = BigNum ByteString
     deriving (Show,Eq)
 
 bigNumToInteger :: BigNum -> Integer
@@ -297,14 +297,14 @@ data ServerKeyXchgAlgorithmData =
     | SKX_RSA (Maybe ServerRSAParams)
     | SKX_DH_DSS (Maybe ServerRSAParams)
     | SKX_DH_RSA (Maybe ServerRSAParams)
-    | SKX_Unparsed Bytes -- if we parse the server key xchg before knowing the actual cipher, we end up with this structure.
-    | SKX_Unknown Bytes
+    | SKX_Unparsed ByteString -- if we parse the server key xchg before knowing the actual cipher, we end up with this structure.
+    | SKX_Unknown ByteString
     deriving (Show,Eq)
 
 data ClientKeyXchgAlgorithmData =
-      CKX_RSA Bytes
+      CKX_RSA ByteString
     | CKX_DH DHPublic
-    | CKX_ECDH Bytes
+    | CKX_ECDH ByteString
     deriving (Show,Eq)
 
 type DeprecatedRecord = ByteString

--- a/core/Network/TLS/Util.hs
+++ b/core/Network/TLS/Util.hs
@@ -13,23 +13,24 @@ module Network.TLS.Util
         ) where
 
 import Data.List (foldl')
-import Network.TLS.Imports (Bytes)
+-- import Network.TLS.Imports (ByteString)
+import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 
 import Control.Exception (SomeException)
 import Control.Concurrent.Async
 
-sub :: Bytes -> Int -> Int -> Maybe Bytes
+sub :: ByteString -> Int -> Int -> Maybe ByteString
 sub b offset len
     | B.length b < offset + len = Nothing
     | otherwise                 = Just $ B.take len $ snd $ B.splitAt offset b
 
-takelast :: Int -> Bytes -> Maybe Bytes
+takelast :: Int -> ByteString -> Maybe ByteString
 takelast i b
     | B.length b >= i = sub b (B.length b - i) i
     | otherwise       = Nothing
 
-partition3 :: Bytes -> (Int,Int,Int) -> Maybe (Bytes, Bytes, Bytes)
+partition3 :: ByteString -> (Int,Int,Int) -> Maybe (ByteString, ByteString, ByteString)
 partition3 bytes (d1,d2,d3)
     | any (< 0) l             = Nothing
     | sum l /= B.length bytes = Nothing
@@ -39,7 +40,7 @@ partition3 bytes (d1,d2,d3)
               (p2, r2) = B.splitAt d2 r1
               (p3, _)  = B.splitAt d3 r2
 
-partition6 :: Bytes -> (Int,Int,Int,Int,Int,Int) -> Maybe (Bytes, Bytes, Bytes, Bytes, Bytes, Bytes)
+partition6 :: ByteString -> (Int,Int,Int,Int,Int,Int) -> Maybe (ByteString, ByteString, ByteString, ByteString, ByteString, ByteString)
 partition6 bytes (d1,d2,d3,d4,d5,d6) = if B.length bytes < s then Nothing else Just (p1,p2,p3,p4,p5,p6)
   where s        = sum [d1,d2,d3,d4,d5,d6]
         (p1, r1) = B.splitAt d1 bytes
@@ -67,15 +68,13 @@ False &&! False = False
 -- | verify that 2 bytestrings are equals.
 -- it's a non lazy version, that will compare every bytes.
 -- arguments with different length will bail out early
-bytesEq :: Bytes -> Bytes -> Bool
+bytesEq :: ByteString -> ByteString -> Bool
 bytesEq b1 b2
     | B.length b1 /= B.length b2 = False
     | otherwise                  = and' $ B.zipWith (==) b1 b2
 
 fmapEither :: (a -> b) -> Either l a -> Either l b
-fmapEither f e = case e of
-    Left l  -> Left l
-    Right r -> Right (f r)
+fmapEither f = fmap f
 
 catchException :: IO a -> (SomeException -> IO a) -> IO a
 catchException action handler = withAsync action waitCatch >>= either handler return


### PR DESCRIPTION
`Bytes` was a type alias for `ByteString`. The `Bytes` type is kept
because it is exposed in the API.

Have built http-client-tls and warp-tls from Hackage with this
version of tls and zero changes were needed in those packages.

Related to #229 . I have no problem whatsoever moving from `Bytes`/`ByteString` to `ByteArray` but while `Bytes` and `ByteString` are the same, `Bytes` should be replaced with `ByteString` if it can be done without breaking the API (and it can).
