### PR TITLE
Negotiated FFDHE parameters

### DIFF
--- a/core/Network/TLS.hs
+++ b/core/Network/TLS.hs
@@ -15,6 +15,7 @@ module Network.TLS
     , ServerParams(..)
     , DebugParams(..)
     , DHParams
+    , DHPublic
     , ClientHooks(..)
     , ServerHooks(..)
     , Supported(..)
@@ -23,6 +24,7 @@ module Network.TLS
     , Handshake
     , Logging(..)
     , Measurement(..)
+    , GroupUsage(..)
     , CertificateUsage(..)
     , CertificateRejectReason(..)
     , defaultParamsClient
@@ -137,7 +139,7 @@ import Network.TLS.Struct ( TLSError(..), TLSException(..)
                           , AlertDescription(..)
                           , ClientRandom(..), ServerRandom(..)
                           , Handshake)
-import Network.TLS.Crypto (KxError(..), DHParams, Group(..))
+import Network.TLS.Crypto (KxError(..), DHParams, DHPublic, Group(..))
 import Network.TLS.Cipher
 import Network.TLS.Hooks
 import Network.TLS.Measurement

--- a/core/Network/TLS/Crypto.hs
+++ b/core/Network/TLS/Crypto.hs
@@ -26,6 +26,7 @@ module Network.TLS.Crypto
     , PrivateKey
     , SignatureParams(..)
     , findDigitalSignatureAlg
+    , findFiniteFieldGroup
     , kxEncrypt
     , kxDecrypt
     , kxSign
@@ -38,6 +39,7 @@ import qualified Crypto.Hash as H
 import qualified Data.ByteString as B
 import qualified Data.ByteArray as B (convert)
 import Crypto.Random
+import qualified Crypto.PubKey.DH as DH
 import qualified Crypto.PubKey.DSA as DSA
 import qualified Crypto.PubKey.ECC.ECDSA as ECDSA
 import qualified Crypto.PubKey.ECC.Prim as ECC
@@ -74,6 +76,15 @@ findDigitalSignatureAlg keyPair =
         (PubKeyDSA     _, PrivKeyDSA      _)  -> Just DSS
         --(PubKeyECDSA   _, PrivKeyECDSA    _)  -> Just ECDSA
         _                                     -> Nothing
+
+findFiniteFieldGroup :: DH.Params -> Maybe Group
+findFiniteFieldGroup params = lookup (pg params) table
+  where
+    pg (DH.Params p g _) = (p, g)
+
+    table = [ (pg prms, grp) | grp <- availableFFGroups
+                             , let Just prms = dhParamsForGroup grp
+            ]
 
 -- functions to use the hidden class.
 hashInit :: Hash -> HashContext

--- a/core/Network/TLS/Crypto/DH.hs
+++ b/core/Network/TLS/Crypto/DH.hs
@@ -40,7 +40,7 @@ dhParams p g = DH.Params p g (numBits p)
 dhGenerateKeyPair :: MonadRandom r => DHParams -> r (DHPrivate, DHPublic)
 dhGenerateKeyPair params = do
     priv <- DH.generatePrivate params
-    let pub        = DH.generatePublic params priv
+    let pub        = DH.calculatePublic params priv
     return (priv, pub)
 
 dhGetShared :: DHParams -> DHPrivate -> DHPublic -> DHKey

--- a/core/Network/TLS/Crypto/DH.hs
+++ b/core/Network/TLS/Crypto/DH.hs
@@ -13,6 +13,7 @@ module Network.TLS.Crypto.DH
     , dhParamsGetG
     , dhGenerateKeyPair
     , dhGetShared
+    , dhValid
     , dhUnwrap
     , dhUnwrapPublic
     ) where
@@ -49,6 +50,12 @@ dhGetShared params priv pub =
     -- strips leading zeros from the result of DH.getShared, as required
     -- for DH(E) premaster secret in SSL/TLS before version 1.3.
     stripLeadingZeros (DH.SharedKey sb) = DH.SharedKey (snd $ B.span (== 0) sb)
