### PR TITLE
Impoving tls-debug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ install:
       cabal install random
     fi
     cabal install
+ - cd ../session
+ - if [ "${RUNTEST}" != "0" ]; then cabal install --only-dependencies --enable-tests; else cabal install --only-dependencies; fi
  - cd ../debug
  - if [ "${RUNTEST}" != "0" ]; then cabal install --only-dependencies --enable-tests; else cabal install --only-dependencies; fi
 
@@ -42,6 +44,19 @@ script:
  - if [ "${RUNTEST}" != "0" ]; then cabal configure --enable-tests -v2; else cabal configure -v2; fi
  - cabal build
  - if [ "${RUNTEST}" != "0" ]; then cabal test; fi;
+ - cabal check
+ - cabal sdist
+ - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
+   cd dist/;
+   if [ -f "$SRC_TGZ" ]; then
+      cabal install --force-reinstalls "$SRC_TGZ";
+   else
+      echo "expected '$SRC_TGZ' not found";
+      exit 1;
+   fi
+ - cd ../../session
+ - cabal configure -v2
+ - cabal build
  - cabal check
  - cabal sdist
  - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;

--- a/debug/src/CheckCiphers.hs
+++ b/debug/src/CheckCiphers.hs
@@ -7,19 +7,18 @@ import Network.TLS
 import qualified Crypto.Random.AESCtr as RNG
 
 import qualified Data.ByteString as B
-import Data.Word
 import Data.Char
 
 import Network.Socket
 import Network.BSD
 import System.IO
-import Control.Monad
-import Control.Applicative ((<$>))
 import Control.Concurrent
 import Control.Exception (SomeException(..))
 import qualified Control.Exception as E
 
 import Text.Printf
+
+import Imports
 
 tableCiphers =
     [ (0x0000, "NULL_WITH_NULL_NULL")

--- a/debug/src/CheckCiphers.hs
+++ b/debug/src/CheckCiphers.hs
@@ -1,22 +1,19 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 
-import Network.TLS.Internal
-import Network.TLS.Cipher
-import Network.TLS
-
-import qualified Crypto.Random.AESCtr as RNG
-
-import qualified Data.ByteString as B
-import Data.Char
-
-import Network.Socket
-import Network.BSD
-import System.IO
 import Control.Concurrent
 import Control.Exception (SomeException(..))
 import qualified Control.Exception as E
-
+import qualified Crypto.Random.AESCtr as RNG
+import qualified Data.ByteString as B
+import Data.Char
+import Network.BSD
+import Network.Socket
+import System.IO
 import Text.Printf
+
+import Network.TLS
+import Network.TLS.Cipher
+import Network.TLS.Internal
 
 import Imports
 

--- a/debug/src/Common.hs
+++ b/debug/src/Common.hs
@@ -9,15 +9,14 @@ module Common
     , printHandshakeInfo
     ) where
 
-import Control.Monad
-
 import Data.Char (isDigit)
-
 import Numeric (showHex)
 
 import Network.TLS
 import Network.TLS.Extra.Cipher
 import Network.TLS.Extra.FFDHE
+
+import Imports
 
 namedDHParams :: [(String, DHParams)]
 namedDHParams =

--- a/debug/src/Common.hs
+++ b/debug/src/Common.hs
@@ -7,12 +7,15 @@ module Common
     , readCiphers
     , readDHParams
     , printHandshakeInfo
+    , makeAddrInfo
+    , AddrInfo(..)
     ) where
 
 import Data.Char (isDigit)
 import Numeric (showHex)
+import Network.Socket
 
-import Network.TLS
+import Network.TLS hiding (HostName)
 import Network.TLS.Extra.Cipher
 import Network.TLS.Extra.FFDHE
 
@@ -85,3 +88,12 @@ printHandshakeInfo ctx = do
     case sni of
         Nothing -> return ()
         Just n  -> putStrLn ("server name indication: " ++ n)
