### PR TITLE
Cleaning up import warnings

### DIFF
--- a/core/Network/TLS/Backend.hs
+++ b/core/Network/TLS/Backend.hs
@@ -21,12 +21,11 @@ module Network.TLS.Backend
     , Backend(..)
     ) where
 
-import Data.ByteString (ByteString)
+import Network.TLS.Imports
 import qualified Data.ByteString as B
 import System.IO (Handle, hSetBuffering, BufferMode(..), hFlush, hClose)
 
 #ifdef INCLUDE_NETWORK
-import Control.Monad
 import qualified Network.Socket as Network (Socket, close)
 import qualified Network.Socket.ByteString as Network
 #endif

--- a/core/Network/TLS/Compression.hs
+++ b/core/Network/TLS/Compression.hs
@@ -23,9 +23,8 @@ module Network.TLS.Compression
     , compressionIntersectID
     ) where
 
-import Data.Word
 import Network.TLS.Types (CompressionID)
-import Data.ByteString (ByteString)
+import Network.TLS.Imports
 import Control.Arrow (first)
 
 -- | supported compression algorithms need to be part of this class

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -65,7 +65,7 @@ import Network.TLS.Hooks
 import Network.TLS.Record.State
 import Network.TLS.Parameters
 import Network.TLS.Measurement
-import Data.ByteString (ByteString)
+import Network.TLS.Imports
 import qualified Data.ByteString as B
 
 import Control.Concurrent.MVar

--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -39,7 +39,6 @@ import Network.TLS.Handshake
 import Network.TLS.Util (catchException)
 import qualified Network.TLS.State as S
 import qualified Data.ByteString as B
-import Data.ByteString.Char8 ()
 import qualified Data.ByteString.Lazy as L
 import qualified Control.Exception as E
 

--- a/core/Network/TLS/Credentials.hs
+++ b/core/Network/TLS/Credentials.hs
@@ -20,11 +20,11 @@ module Network.TLS.Credentials
     ) where
 
 import Data.ByteString (ByteString)
-import Data.Monoid
 import Data.Maybe (catMaybes)
 import Data.List (find)
 import Network.TLS.Crypto
 import Network.TLS.X509
+import Network.TLS.Imports
 import Data.X509.File
 import Data.X509.Memory
 import Data.X509

--- a/core/Network/TLS/Credentials.hs
+++ b/core/Network/TLS/Credentials.hs
@@ -19,7 +19,6 @@ module Network.TLS.Credentials
     , credentialMatchesHashSignatures
     ) where
 
-import Data.ByteString (ByteString)
 import Data.Maybe (catMaybes)
 import Data.List (find)
 import Network.TLS.Crypto

--- a/core/Network/TLS/Credentials.hs
+++ b/core/Network/TLS/Credentials.hs
@@ -20,7 +20,6 @@ module Network.TLS.Credentials
     ) where
 
 import Data.Maybe (catMaybes)
-import Data.List (find)
 import Network.TLS.Crypto
 import Network.TLS.X509
 import Network.TLS.Imports

--- a/core/Network/TLS/Crypto.hs
+++ b/core/Network/TLS/Crypto.hs
@@ -56,7 +56,6 @@ import Network.TLS.Imports
 import Data.ASN1.Types
 import Data.ASN1.Encoding
 import Data.ASN1.BinaryEncoding (DER(..), BER(..))
