### PR TITLE
Renaming for TLS 1.3

### DIFF
--- a/core/Network/TLS/Credentials.hs
+++ b/core/Network/TLS/Credentials.hs
@@ -144,9 +144,9 @@ getHashSignature signed =
         SignatureALG hashAlg PubKeyALG_DSA    -> convertHash TLS.SignatureDSS   hashAlg
         SignatureALG hashAlg PubKeyALG_EC     -> convertHash TLS.SignatureECDSA hashAlg
 
-        SignatureALG X509.HashSHA256 PubKeyALG_RSAPSS -> Just (TLS.HashIntrinsic, TLS.SignatureRSApssSHA256)
-        SignatureALG X509.HashSHA384 PubKeyALG_RSAPSS -> Just (TLS.HashIntrinsic, TLS.SignatureRSApssSHA384)
-        SignatureALG X509.HashSHA512 PubKeyALG_RSAPSS -> Just (TLS.HashIntrinsic, TLS.SignatureRSApssSHA512)
+        SignatureALG X509.HashSHA256 PubKeyALG_RSAPSS -> Just (TLS.HashIntrinsic, TLS.SignatureRSApssRSAeSHA256)
+        SignatureALG X509.HashSHA384 PubKeyALG_RSAPSS -> Just (TLS.HashIntrinsic, TLS.SignatureRSApssRSAeSHA384)
+        SignatureALG X509.HashSHA512 PubKeyALG_RSAPSS -> Just (TLS.HashIntrinsic, TLS.SignatureRSApssRSAeSHA512)
 
         _                                     -> Nothing
   where

--- a/core/Network/TLS/Handshake/Process.hs
+++ b/core/Network/TLS/Handshake/Process.hs
@@ -106,7 +106,7 @@ processClientKeyXchg ctx (CKX_ECDH bytes) = do
     case decodeGroupPublic grp bytes of
       Left _ -> throwCore $ Error_Protocol ("client public key cannot be decoded", True, HandshakeFailure)
       Right clipub -> do
-          srvpri <- usingHState ctx getECDHPrivate
+          srvpri <- usingHState ctx getGroupPrivate
           case groupGetShared clipub srvpri of
               Just premaster -> do
                   rver <- usingState_ ctx getVersion

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -419,7 +419,7 @@ doHandshake sparams mcred ctx chosenVersion usedCipher usedCompression clientSes
             (srvpri, srvpub) <- generateECDHE ctx grp
             let serverParams = ServerECDHParams grp srvpub
             usingHState ctx $ setServerECDHParams serverParams
-            usingHState ctx $ setECDHPrivate srvpri
+            usingHState ctx $ setGroupPrivate srvpri
             return serverParams
 
         generateSKX_ECDHE sigAlg = do

--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -31,13 +31,13 @@ import Network.TLS.Util
 import Control.Monad.State.Strict
 
 signatureCompatible :: DigitalSignatureAlg -> HashAndSignatureAlgorithm -> Bool
-signatureCompatible RSA   (_, SignatureRSA)          = True
-signatureCompatible RSA   (_, SignatureRSApssSHA256) = True
-signatureCompatible RSA   (_, SignatureRSApssSHA384) = True
-signatureCompatible RSA   (_, SignatureRSApssSHA512) = True
-signatureCompatible DSS   (_, SignatureDSS)          = True
-signatureCompatible ECDSA (_, SignatureECDSA)        = True
-signatureCompatible _     (_, _)                     = False
+signatureCompatible RSA   (_, SignatureRSA)              = True
+signatureCompatible RSA   (_, SignatureRSApssRSAeSHA256) = True
+signatureCompatible RSA   (_, SignatureRSApssRSAeSHA384) = True
+signatureCompatible RSA   (_, SignatureRSApssRSAeSHA512) = True
+signatureCompatible DSS   (_, SignatureDSS)              = True
+signatureCompatible ECDSA (_, SignatureECDSA)            = True
+signatureCompatible _     (_, _)                         = False
 
 checkCertificateVerify :: Context
                        -> Version
@@ -101,9 +101,9 @@ signatureParams RSA hashSigAlg =
         Just (HashSHA384, SignatureRSA) -> RSAParams SHA384   RSApkcs1
         Just (HashSHA256, SignatureRSA) -> RSAParams SHA256   RSApkcs1
         Just (HashSHA1  , SignatureRSA) -> RSAParams SHA1     RSApkcs1