+
+-- Check that group element in not in the 2-element subgroup { 1, p - 1 }.
+-- See RFC 7919 section 3 and NIST SP 56A rev 2 section 5.6.2.3.1.
+-- This verification is enough when using a safe prime.
+dhValid :: DHParams -> Integer -> Bool
+dhValid (DH.Params p _ _) y = 1 < y && y < p - 1
 
 dhUnwrap :: DHParams -> DHPublic -> [Integer]
 dhUnwrap (DH.Params p g _) (DH.PublicNumber y) = [p,g,y]

--- a/core/Network/TLS/Crypto/DH.hs
+++ b/core/Network/TLS/Crypto/DH.hs
@@ -4,6 +4,7 @@ module Network.TLS.Crypto.DH
       DHParams
     , DHPublic
     , DHPrivate
+    , DHKey
 
     -- * DH methods
     , dhPublic

--- a/core/Network/TLS/Crypto/IES.hs
+++ b/core/Network/TLS/Crypto/IES.hs
@@ -16,6 +16,8 @@ module Network.TLS.Crypto.IES
     , groupGetShared
     , encodeGroupPublic
     , decodeGroupPublic
+    -- * Compatibility with 'Network.TLS.Crypto.DH'
+    , dhParamsForGroup
     ) where
 
 import Control.Arrow
@@ -71,6 +73,14 @@ x25519 = Proxy
 
 x448 :: Proxy Curve_X448
 x448 = Proxy
+
+dhParamsForGroup :: Group -> Maybe Params
+dhParamsForGroup FFDHE2048 = Just ffdhe2048
+dhParamsForGroup FFDHE3072 = Just ffdhe3072
+dhParamsForGroup FFDHE4096 = Just ffdhe4096
+dhParamsForGroup FFDHE6144 = Just ffdhe6144
+dhParamsForGroup FFDHE8192 = Just ffdhe8192
+dhParamsForGroup _         = Nothing
 
 groupGenerateKeyPair :: MonadRandom r => Group -> r (GroupPrivate, GroupPublic)
 groupGenerateKeyPair P256   =

--- a/core/Network/TLS/Crypto/Types.hs
+++ b/core/Network/TLS/Crypto/Types.hs
@@ -17,6 +17,9 @@ availableFFGroups = [FFDHE2048,FFDHE3072,FFDHE4096,FFDHE6144,FFDHE8192]
 availableECGroups :: [Group]
 availableECGroups = [P256,P384,P521,X25519,X448]
 
+availableGroups :: [Group]
+availableGroups = availableECGroups ++ availableFFGroups
+
 -- Digital signature algorithm, in close relation to public/private key types
 -- and cipher key exchange.
 data DigitalSignatureAlg = RSA | DSS | ECDSA | Ed25519 | Ed448

--- a/core/Network/TLS/Crypto/Types.hs
+++ b/core/Network/TLS/Crypto/Types.hs
@@ -11,8 +11,8 @@ data Group = P256 | P384 | P521 | X25519 | X448
            | FFDHE2048 | FFDHE3072 | FFDHE4096 | FFDHE6144 | FFDHE8192
            deriving (Eq, Show)
 
-availableGroups :: [Group]
-availableGroups = [P256,P384,P521,X25519,X448]
+availableECGroups :: [Group]
+availableECGroups = [P256,P384,P521,X25519,X448]
 
 -- Digital signature algorithm, in close relation to public/private key types
 -- and cipher key exchange.

--- a/core/Network/TLS/Crypto/Types.hs
+++ b/core/Network/TLS/Crypto/Types.hs
@@ -11,6 +11,9 @@ data Group = P256 | P384 | P521 | X25519 | X448
            | FFDHE2048 | FFDHE3072 | FFDHE4096 | FFDHE6144 | FFDHE8192
            deriving (Eq, Show)
 