-import Data.List (find)
 
 {-# DEPRECATED PublicKey "use PubKey" #-}
 type PublicKey = PubKey

--- a/core/Network/TLS/Crypto.hs
+++ b/core/Network/TLS/Crypto.hs
@@ -37,7 +37,6 @@ module Network.TLS.Crypto
 import qualified Crypto.Hash as H
 import qualified Data.ByteString as B
 import qualified Data.ByteArray as B (convert)
-import Data.ByteString (ByteString)
 import Crypto.Random
 import qualified Crypto.PubKey.DSA as DSA
 import qualified Crypto.PubKey.ECC.ECDSA as ECDSA
@@ -52,6 +51,7 @@ import Data.X509 (PrivKey(..), PubKey(..), PubKeyEC(..), SerializedPoint(..))
 import Network.TLS.Crypto.DH
 import Network.TLS.Crypto.IES
 import Network.TLS.Crypto.Types
+import Network.TLS.Imports
 
 import Data.ASN1.Types
 import Data.ASN1.Encoding

--- a/core/Network/TLS/Crypto/IES.hs
+++ b/core/Network/TLS/Crypto/IES.hs
@@ -23,7 +23,6 @@ import Crypto.ECC
 import Crypto.Error
 import Crypto.PubKey.DH
 import Crypto.PubKey.ECIES
-import Data.ByteString (ByteString)
 import Data.Proxy
 import Network.TLS.Crypto.Types
 import Network.TLS.Extra.FFDHE

--- a/core/Network/TLS/Crypto/IES.hs
+++ b/core/Network/TLS/Crypto/IES.hs
@@ -23,6 +23,7 @@ import Crypto.ECC
 import Crypto.Error
 import Crypto.PubKey.DH
 import Crypto.PubKey.ECIES
+import Data.ByteString (ByteString)
 import Data.Proxy
 import Network.TLS.Crypto.Types
 import Network.TLS.Extra.FFDHE

--- a/core/Network/TLS/Extension.hs
+++ b/core/Network/TLS/Extension.hs
@@ -37,9 +37,7 @@ module Network.TLS.Extension
     , SignatureAlgorithms(..)
     ) where
 
-import Data.Word
 import Data.Maybe (fromMaybe, catMaybes)
-import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC
 

--- a/core/Network/TLS/Extension.hs
+++ b/core/Network/TLS/Extension.hs
@@ -37,8 +37,6 @@ module Network.TLS.Extension
     , SignatureAlgorithms(..)
     ) where
 
-import Control.Monad
-
 import Data.Word
 import Data.Maybe (fromMaybe, catMaybes)
 import Data.ByteString (ByteString)

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -30,7 +30,6 @@ import Network.TLS.Types
 import Network.TLS.X509
 import Data.Maybe
 import qualified Data.ByteString as B
-import Data.ByteString.Char8 ()
 
 import Control.Monad.State.Strict
 import Control.Exception (SomeException)

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -29,7 +29,6 @@ import Network.TLS.Util (bytesEq, catchException)
 import Network.TLS.Types
 import Network.TLS.X509
 import Data.Maybe
-import Data.List (find, intersect)
 import qualified Data.ByteString as B
 import Data.ByteString.Char8 ()
 

--- a/core/Network/TLS/Handshake/Common.hs
+++ b/core/Network/TLS/Handshake/Common.hs
@@ -33,7 +33,6 @@ import Network.TLS.Types
 import Network.TLS.Cipher
 import Network.TLS.Util
 import Network.TLS.Imports
-import Data.List (find)
 
 import Control.Monad.State.Strict
 import Control.Exception (throwIO)

--- a/core/Network/TLS/Handshake/Common.hs
+++ b/core/Network/TLS/Handshake/Common.hs
@@ -32,8 +32,8 @@ import Network.TLS.Measurement
 import Network.TLS.Types
 import Network.TLS.Cipher
 import Network.TLS.Util
+import Network.TLS.Imports
 import Data.List (find)
-import Data.ByteString.Char8 (ByteString)
 
 import Control.Monad.State.Strict
 import Control.Exception (throwIO)

--- a/core/Network/TLS/Handshake/Key.hs
+++ b/core/Network/TLS/Handshake/Key.hs
@@ -17,7 +17,6 @@ module Network.TLS.Handshake.Key
     , generateECDHEShared
     ) where
 
-import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 
 import Network.TLS.Handshake.State
@@ -25,6 +24,7 @@ import Network.TLS.State (withRNG, getVersion)
 import Network.TLS.Crypto
 import Network.TLS.Types
 import Network.TLS.Context.Internal