-        Just (HashIntrinsic , SignatureRSApssSHA512) -> RSAParams SHA512 RSApss
-        Just (HashIntrinsic , SignatureRSApssSHA384) -> RSAParams SHA384 RSApss
-        Just (HashIntrinsic , SignatureRSApssSHA256) -> RSAParams SHA256 RSApss
+        Just (HashIntrinsic , SignatureRSApssRSAeSHA512) -> RSAParams SHA512 RSApss
+        Just (HashIntrinsic , SignatureRSApssRSAeSHA384) -> RSAParams SHA384 RSApss
+        Just (HashIntrinsic , SignatureRSApssRSAeSHA256) -> RSAParams SHA256 RSApss
         Nothing                         -> RSAParams SHA1_MD5 RSApkcs1
         Just (hsh       , SignatureRSA) -> error ("unimplemented RSA signature hash type: " ++ show hsh)
         Just (_         , sigAlg)       -> error ("signature algorithm is incompatible with RSA: " ++ show sigAlg)

--- a/core/Network/TLS/Handshake/State.hs
+++ b/core/Network/TLS/Handshake/State.hs
@@ -25,8 +25,8 @@ module Network.TLS.Handshake.State
     , getServerECDHParams
     , setDHPrivate
     , getDHPrivate
-    , setECDHPrivate
-    , getECDHPrivate
+    , setGroupPrivate
+    , getGroupPrivate
     -- * cert accessors
     , setClientCertSent
     , getClientCertSent
@@ -76,7 +76,7 @@ data HandshakeState = HandshakeState
     , hstServerDHParams      :: !(Maybe ServerDHParams)
     , hstDHPrivate           :: !(Maybe DHPrivate)
     , hstServerECDHParams    :: !(Maybe ServerECDHParams)
-    , hstECDHPrivate         :: !(Maybe GroupPrivate)
+    , hstGroupPrivate        :: !(Maybe GroupPrivate)
     , hstHandshakeDigest     :: !(Either [ByteString] HashCtx)
     , hstHandshakeMessages   :: [ByteString]
     , hstClientCertRequest   :: !(Maybe ClientCertRequestData) -- ^ Set to Just-value when certificate request was received
@@ -114,7 +114,7 @@ newEmptyHandshake ver crand = HandshakeState
     , hstServerDHParams      = Nothing
     , hstDHPrivate           = Nothing
     , hstServerECDHParams    = Nothing
-    , hstECDHPrivate         = Nothing
+    , hstGroupPrivate        = Nothing
     , hstHandshakeDigest     = Left []
     , hstHandshakeMessages   = []
     , hstClientCertRequest   = Nothing
