### PR TITLE
Wrap renegotiation failures with HandshakeFailed

### DIFF
--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -93,9 +93,9 @@ recvData ctx = liftIO $ do
             terminate err AlertLevel_Fatal InternalError (show err)
 
         process (Handshake [ch@(ClientHello {})]) =
-            withRWLock ctx ((ctxDoHandshakeWith ctx) ctx ch) >> recvData ctx
+            handshakeWith ctx ch >> recvData ctx
         process (Handshake [hr@HelloRequest]) =
-            withRWLock ctx ((ctxDoHandshakeWith ctx) ctx hr) >> recvData ctx
+            handshakeWith ctx hr >> recvData ctx
 
         process (Alert [(AlertLevel_Warning, CloseNotify)]) = tryBye >> setEOF ctx >> return B.empty
         process (Alert [(AlertLevel_Fatal, desc)]) = do


### PR DESCRIPTION
In snoyberg/http-client#273 was reported a new case where tls external API throws TLSError directly instead of wrapping the value in TLSException (failure seen when connecting to https://paste.debian.net with tls-1.3.9).

This PR applies the same error handling when renegotiation handshake is triggered locally or remotely.
