### PR TITLE
Allow tls-1.4.0 in tls-debug

### DIFF
--- a/debug/tls-debug.cabal
+++ b/debug/tls-debug.cabal
@@ -25,7 +25,7 @@ Executable           tls-stunnel
                    , x509-system >= 1.0
                    , data-default-class
                    , cryptonite >= 0.24
-                   , tls >= 1.3.0 && < 1.4
+                   , tls >= 1.3.0 && < 1.5
   if os(windows)
     Buildable:       False
   else
@@ -56,7 +56,7 @@ Executable           tls-retrievecertificate
                    , x509
                    , x509-system >= 1.4
                    , x509-validation >= 1.5.0
-                   , tls >= 1.3 && < 1.4
+                   , tls >= 1.3 && < 1.5
   Buildable:         True
   ghc-options:       -Wall -fno-warn-missing-signatures
 
@@ -71,7 +71,7 @@ Executable           tls-simpleclient
                    , data-default-class
                    , cryptonite >= 0.14
                    , x509-system >= 1.0
-                   , tls >= 1.3.6 && < 1.4
+                   , tls >= 1.3.6 && < 1.5
   Buildable:         True
   ghc-options:       -Wall -fno-warn-missing-signatures
 
@@ -87,7 +87,7 @@ Executable           tls-simpleserver
                    , cryptonite
                    , x509-store
                    , x509-system >= 1.0
-                   , tls >= 1.3 && < 1.4
+                   , tls >= 1.3 && < 1.5
   Buildable:         True
   ghc-options:       -Wall -fno-warn-missing-signatures
 


### PR DESCRIPTION
Releasing tls-debug would be good too as we've added features and updated the cipher lists.