+import Network.TLS.Imports
 
 {- if the RSA encryption fails we just return an empty bytestring, and let the protocol
  - fail by itself; however it would be probably better to just report it since it's an internal problem.

--- a/core/Network/TLS/Handshake/Process.hs
+++ b/core/Network/TLS/Handshake/Process.hs
@@ -15,7 +15,6 @@ module Network.TLS.Handshake.Process
 
 import Control.Concurrent.MVar
 import Control.Monad.State.Strict (gets)
-import Control.Monad
 import Control.Monad.IO.Class (liftIO)
 
 import Network.TLS.Types (Role(..), invertRole)

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -31,14 +31,11 @@ import Network.TLS.Handshake.Process
 import Network.TLS.Handshake.Key
 import Network.TLS.Measurement
 import Data.Maybe (isJust, listToMaybe, mapMaybe)
-import Data.List (findIndex, intersect)
 import qualified Data.ByteString as B
 import Data.ByteString.Char8 ()
 import Data.Ord (Down(..))
 #if MIN_VERSION_base(4,8,0)
-import Data.List (sortOn)
 #else
-import Data.List (sortBy)
 import Data.Ord (comparing)
 #endif
 

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -31,7 +31,6 @@ import Network.TLS.Handshake.Key
 import Network.TLS.Measurement
 import Data.Maybe (isJust, listToMaybe, mapMaybe)
 import qualified Data.ByteString as B
-import Data.ByteString.Char8 ()
 
 import Control.Monad.State.Strict
 

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 -- |
 -- Module      : Network.TLS.Handshake.Server
 -- License     : BSD-style
@@ -33,11 +32,6 @@ import Network.TLS.Measurement
 import Data.Maybe (isJust, listToMaybe, mapMaybe)
 import qualified Data.ByteString as B
 import Data.ByteString.Char8 ()
-import Data.Ord (Down(..))
-#if MIN_VERSION_base(4,8,0)
-#else
-import Data.Ord (comparing)
-#endif
 
 import Control.Monad.State.Strict
 
@@ -630,9 +624,3 @@ getCiphers sparams creds sigCreds = filter authorizedCKE (supportedCiphers $ ser
             canSignRSA    = RSA `elem` signingAlgs
             canEncryptRSA = isJust $ credentialsFindForDecrypting creds
             signingAlgs   = credentialsListSigningAlgorithms sigCreds
-
-#if !MIN_VERSION_base(4,8,0)
-sortOn :: Ord b => (a -> b) -> [a] -> [a]
-sortOn f =
-  map snd . sortBy (comparing fst) . map (\x -> let y = f x in y `seq` (y, x))
-#endif

--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -28,6 +28,7 @@ import Network.TLS.Handshake.State
 import Network.TLS.Handshake.Key
 import Network.TLS.Util
 
+import Data.ByteString (ByteString)
 import Control.Monad.State.Strict
 
 signatureCompatible :: DigitalSignatureAlg -> HashAndSignatureAlgorithm -> Bool

--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -28,7 +28,6 @@ import Network.TLS.Handshake.State
 import Network.TLS.Handshake.Key
 import Network.TLS.Util
 
-import Data.ByteString (ByteString)
 import Control.Monad.State.Strict
 
 signatureCompatible :: DigitalSignatureAlg -> HashAndSignatureAlgorithm -> Bool

--- a/core/Network/TLS/Handshake/State.hs
+++ b/core/Network/TLS/Handshake/State.hs
@@ -57,7 +57,7 @@ import Network.TLS.Crypto
 import Network.TLS.Cipher
 import Network.TLS.Compression
 import Network.TLS.Types
-import Control.Applicative (Applicative, (<$>))
+import Network.TLS.Imports
 import Control.Monad.State.Strict
 import Data.X509 (CertificateChain)
 import Data.ByteArray (ByteArrayAccess)

--- a/core/Network/TLS/Handshake/State.hs
+++ b/core/Network/TLS/Handshake/State.hs
@@ -61,7 +61,6 @@ import Network.TLS.Imports
 import Control.Monad.State.Strict
 import Data.X509 (CertificateChain)
 import Data.ByteArray (ByteArrayAccess)
-import Data.ByteString (ByteString)
 
 data HandshakeKeyState = HandshakeKeyState
     { hksRemotePublicKey :: !(Maybe PubKey)

--- a/core/Network/TLS/IO.hs
+++ b/core/Network/TLS/IO.hs
@@ -19,8 +19,8 @@ import Network.TLS.Packet
 import Network.TLS.Hooks
 import Network.TLS.Sending
 import Network.TLS.Receiving
+import Network.TLS.Imports
 import qualified Data.ByteString as B
-import Data.ByteString.Char8 (ByteString)
 
 import Data.IORef
 import Control.Monad.State.Strict

--- a/core/Network/TLS/Imports.hs
+++ b/core/Network/TLS/Imports.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -fno-warn-dodgy-exports #-} -- Char8
+
 -- |
 -- Module      : Network.TLS.Imports
 -- License     : BSD-style
@@ -11,6 +13,7 @@ module Network.TLS.Imports
     (
     -- generic exports
       ByteString
+    , module Data.ByteString.Char8 -- instance
     , module Control.Applicative
     , module Control.Monad
     , module Data.Bits
@@ -26,6 +29,7 @@ module Network.TLS.Imports
     ) where
 
 import Data.ByteString (ByteString)
+import Data.ByteString.Char8 ()
 
 import Control.Applicative
 import Control.Monad

--- a/core/Network/TLS/Imports.hs
+++ b/core/Network/TLS/Imports.hs
@@ -9,7 +9,8 @@
 module Network.TLS.Imports
     (
     -- generic exports
-      Control.Applicative.Applicative(..)
+      ByteString
+    , Control.Applicative.Applicative(..)
     , (Control.Applicative.<$>)
     , Data.Monoid.Monoid(..)
     -- project definition

--- a/core/Network/TLS/Imports.hs
+++ b/core/Network/TLS/Imports.hs
@@ -15,14 +15,20 @@ module Network.TLS.Imports
     , Data.Monoid.Monoid(..)
     -- project definition
     , showBytesHex
+    , module Data.Bits
+    , module Data.Word
+    , module Control.Monad
     ) where
 
 import qualified Control.Applicative
 import qualified Data.Monoid
 
-import           Data.ByteString (ByteString)
+import           Data.Bits
 import           Data.ByteArray.Encoding as B
+import           Data.ByteString (ByteString)
+import           Data.Word
 import qualified Prelude
+import           Control.Monad
 
 showBytesHex :: ByteString -> Prelude.String
 showBytesHex bs = Prelude.show (B.convertToBase B.Base16 bs :: ByteString)

--- a/core/Network/TLS/Imports.hs
+++ b/core/Network/TLS/Imports.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 -- |
 -- Module      : Network.TLS.Imports
 -- License     : BSD-style
@@ -6,44 +7,45 @@
 -- Stability   : experimental
 -- Portability : unknown
 --
-{-# LANGUAGE NoImplicitPrelude #-}
 module Network.TLS.Imports
     (
     -- generic exports
       ByteString
-    , Control.Applicative.Applicative(..)
-    , (Control.Applicative.<$>)
-    , Data.Monoid.Monoid(..)
-    -- project definition
-    , showBytesHex
+    , module Control.Applicative
+    , module Control.Monad
     , module Data.Bits
     , module Data.List
+    , module Data.Monoid
     , module Data.Ord
     , module Data.Word
-    , module Control.Monad
 #if !MIN_VERSION_base(4,8,0)
     , sortOn
 #endif
+    -- project definition
+    , showBytesHex
     ) where
 
-import qualified Control.Applicative
-import qualified Data.Monoid
+import Data.ByteString (ByteString)
 
-import           Data.Bits
-import           Data.ByteArray.Encoding as B
-import           Data.ByteString (ByteString)
-import           Data.List
-import           Data.Ord
-import           Data.Word
-import qualified Prelude
-import           Control.Monad
+import Control.Applicative
+import Control.Monad
+import Data.Bits
+import Data.List
+import Data.Monoid
+import Data.Ord
+import Data.Word
 
-showBytesHex :: ByteString -> Prelude.String
-showBytesHex bs = Prelude.show (B.convertToBase B.Base16 bs :: ByteString)
-
+import Data.ByteArray.Encoding as B
+import qualified Prelude as P
 
 #if !MIN_VERSION_base(4,8,0)
+import Prelude ((.))
+
 sortOn :: Ord b => (a -> b) -> [a] -> [a]
 sortOn f =
-  map snd . sortBy (comparing fst) . map (\x -> let y = f x in y `seq` (y, x))
+  map P.snd . sortBy (comparing P.fst) . map (\x -> let y = f x in y `P.seq` (y, x))
 #endif
+
+showBytesHex :: ByteString -> P.String
+showBytesHex bs = P.show (B.convertToBase B.Base16 bs :: ByteString)
+

--- a/core/Network/TLS/Imports.hs
+++ b/core/Network/TLS/Imports.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- |
 -- Module      : Network.TLS.Imports
 -- License     : BSD-style
@@ -17,8 +18,12 @@ module Network.TLS.Imports
     , showBytesHex
     , module Data.Bits
     , module Data.List
+    , module Data.Ord
     , module Data.Word
     , module Control.Monad
+#if !MIN_VERSION_base(4,8,0)
+    , sortOn
+#endif
     ) where
 
 import qualified Control.Applicative
@@ -28,9 +33,17 @@ import           Data.Bits
 import           Data.ByteArray.Encoding as B
 import           Data.ByteString (ByteString)
 import           Data.List
+import           Data.Ord
 import           Data.Word
 import qualified Prelude
 import           Control.Monad
 
 showBytesHex :: ByteString -> Prelude.String
 showBytesHex bs = Prelude.show (B.convertToBase B.Base16 bs :: ByteString)
+
+
+#if !MIN_VERSION_base(4,8,0)
+sortOn :: Ord b => (a -> b) -> [a] -> [a]
+sortOn f =
+  map snd . sortBy (comparing fst) . map (\x -> let y = f x in y `seq` (y, x))
+#endif

--- a/core/Network/TLS/Imports.hs
+++ b/core/Network/TLS/Imports.hs
@@ -9,8 +9,7 @@
 module Network.TLS.Imports
     (
     -- generic exports
-      ByteString
-    , Control.Applicative.Applicative(..)
+      Control.Applicative.Applicative(..)
     , (Control.Applicative.<$>)
     , Data.Monoid.Monoid(..)
     -- project definition

--- a/core/Network/TLS/Imports.hs
+++ b/core/Network/TLS/Imports.hs
@@ -16,6 +16,7 @@ module Network.TLS.Imports
     -- project definition
     , showBytesHex
     , module Data.Bits
+    , module Data.List
     , module Data.Word
     , module Control.Monad
     ) where
@@ -26,6 +27,7 @@ import qualified Data.Monoid
 import           Data.Bits
 import           Data.ByteArray.Encoding as B
 import           Data.ByteString (ByteString)
+import           Data.List
 import           Data.Word
 import qualified Prelude
 import           Control.Monad

--- a/core/Network/TLS/MAC.hs
+++ b/core/Network/TLS/MAC.hs
@@ -17,9 +17,8 @@ module Network.TLS.MAC
 
 import Network.TLS.Crypto
 import Network.TLS.Types
-import Data.ByteString (ByteString)
+import Network.TLS.Imports
 import qualified Data.ByteString as B
-import Data.Bits (xor)
 
 type HMAC = ByteString -> ByteString -> ByteString
 

--- a/core/Network/TLS/Measurement.hs
+++ b/core/Network/TLS/Measurement.hs
@@ -14,7 +14,7 @@ module Network.TLS.Measurement
         , incrementNbHandshakes
         ) where
 
-import Data.Word
+import Network.TLS.Imports
 
 -- | record some data about this connection.
 data Measurement = Measurement

--- a/core/Network/TLS/Packet.hs
+++ b/core/Network/TLS/Packet.hs
@@ -64,8 +64,6 @@ import Network.TLS.Struct
 import Network.TLS.Wire
 import Network.TLS.Cap
 import Data.Maybe (fromJust)
-import Data.Word
-import Control.Monad
 import Data.ASN1.Types (fromASN1, toASN1)
 import Data.ASN1.Encoding (decodeASN1', encodeASN1')
 import Data.ASN1.BinaryEncoding (DER(..))
@@ -73,7 +71,6 @@ import Data.X509 (CertificateChainRaw(..), encodeCertificateChain, decodeCertifi
 import Network.TLS.Crypto
 import Network.TLS.MAC
 import Network.TLS.Cipher (CipherKeyExchangeType(..), Cipher(..))
-import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC
 import           Data.ByteArray (ByteArrayAccess)

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -36,7 +36,6 @@ import Network.TLS.X509
 import Network.TLS.RNG (Seed)
 import Network.TLS.Imports
 import Data.Default.Class
-import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 
 type HostName = String

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -1,5 +1,3 @@
- {-# LANGUAGE CPP #-}
-
 -- |
 -- Module      : Network.TLS.Parameters
 -- License     : BSD-style
@@ -36,12 +34,10 @@ import Network.TLS.Crypto
 import Network.TLS.Credentials
 import Network.TLS.X509
 import Network.TLS.RNG (Seed)
+import Network.TLS.Imports
 import Data.Default.Class
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
-#if __GLASGOW_HASKELL__ < 710
-import Data.Monoid (mempty)
-#endif
 
 type HostName = String
 

--- a/core/Network/TLS/Record/Disengage.hs
+++ b/core/Network/TLS/Record/Disengage.hs
@@ -28,7 +28,7 @@ import Network.TLS.Compression
 import Network.TLS.Util
 import Network.TLS.Wire
 import Network.TLS.Packet
-import Data.ByteString (ByteString)
+import Network.TLS.Imports
 import qualified Data.ByteString as B
 import qualified Data.ByteArray as B (convert)
 

--- a/core/Network/TLS/Record/Engage.hs
+++ b/core/Network/TLS/Record/Engage.hs
@@ -13,7 +13,6 @@ module Network.TLS.Record.Engage
         ( engageRecord
         ) where
 
-import Control.Applicative
 import Control.Monad.State.Strict
 import Crypto.Cipher.Types (AuthTag(..))
 
@@ -24,6 +23,7 @@ import Network.TLS.Cipher
 import Network.TLS.Compression
 import Network.TLS.Wire
 import Network.TLS.Packet
+import Network.TLS.Imports
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import qualified Data.ByteArray as B (convert)

--- a/core/Network/TLS/Record/Engage.hs
+++ b/core/Network/TLS/Record/Engage.hs
@@ -24,7 +24,6 @@ import Network.TLS.Compression
 import Network.TLS.Wire
 import Network.TLS.Packet
 import Network.TLS.Imports
-import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import qualified Data.ByteArray as B (convert)
 

--- a/core/Network/TLS/Record/State.hs
+++ b/core/Network/TLS/Record/State.hs
@@ -25,7 +25,6 @@ module Network.TLS.Record.State
     ) where
 
 import Data.Word
-import Control.Applicative
 import Control.Monad.State.Strict
 import Network.TLS.Compression
 import Network.TLS.Cipher
@@ -36,6 +35,7 @@ import Network.TLS.Wire
 import Network.TLS.Packet
 import Network.TLS.MAC
 import Network.TLS.Util
+import Network.TLS.Imports
 
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B

--- a/core/Network/TLS/Record/State.hs
+++ b/core/Network/TLS/Record/State.hs
@@ -24,7 +24,6 @@ module Network.TLS.Record.State
     , getMacSequence
     ) where
 
-import Data.Word
 import Control.Monad.State.Strict
 import Network.TLS.Compression
 import Network.TLS.Cipher
@@ -37,7 +36,6 @@ import Network.TLS.MAC
 import Network.TLS.Util
 import Network.TLS.Imports
 
-import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 
 data CryptState = CryptState

--- a/core/Network/TLS/Record/Types.hs
+++ b/core/Network/TLS/Record/Types.hs
@@ -41,7 +41,6 @@ module Network.TLS.Record.Types
 import Network.TLS.Struct
 import Network.TLS.Imports
 import Network.TLS.Record.State
-import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 
 -- | Represent a TLS record.

--- a/core/Network/TLS/Record/Types.hs
+++ b/core/Network/TLS/Record/Types.hs
@@ -39,10 +39,10 @@ module Network.TLS.Record.Types
     ) where
 
 import Network.TLS.Struct
+import Network.TLS.Imports
 import Network.TLS.Record.State
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
-import Control.Applicative ((<$>))
 
 -- | Represent a TLS record.
 data Record a = Record !ProtocolType !Version !(Fragment a) deriving (Show,Eq)

--- a/core/Network/TLS/Sending.hs
+++ b/core/Network/TLS/Sending.hs
@@ -14,7 +14,6 @@ import Control.Monad.State.Strict
 import Control.Concurrent.MVar
 import Data.IORef
 
-import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 
 import Network.TLS.Types (Role(..))

--- a/core/Network/TLS/Sending.hs
+++ b/core/Network/TLS/Sending.hs
@@ -10,7 +10,6 @@
 --
 module Network.TLS.Sending (writePacket) where
 
-import Control.Applicative
 import Control.Monad.State.Strict
 import Control.Concurrent.MVar
 import Data.IORef
@@ -29,6 +28,7 @@ import Network.TLS.State
 import Network.TLS.Handshake.State
 import Network.TLS.Cipher
 import Network.TLS.Util
+import Network.TLS.Imports
 
 -- | 'makePacketData' create a Header and a content bytestring related to a packet
 -- this doesn't change any state

--- a/core/Network/TLS/State.hs
+++ b/core/Network/TLS/State.hs
@@ -57,7 +57,6 @@ import Network.TLS.RNG
 import Network.TLS.Types (Role(..))
 import Network.TLS.Wire (GetContinuation)
 import Network.TLS.Extension
-import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import Control.Monad.State.Strict
 import Network.TLS.ErrT

--- a/core/Network/TLS/Struct.hs
+++ b/core/Network/TLS/Struct.hs
@@ -60,9 +60,7 @@ module Network.TLS.Struct
     , typeOfHandshake
     ) where
 