+availableFFGroups :: [Group]
+availableFFGroups = [FFDHE2048,FFDHE3072,FFDHE4096,FFDHE6144,FFDHE8192]
+
 availableECGroups :: [Group]
 availableECGroups = [P256,P384,P521,X25519,X448]
 

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -63,7 +63,7 @@ handshakeClient cparams ctx = do
         getExtensions = sequence [sniExtension
                                  ,secureReneg
                                  ,alpnExtension
-                                 ,curveExtension
+                                 ,groupExtension
                                  ,ecPointExtension
                                  --,sessionTicketExtension
                                  ,signatureAlgExtension
@@ -90,7 +90,7 @@ handshakeClient cparams ctx = do
                                  return $ Just $ toExtensionRaw $ ServerName [ServerNameHostName sni]
                          else return Nothing
 
-        curveExtension = return $ Just $ toExtensionRaw $ NegotiatedGroups ((supportedGroups $ ctxSupported ctx) `intersect` availableECGroups)
+        groupExtension = return $ Just $ toExtensionRaw $ NegotiatedGroups (supportedGroups $ ctxSupported ctx)
         ecPointExtension = return $ Just $ toExtensionRaw $ EcPointFormatsSupported [EcPointFormat_Uncompressed]
                                 --[EcPointFormat_Uncompressed,EcPointFormat_AnsiX962_compressed_prime,EcPointFormat_AnsiX962_compressed_char2]
         --heartbeatExtension = return $ Just $ toExtensionRaw $ HeartBeat $ HeartBeat_PeerAllowedToSend

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -90,7 +90,7 @@ handshakeClient cparams ctx = do
                                  return $ Just $ toExtensionRaw $ ServerName [ServerNameHostName sni]
                          else return Nothing
 
-        curveExtension = return $ Just $ toExtensionRaw $ NegotiatedGroups ((supportedGroups $ ctxSupported ctx) `intersect` availableGroups)
+        curveExtension = return $ Just $ toExtensionRaw $ NegotiatedGroups ((supportedGroups $ ctxSupported ctx) `intersect` availableECGroups)
         ecPointExtension = return $ Just $ toExtensionRaw $ EcPointFormatsSupported [EcPointFormat_Uncompressed]
                                 --[EcPointFormat_Uncompressed,EcPointFormat_AnsiX962_compressed_prime,EcPointFormat_AnsiX962_compressed_char2]
         --heartbeatExtension = return $ Just $ toExtensionRaw $ HeartBeat $ HeartBeat_PeerAllowedToSend

--- a/core/Network/TLS/Handshake/Key.hs
+++ b/core/Network/TLS/Handshake/Key.hs
@@ -15,6 +15,8 @@ module Network.TLS.Handshake.Key
     , generateDHE
     , generateECDHE
     , generateECDHEShared
+    , generateFFDHE
+    , generateFFDHEShared
     ) where
 
 import qualified Data.ByteString as B
@@ -68,3 +70,9 @@ generateECDHE ctx grp = usingState_ ctx $ withRNG $ groupGenerateKeyPair grp
 
 generateECDHEShared :: Context -> GroupPublic -> IO (Maybe (GroupPublic, GroupKey))
 generateECDHEShared ctx pub = usingState_ ctx $ withRNG $ groupGetPubShared pub
+
+generateFFDHE :: Context -> Group -> IO (DHParams, DHPrivate, DHPublic)
+generateFFDHE ctx grp = usingState_ ctx $ withRNG $ dhGroupGenerateKeyPair grp
+
+generateFFDHEShared :: Context -> Group -> DHPublic -> IO (Maybe (DHPublic, DHKey))
+generateFFDHEShared ctx grp pub = usingState_ ctx $ withRNG $ dhGroupGetPubShared grp pub

--- a/core/Network/TLS/Handshake/Process.hs
+++ b/core/Network/TLS/Handshake/Process.hs
@@ -93,8 +93,12 @@ processClientKeyXchg ctx (CKX_DH clientDHValue) = do
     role <- usingState_ ctx isClientContext
 
     serverParams <- usingHState ctx getServerDHParams
+    let params = serverDHParamsToParams serverParams
+    unless (dhValid params $ dhUnwrapPublic clientDHValue) $
+        throwCore $ Error_Protocol ("invalid client public key", True, HandshakeFailure)
+
     dhpriv       <- usingHState ctx getDHPrivate