+
+makeAddrInfo :: Maybe HostName -> PortNumber -> IO AddrInfo
+makeAddrInfo maddr port = do
+    let flgs = [AI_ADDRCONFIG, AI_NUMERICSERV, AI_PASSIVE]
+        hints = defaultHints {
+            addrFlags = flgs
+          , addrSocketType = Stream
+          }
+    head <$> getAddrInfo (Just hints) maddr (Just $ show port)

--- a/debug/src/HexDump.hs
+++ b/debug/src/HexDump.hs
@@ -2,11 +2,11 @@ module HexDump
     ( hexdump
     ) where
 
-import Data.List
-import Data.Word
 import qualified Data.ByteString as B
 
-hexdump :: String -> B.ByteString -> [String]
+import Imports
+
+hexdump :: String -> ByteString -> [String]
 hexdump pre b = disptable (defaultConfig { configRowLeft = pre ++ "  | " } ) $ B.unpack b
 
 data BytedumpConfig = BytedumpConfig

--- a/debug/src/Imports.hs
+++ b/debug/src/Imports.hs
@@ -1,0 +1,17 @@
+module Imports (
+    ByteString
+  , module Control.Applicative
+  , module Control.Monad
+  , module Data.List
+  , module Data.Maybe
+  , module Data.Monoid
+  , module Data.Word
+  ) where
+
+import Control.Applicative
+import Control.Monad
+import Data.ByteString (ByteString)
+import Data.List
+import Data.Maybe
+import Data.Monoid
+import Data.Word

--- a/debug/src/RetrieveCertificate.hs
+++ b/debug/src/RetrieveCertificate.hs
@@ -13,8 +13,6 @@ import Data.X509 as X509
 import Data.X509.Validation
 import System.X509
 
-import Control.Applicative
-import Control.Monad
 import Control.Exception
 
 import Data.Char (isDigit)
@@ -27,6 +25,8 @@ import System.Environment
 import System.Exit
 
 import qualified Data.ByteString.Char8 as B
+
+import Imports
 
 openConnection s p = do
     ref <- newIORef Nothing