-import Data.ByteString (ByteString)
 import qualified Data.ByteString as B (length)
-import Data.Word
 import Data.X509 (CertificateChain, DistinguishedName)
 import Data.Typeable
 import Control.Exception (Exception(..))

--- a/core/Network/TLS/Types.hs
+++ b/core/Network/TLS/Types.hs
@@ -16,8 +16,7 @@ module Network.TLS.Types
     , Direction(..)
     ) where
 
-import Data.ByteString (ByteString)
-import Data.Word
+import Network.TLS.Imports
 
 type HostName = String
 

--- a/core/Network/TLS/Util.hs
+++ b/core/Network/TLS/Util.hs
@@ -12,7 +12,6 @@ module Network.TLS.Util
         , catchException
         ) where
 
-import Data.List (foldl')
 import qualified Data.ByteString as B
 import Network.TLS.Imports
 

--- a/core/Network/TLS/Util.hs
+++ b/core/Network/TLS/Util.hs
@@ -13,9 +13,8 @@ module Network.TLS.Util
         ) where
 
 import Data.List (foldl')
--- import Network.TLS.Imports (ByteString)
-import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
+import Network.TLS.Imports
 
 import Control.Exception (SomeException)
 import Control.Concurrent.Async

--- a/core/Network/TLS/Util/ASN1.hs
+++ b/core/Network/TLS/Util/ASN1.hs
@@ -12,10 +12,10 @@ module Network.TLS.Util.ASN1
     , encodeASN1Object
     ) where
 
