### PR TITLE
Tests/Ciphers.hs: Disable deprecation warning

### DIFF
--- a/core/Tests/Ciphers.hs
+++ b/core/Tests/Ciphers.hs
@@ -1,3 +1,5 @@
+-- Disable this warning so we can still test deprecated functionality.
+{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 module Ciphers
     ( propertyBulkFunctional
     ) where

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -1,3 +1,5 @@
+-- Disable this warning so we can still test deprecated functionality.
+{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 module Connection
     ( newPairContext
     , arbitraryCiphers

--- a/debug/src/Common.hs
+++ b/debug/src/Common.hs
@@ -1,3 +1,5 @@
+-- Disable this warning so we can still test deprecated functionality.
+{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 module Common
     ( printCiphers
     , printDHParams

--- a/debug/src/SimpleServer.hs
+++ b/debug/src/SimpleServer.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+-- Disable this warning so we can still test deprecated functionality.
+{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 import Crypto.Random
 import Network.BSD
 import Network.Socket (socket, Family(..), SocketType(..), close, SockAddr(..), bind, listen, accept, iNADDR_ANY)

--- a/debug/src/Stunnel.hs
+++ b/debug/src/Stunnel.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+-- Disable this warning so we can still test deprecated functionality.
+{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 import Network.BSD
 import Network.Socket hiding (Debug)
 import System.IO


### PR DESCRIPTION
Need to disable this warning so we can still test deprecated
functionality but also not get a warning.