### PR TITLE
 Compatibility with Semigroup/Monoid proposal

### DIFF
--- a/core/Network/TLS/Credentials.hs
+++ b/core/Network/TLS/Credentials.hs
@@ -5,6 +5,7 @@
 -- Stability   : experimental
 -- Portability : unknown
 --
+{-# LANGUAGE CPP #-}
 module Network.TLS.Credentials
     ( Credential
     , Credentials(..)
@@ -33,9 +34,16 @@ type Credential = (CertificateChain, PrivKey)
 
 newtype Credentials = Credentials [Credential]
 
+#if MIN_VERSION_base(4,9,0)
+instance Semigroup Credentials where
+    (Credentials l1) <> (Credentials l2) = Credentials (l1 ++ l2)
+#endif
+
 instance Monoid Credentials where
     mempty = Credentials []
+#if !(MIN_VERSION_base(4,11,0))
     mappend (Credentials l1) (Credentials l2) = Credentials (l1 ++ l2)
+#endif
 
 -- | try to create a new credential object from a public certificate
 -- and the associated private key that are stored on the filesystem

--- a/core/Network/TLS/Credentials.hs
+++ b/core/Network/TLS/Credentials.hs
@@ -36,7 +36,7 @@ newtype Credentials = Credentials [Credential]
 
 #if MIN_VERSION_base(4,9,0)
 instance Semigroup Credentials where
-    (Credentials l1) <> (Credentials l2) = Credentials (l1 ++ l2)
+    Credentials l1 <> Credentials l2 = Credentials (l1 ++ l2)
 #endif
 
 instance Monoid Credentials where

--- a/core/Network/TLS/Imports.hs
+++ b/core/Network/TLS/Imports.hs
@@ -19,7 +19,11 @@ module Network.TLS.Imports
     , module Data.Bits
     , module Data.List
     , module Data.Maybe
+#if MIN_VERSION_base(4,9,0)
+    , module Data.Semigroup
+#else
     , module Data.Monoid
+#endif
     , module Data.Ord
     , module Data.Word
 #if !MIN_VERSION_base(4,8,0)
@@ -37,7 +41,11 @@ import Control.Monad
 import Data.Bits
 import Data.List
 import Data.Maybe hiding (fromJust)
+#if MIN_VERSION_base(4,9,0)
+import Data.Semigroup
+#else
 import Data.Monoid
+#endif
 import Data.Ord
 import Data.Word
 

--- a/test-scripts/TestClient.hs
+++ b/test-scripts/TestClient.hs
@@ -312,7 +312,6 @@ main = do
         t2 (LowerBound TLS10)
             [ "www.google.com"
             , "www.facebook.com"
-            , "www.github.com"
             , "mail.office365.com"
             , "login.live.com"
             , "www.udacity.com"
@@ -320,4 +319,5 @@ main = do
             ] ++
         t2 (LowerBound TLS12)
             [ "developer.apple.com"
+            , "www.github.com"
             ]


### PR DESCRIPTION
Not all dependencies are ready yet but we should have compatibility with GHC 8.4 before any new release of `tls`.