+import Network.TLS.Imports
 import Data.ASN1.Types (fromASN1, toASN1, ASN1Object)
 import Data.ASN1.Encoding (decodeASN1', encodeASN1')
 import Data.ASN1.BinaryEncoding (DER(..))
-import Data.ByteString (ByteString)
 
 -- | Attempt to decode a bytestring representing
 -- an DER ASN.1 serialized object into the object.

--- a/core/Network/TLS/Wire.hs
+++ b/core/Network/TLS/Wire.hs
@@ -54,11 +54,7 @@ module Network.TLS.Wire
 import Data.Serialize.Get hiding (runGet)
 import qualified Data.Serialize.Get as G
 import Data.Serialize.Put
-import Control.Monad
-import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
-import Data.Word
-import Data.Bits
 import Network.TLS.Struct
 import Network.TLS.Imports
 import Network.TLS.Util.Serialization

--- a/core/Network/TLS/Wire.hs
+++ b/core/Network/TLS/Wire.hs
@@ -54,13 +54,13 @@ module Network.TLS.Wire
 import Data.Serialize.Get hiding (runGet)
 import qualified Data.Serialize.Get as G
 import Data.Serialize.Put
-import Control.Applicative ((<$>))
 import Control.Monad
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import Data.Word
 import Data.Bits
 import Network.TLS.Struct
+import Network.TLS.Imports
 import Network.TLS.Util.Serialization
 
 type GetContinuation a = ByteString -> GetResult a


### PR DESCRIPTION
Currently, import warnings of some modules are displayed. With this PR,
- GHC 7.8 does not display warnings
- GHC 7.10, 8.0 and 8.2 displays 16 import warnings only of `Imports`

After stopping support of GHC 7.8, we can just remove `import Network.TLS.Imports` from 15 modules. One exeption is `Struct.hs` which is using `showBytesHex`.