### PR TITLE
IV length for AEAD ciphers

### DIFF
--- a/core/Tests/Ciphers.hs
+++ b/core/Tests/Ciphers.hs
@@ -16,7 +16,7 @@ arbitraryKey :: Bulk -> Gen B.ByteString
 arbitraryKey bulk = B.pack `fmap` vector (bulkKeySize bulk)
 
 arbitraryIV :: Bulk -> Gen B.ByteString
-arbitraryIV bulk = B.pack `fmap` vector (bulkIVSize bulk)
+arbitraryIV bulk = B.pack `fmap` vector (bulkIVSize bulk + bulkExplicitIV bulk)
 
 arbitraryText :: Bulk -> Gen B.ByteString
 arbitraryText bulk = B.pack `fmap` vector (bulkBlockSize bulk)

--- a/core/Tests/Ciphers.hs
+++ b/core/Tests/Ciphers.hs
@@ -13,13 +13,13 @@ import Network.TLS.Cipher
 import Network.TLS.Extra.Cipher
 
 arbitraryKey :: Bulk -> Gen B.ByteString
-arbitraryKey bulk = B.pack `fmap` vector (fromIntegral $ bulkKeySize bulk)
+arbitraryKey bulk = B.pack `fmap` vector (bulkKeySize bulk)
 
 arbitraryIV :: Bulk -> Gen B.ByteString
-arbitraryIV bulk = B.pack `fmap` vector (fromIntegral $ bulkIVSize bulk)
+arbitraryIV bulk = B.pack `fmap` vector (bulkIVSize bulk)
 
 arbitraryText :: Bulk -> Gen B.ByteString
-arbitraryText bulk = B.pack `fmap` vector (fromIntegral $ bulkBlockSize bulk)
+arbitraryText bulk = B.pack `fmap` vector (bulkBlockSize bulk)
 
 data BulkTest = BulkTest Bulk B.ByteString B.ByteString B.ByteString B.ByteString
     deriving (Show,Eq)


### PR DESCRIPTION
It looks the length is not correct in tests related to AES GCM ciphers.

Found this when testing addition of AES CCM with implementation from @wangbj.