### PR TITLE
Verify certificate key usage

### DIFF
--- a/core/Network/TLS/Handshake/Certificate.hs
+++ b/core/Network/TLS/Handshake/Certificate.hs
@@ -7,6 +7,7 @@
 --
 module Network.TLS.Handshake.Certificate
     ( certificateRejected
+    , badCertificate
     , rejectOnException
     ) where
 
@@ -26,6 +27,9 @@ certificateRejected CertificateRejectUnknownCA =
     throwCore $ Error_Protocol ("certificate has unknown CA", True, UnknownCa)
 certificateRejected (CertificateRejectOther s) =
     throwCore $ Error_Protocol ("certificate rejected: " ++ s, True, CertificateUnknown)
+
+badCertificate :: MonadIO m => String -> m a
+badCertificate msg = throwCore $ Error_Protocol (msg, True, BadCertificate)
 
 rejectOnException :: SomeException -> IO CertificateUsage
 rejectOnException e = return $ CertificateUsageReject $ CertificateRejectOther $ show e

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -479,7 +479,7 @@ recvClientData sparams ctx = runRecvState ctx (RecvStateHandshake processClientC
         processCertificateVerify (Handshake [hs@(CertVerify dsig)]) = do
             processHandshake ctx hs
 
-            checkValidClientCertChain "change cipher message expected"
+            certs <- checkValidClientCertChain "change cipher message expected"
 
             usedVersion <- usingState_ ctx getVersion
             -- Fetch all handshake messages up to now.
@@ -495,7 +495,6 @@ recvClientData sparams ctx = runRecvState ctx (RecvStateHandshake processClientC
                 -- When verification succeeds, commit the
                 -- client certificate chain to the context.
                 --
-                Just certs <- usingHState ctx getClientCertChain
                 usingState_ ctx $ setClientCertificateChain certs
                 return ()
               else do
@@ -510,7 +509,6 @@ recvClientData sparams ctx = runRecvState ctx (RecvStateHandshake processClientC
                         -- application callbacks accepts, we
                         -- also commit the client certificate
                         -- chain to the context.
-                        Just certs <- usingHState ctx getClientCertChain
                         usingState_ ctx $ setClientCertificateChain certs
                     else throwCore $ Error_Protocol ("verification failed", True, BadCertificate)
             return $ RecvStateNext expectChangeCipher
@@ -545,7 +543,7 @@ recvClientData sparams ctx = runRecvState ctx (RecvStateHandshake processClientC
             case chain of
                 Nothing -> throwCore throwerror
                 Just cc | isNullCertificateChain cc -> throwCore throwerror
-                        | otherwise                 -> return ()
+                        | otherwise                 -> return cc
 
 hashAndSignaturesInCommon :: Context -> [ExtensionRaw] -> [HashAndSignatureAlgorithm]
 hashAndSignaturesInCommon ctx exts =

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -510,7 +510,7 @@ recvClientData sparams ctx = runRecvState ctx (RecvStateHandshake processClientC
                         -- also commit the client certificate
                         -- chain to the context.
                         usingState_ ctx $ setClientCertificateChain certs
-                    else throwCore $ Error_Protocol ("verification failed", True, BadCertificate)
+                    else badCertificate "verification failed"
             return $ RecvStateNext expectChangeCipher
 
         processCertificateVerify p = do

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -316,6 +316,10 @@ data ServerHooks = ServerHooks
       -- | This action is called when a client certificate chain
       -- is received from the client.  When it returns a
       -- CertificateUsageReject value, the handshake is aborted.
+      --
+      -- The function is not expected to verify the key-usage
+      -- extension of the certificate.  This verification is
+      -- performed by the library internally.
       onClientCertificate :: CertificateChain -> IO CertificateUsage
 
       -- | This action is called when the client certificate

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -281,6 +281,11 @@ data ClientHooks = ClientHooks
       -- implementation calls 'validateDefault' which validates according to the
       -- default hooks and checks provided by "Data.X509.Validation".  This can
       -- be replaced with a custom validation function using different settings.
+      --
+      -- The function is not expected to verify the key-usage extension of the
+      -- end-entity certificate, as this depends on the dynamically-selected
+      -- cipher and this part should not be cached.  Key-usage verification
+      -- is performed by the library internally.
     , onServerCertificate  :: CertificateStore -> ValidationCache -> ServiceID -> CertificateChain -> IO [FailedReason]
       -- | This action is called when the client sends ClientHello
       --   to determine ALPN values such as '["h2", "http/1.1"]'.

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -6,9 +6,11 @@ module Connection
     , arbitraryVersions
     , arbitraryHashSignatures
     , arbitraryGroups
+    , arbitraryKeyUsage
     , arbitraryPairParams
     , arbitraryPairParamsWithVersionsAndCiphers
     , arbitraryClientCredential
+    , arbitraryRSACredentialWithUsage
     , isCustomDHParams
     , leafPublicKey
     , oneSessionManager
@@ -174,6 +176,12 @@ arbitraryPairParamsWithVersionsAndCiphers (clientVersions, serverVersions) (clie
 
 arbitraryClientCredential :: Gen Credential
 arbitraryClientCredential = arbitraryCredentialsOfEachType >>= elements
+
+arbitraryRSACredentialWithUsage :: [ExtKeyUsageFlag] -> Gen (CertificateChain, PrivKey)
+arbitraryRSACredentialWithUsage usageFlags = do
+    let (pubKey, privKey) = getGlobalRSAPair
+    cert <- arbitraryX509WithKeyAndUsage usageFlags (PubKeyRSA pubKey, ())
+    return (CertificateChain [cert], PrivKeyRSA privKey)
 
 -- | simple session manager to store one session id and session data for a single thread.
 -- a Real concurrent session manager would use an MVar and have multiples items.


### PR DESCRIPTION
This is to address one issue reported in #155:
```
 FAIL certificate has invalid key usage for HTTPS connection [reject bad-key-usage.badtls.io:11005]
      output: 200 OK
```
