### PR TITLE
Improve selection of server certificate and use "signature_algorithms" extension

### DIFF
--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -57,7 +57,6 @@ module Network.TLS.Context.Internal
 import Network.TLS.Backend
 import Network.TLS.Extension
 import Network.TLS.Cipher
-import Network.TLS.Credentials (Credentials)
 import Network.TLS.Struct
 import Network.TLS.Compression (Compression)
 import Network.TLS.State
@@ -91,8 +90,6 @@ data Context = Context
     { ctxConnection       :: Backend   -- ^ return the backend object associated with this context
     , ctxSupported        :: Supported
     , ctxShared           :: Shared
-    , ctxCiphers          :: Credentials -> [Cipher]  -- ^ list of allowed ciphers according to parameters
-                                                      -- and additional credentials
     , ctxState            :: MVar TLSState
     , ctxMeasurement      :: IORef Measurement
     , ctxEOF_             :: IORef Bool    -- ^ has the handle EOFed or not.

--- a/core/Network/TLS/Crypto.hs
+++ b/core/Network/TLS/Crypto.hs
@@ -25,6 +25,7 @@ module Network.TLS.Crypto
     , PublicKey
     , PrivateKey
     , SignatureParams(..)
+    , findDigitalSignatureAlg
     , kxEncrypt
     , kxDecrypt
     , kxSign
@@ -66,6 +67,14 @@ data KxError =
       RSAError RSA.Error
     | KxUnsupported
     deriving (Show)
+
+findDigitalSignatureAlg :: (PubKey, PrivKey) -> Maybe DigitalSignatureAlg
+findDigitalSignatureAlg keyPair =
+    case keyPair of
+        (PubKeyRSA     _, PrivKeyRSA      _)  -> Just RSA
+        (PubKeyDSA     _, PrivKeyDSA      _)  -> Just DSS
+        --(PubKeyECDSA   _, PrivKeyECDSA    _)  -> Just ECDSA
+        _                                     -> Nothing
 
 -- functions to use the hidden class.
 hashInit :: Hash -> HashContext

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -207,8 +207,7 @@ handshakeServerWith sparams ctx clientHello@(ClientHello clientVersion _ clientS
     doHandshake sparams cred ctx chosenVersion usedCipher usedCompression clientSession resumeSessionData exts
 
   where
-        commonCipherIDs extra = ciphers `intersect` map cipherID (ctxCiphers ctx extra)
-        commonCiphers   extra = filter (flip elem (commonCipherIDs extra) . cipherID) (ctxCiphers ctx extra)
+        commonCiphers extra   = filter ((`elem` ciphers) . cipherID) (ctxCiphers ctx extra)
         commonCompressions    = compressionIntersectID (supportedCompressions $ ctxSupported ctx) compressions
         usedCompression       = head commonCompressions
 

--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -101,9 +101,9 @@ signatureParams RSA hashSigAlg =
         Just (HashSHA384, SignatureRSA) -> RSAParams SHA384   RSApkcs1
         Just (HashSHA256, SignatureRSA) -> RSAParams SHA256   RSApkcs1
         Just (HashSHA1  , SignatureRSA) -> RSAParams SHA1     RSApkcs1
-        Just (HashTLS13 , SignatureRSApssSHA512) -> RSAParams SHA512 RSApss
-        Just (HashTLS13 , SignatureRSApssSHA384) -> RSAParams SHA384 RSApss
-        Just (HashTLS13 , SignatureRSApssSHA256) -> RSAParams SHA256 RSApss
+        Just (HashIntrinsic , SignatureRSApssSHA512) -> RSAParams SHA512 RSApss
+        Just (HashIntrinsic , SignatureRSApssSHA384) -> RSAParams SHA384 RSApss
+        Just (HashIntrinsic , SignatureRSApssSHA256) -> RSAParams SHA256 RSApss
         Nothing                         -> RSAParams SHA1_MD5 RSApkcs1
         Just (hsh       , SignatureRSA) -> error ("unimplemented RSA signature hash type: " ++ show hsh)
         Just (_         , sigAlg)       -> error ("signature algorithm is incompatible with RSA: " ++ show sigAlg)

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -310,6 +310,9 @@ data ServerHooks = ServerHooks
       -- This is most useful for transparent proxies where
       -- credentials must be generated on the fly according to
       -- the host the client is trying to connect to.
+      --
+      -- Returned credentials may be ignored if a client does not support
+      -- the signature algorithms used in the certificate chain.
     , onServerNameIndication  :: Maybe HostName -> IO Credentials
 
       -- | at each new handshake, we call this hook to see if we allow handshake to happens.

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -158,10 +158,10 @@ data Supported = Supported
       -- ordered by decreasing priority.
       --
       -- This list is sent to the peer as part of the signature_algorithms
-      -- extension.  It is also used to restrict the choice of hash and
-      -- signature algorithm, but only when the TLS version is 1.2 or above.
-      -- In order to disable SHA-1 one must then also disable earlier protocol
-      -- versions in 'supportedVersions'.
+      -- extension.  It is also used to restrict the choice of server
+      -- credential, signature and hash algorithm, but only when the TLS
+      -- version is 1.2 or above.  In order to disable SHA-1 one must then
+      -- also disable earlier protocol versions in 'supportedVersions'.
     , supportedHashSignatures :: [HashAndSignatureAlgorithm]
       -- | Secure renegotiation defined in RFC5746.
       --   If 'True', clients send the renegotiation_info extension.

--- a/core/Network/TLS/Struct.hs
+++ b/core/Network/TLS/Struct.hs
@@ -103,7 +103,7 @@ data HashAlgorithm =
     | HashSHA256
     | HashSHA384
     | HashSHA512
-    | HashTLS13
+    | HashIntrinsic
     | HashOther Word8
     deriving (Show,Eq)
 
@@ -519,7 +519,7 @@ instance TypeValuable HashAlgorithm where
     valOfType HashSHA256    = 4
     valOfType HashSHA384    = 5
     valOfType HashSHA512    = 6
-    valOfType HashTLS13     = 8
+    valOfType HashIntrinsic = 8
     valOfType (HashOther i) = i
 
     valToType 0 = Just HashNone
@@ -529,7 +529,7 @@ instance TypeValuable HashAlgorithm where
     valToType 4 = Just HashSHA256
     valToType 5 = Just HashSHA384
     valToType 6 = Just HashSHA512
-    valToType 8 = Just HashTLS13
+    valToType 8 = Just HashIntrinsic
     valToType i = Just (HashOther i)
 
 instance TypeValuable SignatureAlgorithm where

--- a/core/Tests/Certificate.hs
+++ b/core/Tests/Certificate.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Certificate
     ( arbitraryX509
@@ -9,6 +10,7 @@ module Certificate
 
 import Control.Applicative
 import Test.Tasty.QuickCheck
+import Data.ASN1.OID
 import Data.X509
 import Data.Hourglass
 import qualified Data.ByteString as B
@@ -48,7 +50,6 @@ maxSerial = 16777216
 arbitraryCertificate :: PubKey -> Gen Certificate
 arbitraryCertificate pubKey = do
     serial    <- choose (0,maxSerial)
-    issuerdn  <- arbitraryDN
     subjectdn <- arbitraryDN
     validity  <- (,) <$> arbitrary <*> arbitrary
     let sigalg = SignatureALG HashSHA1 (pubkeyToAlg pubKey)
@@ -64,6 +65,7 @@ arbitraryCertificate pubKey = do
                 [ testExtensionEncode True $ ExtKeyUsage [KeyUsage_digitalSignature,KeyUsage_keyEncipherment,KeyUsage_keyCertSign]
                 ]
             }
+  where issuerdn = DistinguishedName [(getObjectID DnCommonName, "Root CA")]
 
 simpleCertificate :: PubKey -> Certificate
 simpleCertificate pubKey =

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -60,7 +60,7 @@ arbitraryVersions = sublistOf knownVersions
 knownHashSignatures :: [HashAndSignatureAlgorithm]
 knownHashSignatures = filter nonECDSA availableHashSignatures
   where
-    availableHashSignatures = [(TLS.HashTLS13,  SignatureRSApssSHA256)
+    availableHashSignatures = [(TLS.HashIntrinsic, SignatureRSApssSHA256)
                               ,(TLS.HashSHA512, SignatureRSA)
                               ,(TLS.HashSHA512, SignatureECDSA)
                               ,(TLS.HashSHA384, SignatureRSA)

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -9,6 +9,7 @@ module Connection
     , arbitraryPairParams
     , arbitraryPairParamsWithVersionsAndCiphers
     , arbitraryClientCredential
+    , leafPublicKey
     , oneSessionManager
     , setPairParamsSessionManager
     , setPairParamsSessionResuming
@@ -92,6 +93,10 @@ arbitraryCredentialsOfEachType = do
          ) [ (PubKeyRSA pubKey, PrivKeyRSA privKey)
            , (PubKeyDSA dsaPub, PrivKeyDSA dsaPriv)
            ]
+
+leafPublicKey :: CertificateChain -> Maybe PubKey
+leafPublicKey (CertificateChain [])       = Nothing
+leafPublicKey (CertificateChain (leaf:_)) = Just (certPubKey $ signedObject $ getSigned leaf)
 
 arbitraryCipherPair :: Version -> Gen ([Cipher], [Cipher])
 arbitraryCipherPair connectVersion = do

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -121,19 +121,7 @@ prop_handshake_hashsignatures = do
         serverParam' = serverParam { serverSupported = (serverSupported serverParam)
                                        { supportedHashSignatures = serverHashSigs }
                                    }
-        -- Not only client and server must have hash/signature algorithms
-        -- in common but SHA-1 must also be supported by the client for a
-        -- common signature algorithm.  This is because server certificates
-        -- are SHA-1 only.
-        commonHashSigs = clientHashSigs `intersect` serverHashSigs
-        certSigAlgs    = [a | (HashSHA1, a) <- clientHashSigs]
-
-        hasCertSigAlg (_, SignatureRSApssSHA512) = SignatureRSA `elem` certSigAlgs
-        hasCertSigAlg (_, SignatureRSApssSHA384) = SignatureRSA `elem` certSigAlgs
-        hasCertSigAlg (_, SignatureRSApssSHA256) = SignatureRSA `elem` certSigAlgs
-        hasCertSigAlg (_, s)                     = s `elem` certSigAlgs
-
-        shouldFail     = all (not . hasCertSigAlg) commonHashSigs
+        shouldFail = null (clientHashSigs `intersect` serverHashSigs)
     if shouldFail
         then runTLSInitFailure (clientParam',serverParam')
         else runTLSPipeSimple  (clientParam',serverParam')

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -138,6 +138,7 @@ Test-Suite test-tls
                    , QuickCheck
                    , cryptonite
                    , bytestring
+                   , asn1-types
                    , x509
                    , x509-validation
                    , hourglass
@@ -156,6 +157,7 @@ Benchmark bench-tls
                    , criterion >= 1.0
                    , mtl
                    , bytestring
+                   , asn1-types
                    , hourglass
                    , QuickCheck >= 2
                    , tasty-quickcheck


### PR DESCRIPTION
This adds behavior described in #195, with a rework of how cipher/credential code is organized.

I was reluctant to create impacts for something non essential like #195 but see now that supporting EdDSA in the future will require filtering credentials (instead of ciphers like we did before). 

On a diagram we need to go from this:
```
Pub/Priv Key Type <-- Key Exchange Type <-- HashAndSignatureAlg
(credential)      <-- (cipher)          <-- (supported exts)
```
to this:
```
Key Exchange Type <--> Pub/Priv Key Type <-- HashAndSignatureAlg
(cipher)          <--> (credential)      <-- (supported exts)
```

This is because the relation between key exchange and certificate will become n..n:

| Key Exchange | Public/Private Key |
|--------------|--------------------|
| DHE_RSA      | RSA                |
| DHE_DSS      | DSA                |
| ECDHE_RSA    | RSA                |
| ECDHE_ECDSA  | ECDSA              |
| ECDHE_ECDSA  | Ed25519            |
| ECDHE_ECDSA  | Ed448              |

Changing the design, it is easier to add something like #195.  With the fallback mechanism described in TLS 1.3 this is not supposed to restrict handshake possibilities (i.e. the PR does not change test cases).  So this looks safe for TLS 1.2 too.

I limited verification to the leaf certificate because a server has no reliable way to  know what is the client view of trust anchors.