-    let premaster = dhGetShared (serverDHParamsToParams serverParams) dhpriv clientDHValue
+    let premaster = dhGetShared params dhpriv clientDHValue
     usingHState ctx $ setMasterSecretFromPre rver role premaster
 
 processClientKeyXchg ctx (CKX_ECDH bytes) = do

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -134,16 +134,24 @@ handshakeServerWith sparams ctx clientHello@(ClientHello clientVersion _ clientS
     -- negotiated signature parameters.  Then ciphers are evalutated from
     -- the resulting credentials.
 
-    let possibleECGroups = negotiatedECGroupsInCommon ctx exts
+    let possibleGroups   = negotiatedGroupsInCommon ctx exts
+        possibleECGroups = possibleGroups `intersect` availableECGroups
+        possibleFFGroups = possibleGroups `intersect` availableFFGroups
         hasCommonGroupForECDHE = not (null possibleECGroups)
+        hasCommonGroupForFFDHE = not (null possibleFFGroups)
+        hasCustomGroupForFFDHE = isJust (serverDHEParams sparams)
+        canFFDHE = hasCustomGroupForFFDHE || hasCommonGroupForFFDHE
         hasCommonGroup cipher =
             case cipherKeyExchange cipher of
+                CipherKeyExchange_DH_Anon      -> canFFDHE
+                CipherKeyExchange_DHE_RSA      -> canFFDHE
+                CipherKeyExchange_DHE_DSS      -> canFFDHE
                 CipherKeyExchange_ECDHE_RSA    -> hasCommonGroupForECDHE
                 CipherKeyExchange_ECDHE_ECDSA  -> hasCommonGroupForECDHE
                 _                              -> True -- group not used
 
-        -- Ciphers are selected according to TLS version, availability of ECDHE
-        -- group and credential depending on key exchange.
+        -- Ciphers are selected according to TLS version, availability of
+        -- (EC)DHE group and credential depending on key exchange.
         cipherAllowed cipher   = cipherAllowedForVersion chosenVersion cipher && hasCommonGroup cipher
         selectCipher credentials signatureCredentials = filter cipherAllowed (commonCiphers credentials signatureCredentials)
 
@@ -361,7 +369,11 @@ doHandshake sparams mcred ctx chosenVersion usedCipher usedCompression clientSes
         extractCAname cert = certSubjectDN $ getCertificate cert
 
         setup_DHE = do
-            let dhparams = fromJust "server DHE Params" $ serverDHEParams sparams
+            let possibleFFGroups = negotiatedGroupsInCommon ctx exts `intersect` availableFFGroups
+                dhparams =
+                    case possibleFFGroups of
+                        []  -> fromJust "server DHE Params" $ serverDHEParams sparams
+                        g:_ -> fromJust "group DHE Params" $ dhParamsForGroup g
             (priv, pub) <- generateDHE ctx dhparams
 
             let serverParams = serverDHParamsFrom dhparams pub
@@ -405,7 +417,7 @@ doHandshake sparams mcred ctx chosenVersion usedCipher usedCompression clientSes
             return serverParams
 
         generateSKX_ECDHE sigAlg = do
-            let possibleECGroups = negotiatedECGroupsInCommon ctx exts
+            let possibleECGroups = negotiatedGroupsInCommon ctx exts `intersect` availableECGroups
             grp <- case possibleECGroups of
                      []  -> throwCore $ Error_Protocol ("no common group", True, HandshakeFailure)
                      g:_ -> return g
@@ -548,10 +560,10 @@ hashAndSignaturesInCommon ctx exts =
         -- to server preference in 'supportedHashSignatures'.
      in sHashSigs `intersect` cHashSigs
 
-negotiatedECGroupsInCommon :: Context -> [ExtensionRaw] -> [Group]
-negotiatedECGroupsInCommon ctx exts = case extensionLookup extensionID_NegotiatedGroups exts >>= extensionDecode False of
+negotiatedGroupsInCommon :: Context -> [ExtensionRaw] -> [Group]
+negotiatedGroupsInCommon ctx exts = case extensionLookup extensionID_NegotiatedGroups exts >>= extensionDecode False of
     Just (NegotiatedGroups clientGroups) ->
-        let serverGroups = supportedGroups (ctxSupported ctx) `intersect` availableECGroups
+        let serverGroups = supportedGroups (ctxSupported ctx)
         in serverGroups `intersect` clientGroups
     _                                    -> []
 
@@ -591,9 +603,9 @@ findHighestVersionFrom clientVersion allowedVersions =
         []  -> Nothing
         v:_ -> Just v
 
--- We filter our allowed ciphers here according to server DHE parameters and
--- dynamic credential lists.  Credentials 'creds' come from server parameters
--- but also SNI callback.  When the key exchange requires a signature, we use a
+-- We filter our allowed ciphers here according to dynamic credential lists.
+-- Credentials 'creds' come from server parameters but also SNI callback.
+-- When the key exchange requires a signature, we use a
 -- subset of this list named 'sigCreds'.  This list has been filtered in order
 -- to remove certificates that are not compatible with hash/signature
 -- restrictions (TLS 1.2).
@@ -602,9 +614,9 @@ getCiphers sparams creds sigCreds = filter authorizedCKE (supportedCiphers $ ser
       where authorizedCKE cipher =
                 case cipherKeyExchange cipher of
                     CipherKeyExchange_RSA         -> canEncryptRSA
-                    CipherKeyExchange_DH_Anon     -> canDHE
-                    CipherKeyExchange_DHE_RSA     -> canSignRSA && canDHE
-                    CipherKeyExchange_DHE_DSS     -> canSignDSS && canDHE
+                    CipherKeyExchange_DH_Anon     -> True
+                    CipherKeyExchange_DHE_RSA     -> canSignRSA
+                    CipherKeyExchange_DHE_DSS     -> canSignDSS
                     CipherKeyExchange_ECDHE_RSA   -> canSignRSA
                     -- unimplemented: EC
                     CipherKeyExchange_ECDHE_ECDSA -> False
@@ -617,7 +629,6 @@ getCiphers sparams creds sigCreds = filter authorizedCKE (supportedCiphers $ ser
                     CipherKeyExchange_ECDH_ECDSA  -> False
                     CipherKeyExchange_ECDH_RSA    -> False
 
-            canDHE        = isJust $ serverDHEParams sparams
             canSignDSS    = DSS `elem` signingAlgs
             canSignRSA    = RSA `elem` signingAlgs
             canEncryptRSA = isJust $ credentialsFindForDecrypting creds

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -134,8 +134,8 @@ handshakeServerWith sparams ctx clientHello@(ClientHello clientVersion _ clientS
     -- negotiated signature parameters.  Then ciphers are evalutated from
     -- the resulting credentials.
 
-    let possibleGroups = negotiatedGroupsInCommon ctx exts
-        hasCommonGroupForECDHE = not (null possibleGroups)
+    let possibleECGroups = negotiatedECGroupsInCommon ctx exts
+        hasCommonGroupForECDHE = not (null possibleECGroups)
         hasCommonGroup cipher =
             case cipherKeyExchange cipher of
                 CipherKeyExchange_ECDHE_RSA    -> hasCommonGroupForECDHE
@@ -405,8 +405,8 @@ doHandshake sparams mcred ctx chosenVersion usedCipher usedCompression clientSes
             return serverParams
 
         generateSKX_ECDHE sigAlg = do
-            let possibleGroups = negotiatedGroupsInCommon ctx exts
-            grp <- case possibleGroups of
+            let possibleECGroups = negotiatedECGroupsInCommon ctx exts
+            grp <- case possibleECGroups of
                      []  -> throwCore $ Error_Protocol ("no common group", True, HandshakeFailure)
                      g:_ -> return g
             serverParams <- setup_ECDHE grp
@@ -548,10 +548,10 @@ hashAndSignaturesInCommon ctx exts =
         -- to server preference in 'supportedHashSignatures'.
      in sHashSigs `intersect` cHashSigs
 
-negotiatedGroupsInCommon :: Context -> [ExtensionRaw] -> [Group]
-negotiatedGroupsInCommon ctx exts = case extensionLookup extensionID_NegotiatedGroups exts >>= extensionDecode False of
+negotiatedECGroupsInCommon :: Context -> [ExtensionRaw] -> [Group]
+negotiatedECGroupsInCommon ctx exts = case extensionLookup extensionID_NegotiatedGroups exts >>= extensionDecode False of
     Just (NegotiatedGroups clientGroups) ->
-        let serverGroups = supportedGroups (ctxSupported ctx) `intersect` availableGroups
+        let serverGroups = supportedGroups (ctxSupported ctx) `intersect` availableECGroups
         in serverGroups `intersect` clientGroups
     _                                    -> []
 

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -111,8 +111,9 @@ data ServerParams = ServerParams
       -- messages.  For TLS1.0, it should not be empty.
     , serverCACertificates :: [SignedCertificate]
 
-      -- | Server Optional Diffie Hellman parameters. If this value is not
-      -- properly set, no Diffie Hellman key exchange will take place.
+      -- | Server Optional Diffie Hellman parameters.  Setting parameters is
+      -- necessary for FFDHE key exchange when clients are not compatible
+      -- with RFC 7919.
       --
       -- Value can be one of the standardized groups from module
       -- "Network.TLS.Extra.FFDHE" or custom parameters generated with

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -113,6 +113,10 @@ data ServerParams = ServerParams
 
       -- | Server Optional Diffie Hellman parameters. If this value is not
       -- properly set, no Diffie Hellman key exchange will take place.
+      --
+      -- Value can be one of the standardized groups from module
+      -- "Network.TLS.Extra.FFDHE" or custom parameters generated with
+      -- 'Crypto.PubKey.DH.generateParams'.
     , serverDHEParams         :: Maybe DHParams
 
     , serverShared            :: Shared

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -181,7 +181,8 @@ data Supported = Supported
       -- 'False', empty packets will never be added, which is less secure, but might help in rare
       -- cases.
     , supportedEmptyPacket         :: Bool
-      -- | A list of supported elliptic curves in the preferred order.
+      -- | A list of supported elliptic curves and finite-field groups in the
+      --   preferred order.
       --   The default value is ['P256','P384','P521'].
       --   'P256' provides 128-bit security which is strong enough
       --   until 2030 and is fast because its backend is written in C.

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -77,8 +77,10 @@ knownHashSignatures = filter nonECDSA availableHashSignatures
 arbitraryHashSignatures :: Gen [HashAndSignatureAlgorithm]
 arbitraryHashSignatures = sublistOf knownHashSignatures
 
-knownGroups :: [Group]
-knownGroups = [P256,P384,P521,X25519,X448]
+knownGroups, knownECGroups, knownFFGroups :: [Group]
+knownECGroups = [P256,P384,P521,X25519,X448]
+knownFFGroups = [FFDHE2048,FFDHE3072,FFDHE4096,FFDHE6144,FFDHE8192]
+knownGroups   = knownECGroups ++ knownFFGroups
 
 arbitraryGroups :: Gen [Group]
 arbitraryGroups = listOf1 $ elements knownGroups
@@ -102,7 +104,7 @@ arbitraryCipherPair :: Version -> Gen ([Cipher], [Cipher])
 arbitraryCipherPair connectVersion = do
     serverCiphers      <- arbitraryCiphers `suchThat`
                                 (\cs -> or [maybe True (<= connectVersion) (cipherMinVer x) | x <- cs])
-    clientCiphers      <- oneof [arbitraryCiphers] `suchThat`
+    clientCiphers      <- arbitraryCiphers `suchThat`
                                 (\cs -> or [x `elem` serverCiphers &&
                                             maybe True (<= connectVersion) (cipherMinVer x) | x <- cs])
     return (clientCiphers, serverCiphers)
@@ -118,11 +120,11 @@ arbitraryPairParams = do
     serAllowedVersions <- (:[]) `fmap` elements allowedVersions
     arbitraryPairParamsWithVersionsAndCiphers (allowedVersions, serAllowedVersions) (clientCiphers, serverCiphers)
 
-arbitraryGroupPair :: Gen ([Group], [Group])
-arbitraryGroupPair = do
-    serverGroups <- arbitraryGroups
-    clientGroups <- oneof [arbitraryGroups] `suchThat`
-                         (\gs -> or [x `elem` serverGroups | x <- gs])
+arbitraryECGroupPair :: Gen ([Group], [Group])
+arbitraryECGroupPair = do
+    let arbitraryECGroups = listOf1 $ elements knownECGroups
+    serverGroups <- arbitraryECGroups
+    clientGroups <- arbitraryECGroups `suchThat` any (`elem` serverGroups)
     return (clientGroups, serverGroups)
 
 arbitraryHashSignaturePair :: Gen ([HashAndSignatureAlgorithm], [HashAndSignatureAlgorithm])
@@ -139,7 +141,7 @@ arbitraryPairParamsWithVersionsAndCiphers (clientVersions, serverVersions) (clie
     dhparams           <- elements [dhParams,ffdhe2048,ffdhe3072]
 
     creds              <- arbitraryCredentialsOfEachType
-    (clientGroups, serverGroups) <- arbitraryGroupPair
+    (clientGroups, serverGroups) <- arbitraryECGroupPair
     (clientHashSignatures, serverHashSignatures) <- arbitraryHashSignaturePair
     let serverState = def
             { serverSupported = def { supportedCiphers  = serverCiphers

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -9,6 +9,7 @@ module Connection
     , arbitraryPairParams
     , arbitraryPairParamsWithVersionsAndCiphers
     , arbitraryClientCredential
+    , isCustomDHParams
     , leafPublicKey
     , oneSessionManager
     , setPairParamsSessionManager
@@ -95,6 +96,9 @@ arbitraryCredentialsOfEachType = do
          ) [ (PubKeyRSA pubKey, PrivKeyRSA privKey)
            , (PubKeyDSA dsaPub, PrivKeyDSA dsaPriv)
            ]
+
+isCustomDHParams :: DHParams -> Bool
+isCustomDHParams params = params == dhParams
 
 leafPublicKey :: CertificateChain -> Maybe PubKey
 leafPublicKey (CertificateChain [])       = Nothing

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -170,6 +170,8 @@ prop_handshake_groups = do
         serverVersions = [TLS12]
         ciphers = [ cipher_ECDHE_RSA_AES256GCM_SHA384
                   , cipher_ECDHE_RSA_AES128CBC_SHA
+                  , cipher_DHE_RSA_AES256GCM_SHA384
+                  , cipher_DHE_RSA_AES128_SHA1
                   ]
     (clientParam,serverParam) <- pick $ arbitraryPairParamsWithVersionsAndCiphers
                                             (clientVersions, serverVersions)
@@ -181,6 +183,7 @@ prop_handshake_groups = do
                                    }
         serverParam' = serverParam { serverSupported = (serverSupported serverParam)
                                        { supportedGroups = serverGroups }
+                                   , serverDHEParams = Nothing
                                    }
         shouldFail = null (clientGroups `intersect` serverGroups)
     if shouldFail


### PR DESCRIPTION
After ECDH this is to improve validation in DH key exchange:
- support for named FFDHE groups (RFC 7919), in addition to custom groups we have today
- minimal validation of DH parameters (but which is enough when using named FFDHE groups)
- optional client callback to implement policy about custom groups

When DHE params match a named group, internally module Crypto.IES is used and the
implementation generates short exponents as optimisation.

Unfortunately because of compatibility this means we get 3 sets of APIs with some redundancy:
- Crypto.DH is used when groups are custom
- Crypto.IES has new compatibility functions with data types like in Crypto.DH and removal of leading zeros (TLS <= 1.2)
- Crypto.IES existing hybrid group functions are kept and extended with FFDH validation checks and use of short exponents, so they should still be usable for TLS 1.3