@@ -159,14 +159,14 @@ setServerECDHParams shp = modify (\hst -> hst { hstServerECDHParams = Just shp }
 getDHPrivate :: HandshakeM DHPrivate
 getDHPrivate = fromJust "server DH private" <$> gets hstDHPrivate
 
-getECDHPrivate :: HandshakeM GroupPrivate
-getECDHPrivate = fromJust "server ECDH private" <$> gets hstECDHPrivate
+getGroupPrivate :: HandshakeM GroupPrivate
+getGroupPrivate = fromJust "server ECDH private" <$> gets hstGroupPrivate
 
 setDHPrivate :: DHPrivate -> HandshakeM ()
 setDHPrivate shp = modify (\hst -> hst { hstDHPrivate = Just shp })
 
-setECDHPrivate :: GroupPrivate -> HandshakeM ()
-setECDHPrivate shp = modify (\hst -> hst { hstECDHPrivate = Just shp })
+setGroupPrivate :: GroupPrivate -> HandshakeM ()
+setGroupPrivate shp = modify (\hst -> hst { hstGroupPrivate = Just shp })
 
 setCertReqSent :: Bool -> HandshakeM ()
 setCertReqSent b = modify (\hst -> hst { hstCertReqSent = b })

--- a/core/Network/TLS/Struct.hs
+++ b/core/Network/TLS/Struct.hs
@@ -230,11 +230,14 @@ data AlertDescription =
     | InappropriateFallback -- RFC7507
     | UserCanceled
     | NoRenegotiation
+    | MissingExtension
     | UnsupportedExtension
     | CertificateUnobtainable
     | UnrecognizedName
     | BadCertificateStatusResponse
     | BadCertificateHashValue
+    | UnknownPskIdentity
+    | CertificateRequired
     deriving (Show,Eq)
 
 data HandshakeType =
@@ -456,11 +459,14 @@ instance TypeValuable AlertDescription where
     valOfType InappropriateFallback  = 86
     valOfType UserCanceled           = 90
     valOfType NoRenegotiation        = 100
+    valOfType MissingExtension       = 109
     valOfType UnsupportedExtension   = 110
     valOfType CertificateUnobtainable = 111
     valOfType UnrecognizedName        = 112
     valOfType BadCertificateStatusResponse = 113
     valOfType BadCertificateHashValue = 114
+    valOfType UnknownPskIdentity      = 115
+    valOfType CertificateRequired     = 116
 
     valToType 0   = Just CloseNotify
     valToType 10  = Just UnexpectedMessage
@@ -486,11 +492,14 @@ instance TypeValuable AlertDescription where
     valToType 86  = Just InappropriateFallback
     valToType 90  = Just UserCanceled
     valToType 100 = Just NoRenegotiation
+    valToType 109 = Just MissingExtension
     valToType 110 = Just UnsupportedExtension
     valToType 111 = Just CertificateUnobtainable
     valToType 112 = Just UnrecognizedName
     valToType 113 = Just BadCertificateStatusResponse
     valToType 114 = Just BadCertificateHashValue
+    valToType 115 = Just UnknownPskIdentity
+    valToType 116 = Just CertificateRequired
     valToType _   = Nothing
 
 instance TypeValuable CertificateType where

--- a/core/Network/TLS/Struct.hs
+++ b/core/Network/TLS/Struct.hs
@@ -110,11 +110,14 @@ data SignatureAlgorithm =
     | SignatureRSA
     | SignatureDSS
     | SignatureECDSA
-    | SignatureRSApssSHA256
-    | SignatureRSApssSHA384
-    | SignatureRSApssSHA512
+    | SignatureRSApssRSAeSHA256
+    | SignatureRSApssRSAeSHA384
+    | SignatureRSApssRSAeSHA512
     | SignatureEd25519
     | SignatureEd448
+    | SignatureRSApsspssSHA256
+    | SignatureRSApsspssSHA384
+    | SignatureRSApsspssSHA512
     | SignatureOther Word8
     deriving (Show,Eq)
 
@@ -531,27 +534,33 @@ instance TypeValuable HashAlgorithm where
     valToType i = Just (HashOther i)
 
 instance TypeValuable SignatureAlgorithm where
-    valOfType SignatureAnonymous    = 0
-    valOfType SignatureRSA          = 1
-    valOfType SignatureDSS          = 2
-    valOfType SignatureECDSA        = 3
-    valOfType SignatureRSApssSHA256 = 4
-    valOfType SignatureRSApssSHA384 = 5
-    valOfType SignatureRSApssSHA512 = 6
-    valOfType SignatureEd25519      = 7
-    valOfType SignatureEd448        = 8
-    valOfType (SignatureOther i)    = i
+    valOfType SignatureAnonymous        =  0
+    valOfType SignatureRSA              =  1
+    valOfType SignatureDSS              =  2
+    valOfType SignatureECDSA            =  3
+    valOfType SignatureRSApssRSAeSHA256 =  4
+    valOfType SignatureRSApssRSAeSHA384 =  5
+    valOfType SignatureRSApssRSAeSHA512 =  6
+    valOfType SignatureEd25519          =  7
+    valOfType SignatureEd448            =  8
+    valOfType SignatureRSApsspssSHA256  =  9
+    valOfType SignatureRSApsspssSHA384  = 10
+    valOfType SignatureRSApsspssSHA512  = 11
+    valOfType (SignatureOther i)        =  i
 
-    valToType 0 = Just SignatureAnonymous
-    valToType 1 = Just SignatureRSA
-    valToType 2 = Just SignatureDSS
-    valToType 3 = Just SignatureECDSA
-    valToType 4 = Just SignatureRSApssSHA256
-    valToType 5 = Just SignatureRSApssSHA384
-    valToType 6 = Just SignatureRSApssSHA512
-    valToType 7 = Just SignatureEd25519
-    valToType 8 = Just SignatureEd448
-    valToType i = Just (SignatureOther i)
+    valToType  0 = Just SignatureAnonymous
+    valToType  1 = Just SignatureRSA
+    valToType  2 = Just SignatureDSS
+    valToType  3 = Just SignatureECDSA
+    valToType  4 = Just SignatureRSApssRSAeSHA256
+    valToType  5 = Just SignatureRSApssRSAeSHA384
+    valToType  6 = Just SignatureRSApssRSAeSHA512
+    valToType  7 = Just SignatureEd25519
+    valToType  8 = Just SignatureEd448
+    valToType  9 = Just SignatureRSApsspssSHA256
+    valToType 10 = Just SignatureRSApsspssSHA384
+    valToType 11 = Just SignatureRSApsspssSHA512
+    valToType  i = Just (SignatureOther i)
 
 instance EnumSafe16 Group where
     fromEnumSafe16 P256      =  23

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -64,7 +64,7 @@ arbitraryVersions = sublistOf knownVersions
 knownHashSignatures :: [HashAndSignatureAlgorithm]
 knownHashSignatures = filter nonECDSA availableHashSignatures
   where
-    availableHashSignatures = [(TLS.HashIntrinsic, SignatureRSApssSHA256)
+    availableHashSignatures = [(TLS.HashIntrinsic, SignatureRSApssRSAeSHA256)
                               ,(TLS.HashSHA512, SignatureRSA)
                               ,(TLS.HashSHA512, SignatureECDSA)
                               ,(TLS.HashSHA384, SignatureRSA)


### PR DESCRIPTION
TLS 1.3 changes some technical terms.
This PR catches up it.
Also, this PR adds new alerts.