--- a/debug/src/RetrieveCertificate.hs
+++ b/debug/src/RetrieveCertificate.hs
@@ -1,30 +1,24 @@
 {-# LANGUAGE DeriveDataTypeable, ViewPatterns #-}
 {-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 
-import Network.TLS
-import Network.TLS.Extra.Cipher
-
-import Network.BSD
-import Network.Socket
-
+import Control.Exception
+import qualified Data.ByteString.Char8 as B
+import Data.Char (isDigit)
 import Data.Default.Class
 import Data.IORef
+import Data.PEM
 import Data.X509 as X509
 import Data.X509.Validation
-import System.X509
-
-import Control.Exception
-
-import Data.Char (isDigit)
-import Data.PEM
-
-import Text.Printf
-
+import Network.BSD
+import Network.Socket
 import System.Console.GetOpt
 import System.Environment
 import System.Exit
+import System.X509
+import Text.Printf
 
-import qualified Data.ByteString.Char8 as B
+import Network.TLS
+import Network.TLS.Extra.Cipher
 
 import Imports
 

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -9,8 +9,7 @@ import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString.Lazy.Char8 as LC
 import Data.Default.Class
 import Data.IORef
-import Network.BSD
-import Network.Socket (socket, Family(..), SocketType(..), close, SockAddr(..), connect)
+import Network.Socket (socket, close, connect)
 import System.Console.GetOpt
 import System.Environment
 import System.Exit
@@ -31,9 +30,9 @@ defaultTimeout = 2000
 bogusCipher cid = cipher_AES128_SHA1 { cipherID = cid }
 
 runTLS debug ioDebug params hostname portNumber f = do
-    he   <- getHostByName hostname
-    sock <- socket AF_INET Stream defaultProtocol
-    let sockaddr = SockAddrInet portNumber (head $ hostAddresses he)
+    ai <- makeAddrInfo (Just hostname) portNumber
+    sock <- socket (addrFamily ai) (addrSocketType ai) (addrProtocol ai)
+    let sockaddr = addrAddress ai
     E.catch (connect sock sockaddr)
           (\(SomeException e) -> close sock >> error ("cannot open socket " ++ show sockaddr ++ " " ++ show e))
     ctx <- contextNew sock params

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -1,24 +1,25 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
-import Crypto.Random
-import Network.BSD
-import Network.Socket (socket, Family(..), SocketType(..), close, SockAddr(..), connect)
-import Network.TLS
-import Network.TLS.Extra.Cipher
-import System.Console.GetOpt
-import System.IO
-import System.Timeout
-import qualified Data.ByteString.Lazy.Char8 as LC
-import qualified Data.ByteString.Char8 as BC
-import qualified Data.ByteString as B
+
 import Control.Exception
 import qualified Control.Exception as E
-import System.Environment
-import System.Exit
-import System.X509
-
+import Crypto.Random
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as BC
+import qualified Data.ByteString.Lazy.Char8 as LC
 import Data.Default.Class
 import Data.IORef
+import Network.BSD
+import Network.Socket (socket, Family(..), SocketType(..), close, SockAddr(..), connect)
+import System.Console.GetOpt
+import System.Environment
+import System.Exit
+import System.IO
+import System.Timeout
+import System.X509
+
+import Network.TLS
+import Network.TLS.Extra.Cipher
 
 import Common
 import HexDump

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -13,19 +13,16 @@ import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString as B
 import Control.Exception
 import qualified Control.Exception as E
-import Control.Monad
 import System.Environment
 import System.Exit
 import System.X509
 
 import Data.Default.Class
 import Data.IORef
-import Data.Monoid
-import Data.List (find)
-import Data.Maybe (isJust, mapMaybe)
 
 import Common
 import HexDump
+import Imports
 
 defaultBenchAmount = 1024 * 1024
 defaultTimeout = 2000

--- a/debug/src/SimpleServer.hs
+++ b/debug/src/SimpleServer.hs
@@ -9,8 +9,7 @@ import qualified Data.ByteString.Lazy.Char8 as LC
 import Data.Default.Class
 import Data.IORef
 import Data.X509.CertificateStore
-import Network.BSD
-import Network.Socket (socket, Family(..), SocketType(..), close, SockAddr(..), bind, listen, accept, iNADDR_ANY)
+import Network.Socket (socket, close, bind, listen, accept)
 import qualified Network.Socket as S
 import System.Console.GetOpt
 import System.Environment
@@ -189,9 +188,10 @@ loadCred _       Nothing =
     error "missing credential certificate"
 
 runOn (sStorage, certStore) flags port = do
-    sock <- socket AF_INET Stream defaultProtocol
+    ai <- makeAddrInfo Nothing port
+    sock <- socket (addrFamily ai) (addrSocketType ai) (addrProtocol ai)
     S.setSocketOption sock S.ReuseAddr 1
-    let sockaddr = SockAddrInet port iNADDR_ANY
+    let sockaddr = addrAddress ai
     bind sock sockaddr
     listen sock 10
     runOn' sock

--- a/debug/src/SimpleServer.hs
+++ b/debug/src/SimpleServer.hs
@@ -1,25 +1,26 @@
 {-# LANGUAGE OverloadedStrings #-}
 -- Disable this warning so we can still test deprecated functionality.
 {-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
+
 import Crypto.Random
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as BC
+import qualified Data.ByteString.Lazy.Char8 as LC
+import Data.Default.Class
+import Data.IORef
+import Data.X509.CertificateStore
 import Network.BSD
 import Network.Socket (socket, Family(..), SocketType(..), close, SockAddr(..), bind, listen, accept, iNADDR_ANY)
 import qualified Network.Socket as S
-import Network.TLS
-import Network.TLS.Extra.Cipher
 import System.Console.GetOpt
-import System.IO
-import System.Timeout
-import qualified Data.ByteString.Lazy.Char8 as LC
-import qualified Data.ByteString.Char8 as BC
-import qualified Data.ByteString as B
 import System.Environment
 import System.Exit
+import System.IO
+import System.Timeout
 import System.X509
-import Data.X509.CertificateStore
 
-import Data.Default.Class
-import Data.IORef
+import Network.TLS
+import Network.TLS.Extra.Cipher
 
 import Common
 import HexDump

--- a/debug/src/SimpleServer.hs
+++ b/debug/src/SimpleServer.hs
@@ -13,7 +13,6 @@ import System.Timeout
 import qualified Data.ByteString.Lazy.Char8 as LC
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString as B
-import Control.Monad
 import System.Environment
 import System.Exit
 import System.X509
@@ -21,12 +20,10 @@ import Data.X509.CertificateStore
 
 import Data.Default.Class
 import Data.IORef
-import Data.Monoid
-import Data.List (find)
-import Data.Maybe (isJust, mapMaybe)
 
 import Common
 import HexDump
+import Imports
 
 defaultBenchAmount = 1024 * 1024
 defaultTimeout = 2000

--- a/debug/src/Stunnel.hs
+++ b/debug/src/Stunnel.hs
@@ -18,7 +18,6 @@ import Control.Concurrent (forkIO)
 import Control.Concurrent.MVar
 import Control.Exception (finally, throw, SomeException(..))
 import qualified Control.Exception as E
-import Control.Monad (when, forever)
 
 import Data.Char (isDigit)
 import Data.Default.Class
@@ -29,6 +28,7 @@ import Network.TLS.Extra.Cipher
 import qualified Crypto.PubKey.DH as DH ()
 
 import Common
+import Imports
 
 loopUntil :: Monad m => m Bool -> m ()
 loopUntil f = f >>= \v -> if v then return () else loopUntil f

--- a/debug/src/Stunnel.hs
+++ b/debug/src/Stunnel.hs
@@ -1,31 +1,28 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 -- Disable this warning so we can still test deprecated functionality.
 {-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
-import Network.BSD
-import Network.Socket hiding (Debug)
-import System.IO
-import System.IO.Error (isEOFError)
-import System.Console.GetOpt
-import System.Environment (getArgs)
-import System.Exit
-import System.X509
-import Data.X509.Validation
-
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as L
 
 import Control.Concurrent (forkIO)
 import Control.Concurrent.MVar
 import Control.Exception (finally, throw, SomeException(..))
 import qualified Control.Exception as E
-
+import qualified Crypto.PubKey.DH as DH ()
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as L
 import Data.Char (isDigit)
 import Data.Default.Class
+import Data.X509.Validation
+import Network.BSD
+import Network.Socket hiding (Debug)
+import System.Console.GetOpt
+import System.Environment (getArgs)
+import System.Exit
+import System.IO
+import System.IO.Error (isEOFError)
+import System.X509
 
 import Network.TLS
 import Network.TLS.Extra.Cipher
-
-import qualified Crypto.PubKey.DH as DH ()
 
 import Common
 import Imports

--- a/debug/tls-debug.cabal
+++ b/debug/tls-debug.cabal
@@ -46,6 +46,7 @@ Executable           tls-stunnel
 
 Executable           tls-retrievecertificate
   Main-is:           RetrieveCertificate.hs
+  Other-modules:     Imports
   Hs-Source-Dirs:    src
   Build-Depends:     base >= 4 && < 5
                    , network
@@ -64,6 +65,7 @@ Executable           tls-simpleclient
   Main-is:           SimpleClient.hs
   Other-modules:     Common
                    , HexDump
+                   , Imports
   Hs-Source-Dirs:    src
   Build-Depends:     base >= 4 && < 5
                    , network
@@ -79,6 +81,7 @@ Executable           tls-simpleserver
   Main-is:           SimpleServer.hs
   Other-modules:     Common
                    , HexDump
+                   , Imports
   Hs-Source-Dirs:    src
   Build-Depends:     base >= 4 && < 5
                    , network

--- a/debug/tls-debug.cabal
+++ b/debug/tls-debug.cabal
@@ -18,6 +18,7 @@ Homepage:            http://github.com/vincenthz/hs-tls
 Executable           tls-stunnel
   Main-is:           Stunnel.hs
   Other-modules:     Common
+                   , Imports
   Hs-Source-Dirs:    src
   Build-Depends:     base >= 4 && < 5
                    , network

--- a/debug/tls-debug.cabal
+++ b/debug/tls-debug.cabal
@@ -74,6 +74,7 @@ Executable           tls-simpleclient
                    , cryptonite >= 0.14
                    , x509-system >= 1.0
                    , tls >= 1.3.6 && < 1.5
+                   , tls-session-manager
   Buildable:         True
   ghc-options:       -Wall -fno-warn-missing-signatures
 

--- a/session/ChangeLog.md
+++ b/session/ChangeLog.md
@@ -1,0 +1,2 @@
+# 0.0.0.0
+- A first release.

--- a/session/LICENSE
+++ b/session/LICENSE
@@ -1,0 +1,29 @@
+Copyright (c) 2017, IIJ Innovation Institute Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+  * Neither the name of the copyright holders nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/session/Network/TLS/Imports.hs
+++ b/session/Network/TLS/Imports.hs
@@ -1,0 +1,17 @@
+module Network.TLS.Imports (
+    module Control.Applicative
+  , module Control.Monad
+  , module Data.Int
+  , module Data.List
+  , module Data.Maybe
+  , module Data.Monoid
+  , module Data.Word
+  ) where
+
+import Control.Applicative
+import Control.Monad
+import Data.Int
+import Data.List
+import Data.Maybe
+import Data.Monoid
+import Data.Word

--- a/session/Network/TLS/SessionManager.hs
+++ b/session/Network/TLS/SessionManager.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE BangPatterns #-}
+
+-- | In-memory TLS session manager.
+--
+-- * Limitation: you can set the maximum size of the session data database.
+-- * Automatic pruning: old session data over their lifetime are pruned automatically.
+-- * Energy saving: no dedicate pruning thread is running when the size of session data database is zero.
+-- * (Replay resistance: each session data is used at most once to prevent replay attacks against 0RTT early data of TLS 1.3.)
+
+module Network.TLS.SessionManager (
+    Config(..)
+  , defaultConfig
+  , newSessionManager
+  ) where
+
+import Control.Exception (assert)
+import Control.Reaper
+import Data.IORef
+import Data.OrdPSQ (OrdPSQ)
+import qualified Data.OrdPSQ as Q
+import Network.TLS (SessionID, SessionData, SessionManager(..))
+import qualified System.Clock as C
+
+import Network.TLS.Imports
+
+----------------------------------------------------------------
+
+-- | Configuration for session managers.
+data Config = Config {
+    -- | Ticket lifetime in seconds.
+      ticketLifetime :: !Int
+    -- | Pruning delay in seconds. This is set to 'reaperDelay'.
+    , pruningDelay   :: !Int
+    -- | The limit size of session data entries.
+    , dbMaxSize      :: !Int
+    }
+
+-- | Lifetime: 1 day , delay: 10 minutes, limit: 10,000 entries.
+defaultConfig :: Config
+defaultConfig = Config {
+      ticketLifetime = 86400
+    , pruningDelay   = 6000
+    , dbMaxSize      = 10000
+    }
+
+----------------------------------------------------------------
+
+type Sec = Int64
+type Value = (SessionData, IORef Availability)
+type DB = OrdPSQ SessionID Sec Value
+type Item = (SessionID, Sec, Value, Operation)
+
+data Operation = Add | Del
+data Use = SingleUse | MultipleUse
+data Availability = Fresh | Used
+
+----------------------------------------------------------------
+
+-- | Creating an in-memory session manager.
+newSessionManager :: Config -> IO SessionManager
+newSessionManager conf = do
+    let lifetime = fromIntegral $ ticketLifetime conf
+        maxsiz = dbMaxSize conf
+    reaper <- mkReaper defaultReaperSettings {
+          reaperEmpty  = Q.empty
+        , reaperCons   = cons maxsiz
+        , reaperAction = clean
+        , reaperNull   = Q.null
+        , reaperDelay  = pruningDelay conf * 1000000
+        }
+    return SessionManager {
+        sessionResume     = resume reaper MultipleUse
+      , sessionEstablish  = establish reaper lifetime
+      , sessionInvalidate = invalidate reaper
+      }
+
+cons :: Int -> Item -> DB -> DB
+cons lim (k,t,v,Add) db
+  | lim <= 0            = Q.empty
+  | Q.size db == lim    = case Q.minView db of
+      Nothing          -> assert False $ Q.insert k t v Q.empty
+      Just (_,_,_,db') -> Q.insert k t v db'
+  | otherwise           = Q.insert k t v db
+cons _   (k,_,_,Del) db = Q.delete k db
+
+clean :: DB -> IO (DB -> DB)
+clean olddb = do
+    currentTime <- C.sec <$> C.getTime C.Monotonic
+    let !pruned = snd $ Q.atMostView currentTime olddb
+    return $ merge pruned
+  where
+    ins db (k,p,v) = Q.insert k p v db
+    -- There is not 'merge' API.
+    -- We hope that newdb is smaller than pruned.
+    merge pruned newdb = foldl' ins pruned entries
+      where
+        entries = Q.toList newdb
+
+----------------------------------------------------------------
+
+establish :: Reaper DB Item -> Sec
+          -> SessionID -> SessionData -> IO ()
+establish reaper lifetime k sd = do
+    ref <- newIORef Fresh
+    !p <- ((+ lifetime) . C.sec) <$> C.getTime C.Monotonic
+    let !v = (sd,ref)
+    reaperAdd reaper (k,p,v,Add)
+
+resume :: Reaper DB Item -> Use
+       -> SessionID -> IO (Maybe SessionData)
+resume reaper use k = do
+    db <- reaperRead reaper
+    case Q.lookup k db of
+      Nothing             -> return Nothing
+      Just (p,v@(sd,ref)) -> do
+           case use of
+               SingleUse -> do
+                   available <- atomicModifyIORef' ref check
+                   reaperAdd reaper (k,p,v,Del)
+                   return $ if available then Just sd else Nothing
+               MultipleUse -> return $ Just sd
+  where
+    check Fresh = (Used,True)
+    check Used  = (Used,False)
+
+invalidate :: Reaper DB Item
+           -> SessionID -> IO ()
+invalidate reaper k = do
+    db <- reaperRead reaper
+    case Q.lookup k db of
+      Nothing    -> return ()
+      Just (p,v) -> reaperAdd reaper (k,p,v,Del)

--- a/session/Setup.hs
+++ b/session/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/session/session/Network/TLS/Imports.hs
+++ b/session/session/Network/TLS/Imports.hs
@@ -1,0 +1,17 @@
+module Network.TLS.Imports (
+    module Control.Applicative
+  , module Control.Monad
+  , module Data.Int
+  , module Data.List
+  , module Data.Maybe
+  , module Data.Monoid
+  , module Data.Word
+  ) where
+
+import Control.Applicative
+import Control.Monad
+import Data.Int
+import Data.List
+import Data.Maybe
+import Data.Monoid
+import Data.Word

--- a/session/tls-session-manager.cabal
+++ b/session/tls-session-manager.cabal
@@ -1,0 +1,26 @@
+name:                tls-session-manager
+version:             0.0.0.2
+synopsis:            In-memory TLS session manager
+description:         TLS session manager with limitation, automatic pruning, energy saving and replay resistance
+license:             BSD3
+license-file:        LICENSE
+author:              Kazu Yamamoto
+maintainer:          kazu@iij.ad.jp
+-- copyright:
+category:            Web
+build-type:          Simple
+extra-source-files:  ChangeLog.md
+cabal-version:       >= 1.10
+
+library
+  exposed-modules:     Network.TLS.SessionManager
+  other-modules:       Network.TLS.Imports
+  -- other-extensions:
+  build-depends:       base >= 4.7 && < 5
+                     , auto-update
+                     , clock
+                     , psqueues >= 0.2.3
+                     , tls
+  -- hs-source-dirs:
+  default-language:    Haskell2010
+  ghc-options:       -Wall

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,7 @@ resolver: lts-9.0
 packages:
 - core/ 
 - debug/
+- session/
 extra-deps:
 - cryptonite-0.24
 flags: {}


### PR DESCRIPTION
This patches do:

- warnings are disappeared thanks to a big imports.
- `tls-simpleserver` loops. So, `--session` was deleted. `tls-session-manager` is used as a session manager.
- `getAddrInfo` is used for modern style.