### PR TITLE
renaming fromJust and exporting Data.Maybe from Imports.

### DIFF
--- a/core/Network/TLS/Credentials.hs
+++ b/core/Network/TLS/Credentials.hs
@@ -19,7 +19,6 @@ module Network.TLS.Credentials
     , credentialMatchesHashSignatures
     ) where
 
-import Data.Maybe (catMaybes)
 import Network.TLS.Crypto
 import Network.TLS.X509
 import Network.TLS.Imports

--- a/core/Network/TLS/Extension.hs
+++ b/core/Network/TLS/Extension.hs
@@ -37,7 +37,6 @@ module Network.TLS.Extension
     , SignatureAlgorithms(..)
     ) where
 
-import Data.Maybe (fromMaybe, catMaybes)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC
 

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -28,7 +28,6 @@ import Network.TLS.Wire (encodeWord16)
 import Network.TLS.Util (bytesEq, catchException)
 import Network.TLS.Types
 import Network.TLS.X509
-import Data.Maybe
 import qualified Data.ByteString as B
 
 import Control.Monad.State.Strict

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -29,7 +29,6 @@ import Network.TLS.Handshake.State
 import Network.TLS.Handshake.Process
 import Network.TLS.Handshake.Key
 import Network.TLS.Measurement
-import Data.Maybe (isJust, listToMaybe, mapMaybe)
 import qualified Data.ByteString as B
 
 import Control.Monad.State.Strict

--- a/core/Network/TLS/Imports.hs
+++ b/core/Network/TLS/Imports.hs
@@ -18,6 +18,7 @@ module Network.TLS.Imports
     , module Control.Monad
     , module Data.Bits
     , module Data.List
+    , module Data.Maybe
     , module Data.Monoid
     , module Data.Ord
     , module Data.Word
@@ -35,6 +36,7 @@ import Control.Applicative
 import Control.Monad
 import Data.Bits
 import Data.List
+import Data.Maybe hiding (fromJust)
 import Data.Monoid
 import Data.Ord
 import Data.Word


### PR DESCRIPTION
I always misunderstand that `fromJust` is from `Data.Maybe` and am confused. To avoid this, renaming the original `fromJust` might be a good idea. If we do this, we can export `Data.Maybe` from `Imports` safely. 