### PR TITLE
Make session resumption successful

### DIFF
--- a/debug/src/CheckCiphers.hs
+++ b/debug/src/CheckCiphers.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ScopedTypeVariables, DeriveDataTypeable #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 
 import Network.TLS.Internal
 import Network.TLS.Cipher
@@ -106,7 +106,7 @@ openConnection s p ciphers = do
         bye ctx
         hClose handle
         return $ Just ccid
-        ) (\(_ :: SomeException) -> return Nothing)
+        ) (\(SomeException _) -> return Nothing)
 
 connectRange :: String -> String -> Int -> [Word16] -> IO (Int, [Word16])
 connectRange d p v r = do

--- a/debug/src/CheckCiphers.hs
+++ b/debug/src/CheckCiphers.hs
@@ -121,7 +121,7 @@ connectRange d p v r = do
                             then splitAt (length newr `div` 2) newr
                             else (newr, [])
             (lc, ls) <- if length lr > 0
-                then connectRange d p v lr 
+                then connectRange d p v lr
                 else return (0,[])
             (rc, rs) <- if length rr > 0
                 then connectRange d p v rr

--- a/debug/src/RetrieveCertificate.hs
+++ b/debug/src/RetrieveCertificate.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ScopedTypeVariables, DeriveDataTypeable, ViewPatterns #-}
+{-# LANGUAGE DeriveDataTypeable, ViewPatterns #-}
 {-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 
 import Network.TLS

--- a/debug/src/RetrieveCertificate.hs
+++ b/debug/src/RetrieveCertificate.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables, DeriveDataTypeable, ViewPatterns #-}
+{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 
 import Network.TLS
 import Network.TLS.Extra.Cipher

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -226,7 +226,7 @@ runOn (sStorage, certStore) flags port hostname
                 when (Verbose `elem` flags) $ printHandshakeInfo ctx
                 sendData ctx $ query
                 loopRecv out ctx
-                bye ctx `catch` \(SomeException e) -> putStrLn $ "byte failed: " ++ show e
+                bye ctx `catch` \(SomeException e) -> putStrLn $ "bye failed: " ++ show e
                 return ()
             when (isJust getOutput) $ hClose out
         loopRecv out ctx = do

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 import Crypto.Random
 import Network.BSD
@@ -39,7 +38,7 @@ runTLS debug ioDebug params hostname portNumber f = do
     sock <- socket AF_INET Stream defaultProtocol
     let sockaddr = SockAddrInet portNumber (head $ hostAddresses he)
     E.catch (connect sock sockaddr)
-          (\(e :: SomeException) -> close sock >> error ("cannot open socket " ++ show sockaddr ++ " " ++ show e))
+          (\(SomeException e) -> close sock >> error ("cannot open socket " ++ show sockaddr ++ " " ++ show e))
     ctx <- contextNew sock params
     contextHookSetLogging ctx getLogging
     () <- f ctx

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -229,7 +229,7 @@ runOn (sStorage, certStore) flags port hostname
                 when (Verbose `elem` flags) $ printHandshakeInfo ctx
                 sendData ctx $ query
                 loopRecv out ctx
-                bye ctx `catch` \(SomeException _) -> return ()
+                bye ctx `catch` \(SomeException e) -> putStrLn $ "byte failed: " ++ show e
                 return ()
             when (isJust getOutput) $ hClose out
         loopRecv out ctx = do

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -12,6 +12,7 @@ import System.Timeout
 import qualified Data.ByteString.Lazy.Char8 as LC
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString as B
+import Control.Concurrent
 import Control.Exception
 import qualified Control.Exception as E
 import Control.Monad
@@ -185,6 +186,7 @@ runOn (sStorage, certStore) flags port hostname
         certCredRequest <- getCredRequest
         doTLS certCredRequest noSession
         when (Session `elem` flags) $ do
+            threadDelay 50000
             session <- readIORef sStorage
             doTLS certCredRequest (Just session)
   where

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 import Crypto.Random
 import Network.BSD
 import Network.Socket (socket, Family(..), SocketType(..), close, SockAddr(..), connect)

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -11,7 +11,6 @@ import System.Timeout
 import qualified Data.ByteString.Lazy.Char8 as LC
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString as B
-import Control.Concurrent
 import Control.Exception
 import qualified Control.Exception as E
 import Control.Monad
@@ -185,7 +184,6 @@ runOn (sStorage, certStore) flags port hostname
         certCredRequest <- getCredRequest
         doTLS certCredRequest noSession
         when (Session `elem` flags) $ do
-            threadDelay 50000
             session <- readIORef sStorage
             doTLS certCredRequest (Just session)
   where

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -226,7 +226,7 @@ runOn (sStorage, certStore) flags port hostname
                 when (Verbose `elem` flags) $ printHandshakeInfo ctx
                 sendData ctx $ query
                 loopRecv out ctx
-                bye ctx
+                bye ctx `catch` \(SomeException _) -> return ()
                 return ()
             when (isJust getOutput) $ hClose out
         loopRecv out ctx = do

--- a/debug/src/SimpleServer.hs
+++ b/debug/src/SimpleServer.hs
@@ -5,6 +5,7 @@
 import Crypto.Random
 import Network.BSD
 import Network.Socket (socket, Family(..), SocketType(..), close, SockAddr(..), bind, listen, accept, iNADDR_ANY)
+import qualified Network.Socket as S
 import Network.TLS
 import Network.TLS.Extra.Cipher
 import System.Console.GetOpt
@@ -35,6 +36,7 @@ bogusCipher cid = cipher_AES128_SHA1 { cipherID = cid }
 
 runTLS debug ioDebug params portNumber f = do
     sock <- socket AF_INET Stream defaultProtocol
+    S.setSocketOption sock S.ReuseAddr 1
     let sockaddr = SockAddrInet portNumber iNADDR_ANY
 
     bind sock sockaddr

--- a/debug/src/SimpleServer.hs
+++ b/debug/src/SimpleServer.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 -- Disable this warning so we can still test deprecated functionality.
 {-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 import Crypto.Random

--- a/debug/src/Stunnel.hs
+++ b/debug/src/Stunnel.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 -- Disable this warning so we can still test deprecated functionality.
 {-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 import Network.BSD
@@ -17,7 +16,7 @@ import qualified Data.ByteString.Lazy as L
 
 import Control.Concurrent (forkIO)
 import Control.Concurrent.MVar
-import Control.Exception (finally, throw, SomeException)
+import Control.Exception (finally, throw, SomeException(..))
 import qualified Control.Exception as E
 import Control.Monad (when, forever)
 
@@ -137,7 +136,7 @@ getAddressDescription a = error ("unrecognized source type (expecting tcp/unix/f
 connectAddressDescription (AddrSocket family sockaddr) = do
     sock <- socket family Stream defaultProtocol
     E.catch (connect sock sockaddr)
-          (\(e :: SomeException) -> close sock >> error ("cannot open socket " ++ show sockaddr ++ " " ++ show e))
+          (\(SomeException e) -> close sock >> error ("cannot open socket " ++ show sockaddr ++ " " ++ show e))
     return $ StunnelSocket sock
 
 connectAddressDescription (AddrFD h1 h2) = do
@@ -146,7 +145,7 @@ connectAddressDescription (AddrFD h1 h2) = do
 listenAddressDescription (AddrSocket family sockaddr) = do
     sock <- socket family Stream defaultProtocol
     E.catch (bind sock sockaddr >> listen sock 10 >> setSocketOption sock ReuseAddr 1)
-          (\(e :: SomeException) -> close sock >> error ("cannot open socket " ++ show sockaddr ++ " " ++ show e))
+          (\(SomeException e) -> close sock >> error ("cannot open socket " ++ show sockaddr ++ " " ++ show e))
     return $ StunnelSocket sock
 
 listenAddressDescription (AddrFD _ _) = do


### PR DESCRIPTION
Session resumption between `tls-simpleclient` and `tls-simpleserver` sometimes fails for some reasons. This PR include:

- Setting reuseaddr to server sockets
- Ignoring an error of `bye` in the client side
- Waiting a bit to ensure that the server can prepare the next socket
- Preventing warnings