### PR TITLE
Use async in test suite

### DIFF
--- a/core/Benchmarks/Benchmarks.hs
+++ b/core/Benchmarks/Benchmarks.hs
@@ -63,9 +63,9 @@ runTLSPipe :: (ClientParams, ServerParams)
            -> a
            -> IO b
 runTLSPipe params tlsServer tlsClient d = do
-    (startQueue, resultQueue) <- establishDataPipe params tlsServer tlsClient
-    writeChan startQueue d
-    readChan resultQueue
+    (writeStart, readResult) <- establishDataPipe params tlsServer tlsClient
+    writeStart d
+    readResult
 
 runTLSPipeSimple :: (ClientParams, ServerParams) -> B.ByteString -> IO B.ByteString
 runTLSPipeSimple params bs = runTLSPipe params tlsServer tlsClient bs

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -264,7 +264,7 @@ establishDataPipe :: (ClientParams, ServerParams) -> (Context -> Chan result -> 
 establishDataPipe params tlsServer tlsClient = do
     -- initial setup
     pipe        <- newPipe
-    _           <- (runPipe pipe)
+    _           <- runPipe pipe
     startQueue  <- newChan
     resultQueue <- newChan
 
@@ -287,7 +287,7 @@ initiateDataPipe :: (ClientParams, ServerParams) -> (Context -> IO a1) -> (Conte
 initiateDataPipe params tlsServer tlsClient = do
     -- initial setup
     pipe        <- newPipe
-    _           <- (runPipe pipe)
+    _           <- runPipe pipe
     cQueue      <- newChan
     sQueue      <- newChan
 

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -261,7 +261,7 @@ newPairContext pipe (cParams, sParams) = do
                                     , loggingPacketRecv = putStrLn . ((pre ++ "<< ") ++) }
                 else def
 
-establishDataPipe :: (ClientParams, ServerParams) -> (Context -> Chan result -> IO ()) -> (Chan start -> Context -> IO ()) -> IO (Chan start, Chan result)
+establishDataPipe :: (ClientParams, ServerParams) -> (Context -> Chan result -> IO ()) -> (Chan start -> Context -> IO ()) -> IO (start -> IO (), IO result)
 establishDataPipe params tlsServer tlsClient = do
     -- initial setup
     pipe        <- newPipe
@@ -276,7 +276,7 @@ establishDataPipe params tlsServer tlsClient = do
     _ <- forkIO $ E.catch (tlsClient startQueue cCtx)
                           (printAndRaise "client" (clientSupported $ fst params))
 
-    return (startQueue, resultQueue)
+    return (writeChan startQueue, readChan resultQueue)
   where
         printAndRaise :: String -> Supported -> E.SomeException -> IO ()
         printAndRaise s supported e = do

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -88,7 +88,7 @@ runTLSPipeSimple13 params modes mEarlyData = runTLSPipe params tlsServer tlsClie
             d <- recvDataNonNull ctx
             writeChan queue d
             minfo <- contextGetInformation ctx
-            (minfo >>= infoTLS13HandshakeMode) `assertEq` Just (snd modes)
+            Just (snd modes) `assertEq` (minfo >>= infoTLS13HandshakeMode)
             when (isJust mEarlyData) $ do
                 d' <- recvDataNonNull ctx
                 writeChan queue d'

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -88,7 +88,7 @@ runTLSPipeSimple13 params modes mEarlyData = runTLSPipe params tlsServer tlsClie
             d <- recvDataNonNull ctx
             writeChan queue d
             minfo <- contextGetInformation ctx
-            join (infoTLS13HandshakeMode <$> minfo) `assertEq` Just (snd modes)
+            (minfo >>= infoTLS13HandshakeMode) `assertEq` Just (snd modes)
             when (isJust mEarlyData) $ do
                 d' <- recvDataNonNull ctx
                 writeChan queue d'
@@ -98,7 +98,7 @@ runTLSPipeSimple13 params modes mEarlyData = runTLSPipe params tlsServer tlsClie
             d <- readChan queue
             sendData ctx (L.fromChunks [d])
             minfo <- contextGetInformation ctx
-            Just (fst modes) `assertEq` join (infoTLS13HandshakeMode <$> minfo)
+            Just (fst modes) `assertEq` (minfo >>= infoTLS13HandshakeMode)
             bye ctx
             return ()
 

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -57,13 +57,13 @@ runTLSPipe params tlsServer tlsClient mEarlyData = do
     d <- B.pack <$> pick (someWords8 256)
     run $ writeStart d
     -- receive it
-    dres <- run $ timeout 10000000 readResult
+    dres <- run $ timeout 60000000 readResult -- 60 sec
     -- check if it equal
     case mEarlyData of
       Nothing -> Just d `assertEq` dres
       Just ed -> do
           Just ed `assertEq` dres
-          dres' <- run $ timeout 10000000 readResult
+          dres' <- run $ timeout 60000000 readResult -- 60 sec
           Just d `assertEq` dres'
     return ()
 

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -170,6 +170,7 @@ Benchmark bench-tls
                    , mtl
                    , bytestring
                    , asn1-types
+                   , async >= 2.0
                    , hourglass
                    , QuickCheck >= 2
                    , tasty-quickcheck

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -141,6 +141,7 @@ Test-Suite test-tls
                      PubKey
   Build-Depends:     base >= 3 && < 5
                    , mtl
+                   , async >= 2.0
                    , cereal >= 0.3
                    , data-default-class
                    , tasty


### PR DESCRIPTION
As mentioned previously, using async we can make sure exceptions in tlsClient/tlsServer are rethrown to the main thread. Failures interrupt the timeout and test results are reported faster.

I also increase the timeout to 1 min, hoping to resolve #252 and #281.