### PR TITLE
Add infoNegotiatedGroup for all versions

### DIFF
--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -142,19 +142,19 @@ contextGetInformation :: Context -> IO (Maybe Information)
 contextGetInformation ctx = do
     ver    <- usingState_ ctx $ gets stVersion
     hstate <- getHState ctx
-    let (ms, cr, sr, hm13, grp13) = case hstate of
+    let (ms, cr, sr, hm13, grp) = case hstate of
                            Just st -> (hstMasterSecret st,
                                        Just (hstClientRandom st),
                                        hstServerRandom st,
                                        if ver == Just TLS13 then Just (hstTLS13HandshakeMode st) else Nothing,
-                                       hstTLS13Group st)
+                                       hstNegotiatedGroup st)
                            Nothing -> (Nothing, Nothing, Nothing, Nothing, Nothing)
     (cipher,comp) <- failOnEitherError $ runRxState ctx $ gets $ \st -> (stCipher st, stCompression st)
     let accepted = case hstate of
             Just st -> hstTLS13RTT0Status st == RTT0Accepted
             Nothing -> False
     case (ver, cipher) of
-        (Just v, Just c) -> return $ Just $ Information v c comp ms cr sr grp13 hm13 accepted
+        (Just v, Just c) -> return $ Just $ Information v c comp ms cr sr grp hm13 accepted
         _                -> return Nothing
 
 contextSend :: Context -> ByteString -> IO ()

--- a/core/Network/TLS/Handshake/Common.hs
+++ b/core/Network/TLS/Handshake/Common.hs
@@ -71,6 +71,7 @@ handshakeTerminate ctx = do
                 return $ Just (newEmptyHandshake (hstClientVersion hshake) (hstClientRandom hshake))
                     { hstServerRandom = hstServerRandom hshake
                     , hstMasterSecret = hstMasterSecret hshake
+                    , hstNegotiatedGroup = hstNegotiatedGroup hshake
                     }
     updateMeasure ctx resetBytesCounters
     -- mark the secure connection up and running.

--- a/core/Network/TLS/Handshake/Common13.hs
+++ b/core/Network/TLS/Handshake/Common13.hs
@@ -239,7 +239,7 @@ getSessionData13 ctx usedCipher tinfo maxSize psk = do
     ver   <- usingState_ ctx getVersion
     malpn <- usingState_ ctx getNegotiatedProtocol
     sni   <- usingState_ ctx getClientSNI
-    mgrp  <- usingHState ctx getTLS13Group
+    mgrp  <- usingHState ctx getNegotiatedGroup
     return SessionData {
         sessionVersion     = ver
       , sessionCipher      = cipherID usedCipher

--- a/core/Network/TLS/Handshake/State.hs
+++ b/core/Network/TLS/Handshake/State.hs
@@ -51,8 +51,8 @@ module Network.TLS.Handshake.State
     -- * misc accessor
     , getPendingCipher
     , setServerHelloParameters
-    , setTLS13Group
-    , getTLS13Group
+    , setNegotiatedGroup
+    , getNegotiatedGroup
     , setTLS13HandshakeMode
     , getTLS13HandshakeMode
     , setTLS13RTT0Status
@@ -107,7 +107,7 @@ data HandshakeState = HandshakeState
     , hstPendingRxState      :: Maybe RecordState
     , hstPendingCipher       :: Maybe Cipher
     , hstPendingCompression  :: Compression
-    , hstTLS13Group          :: Maybe Group
+    , hstNegotiatedGroup     :: Maybe Group
     , hstTLS13HandshakeMode  :: HandshakeMode13
     , hstTLS13RTT0Status     :: !RTT0Status
     , hstTLS13HandshakeMsgs  :: [Handshake13]
@@ -150,7 +150,7 @@ newEmptyHandshake ver crand = HandshakeState
     , hstPendingRxState      = Nothing
     , hstPendingCipher       = Nothing
     , hstPendingCompression  = nullCompression
-    , hstTLS13Group          = Nothing
+    , hstNegotiatedGroup     = Nothing
     , hstTLS13HandshakeMode  = FullHandshake
     , hstTLS13RTT0Status     = RTT0None
     , hstTLS13HandshakeMsgs  = []
@@ -198,11 +198,11 @@ getGroupPrivate = fromJust "server ECDH private" <$> gets hstGroupPrivate
 setGroupPrivate :: GroupPrivate -> HandshakeM ()
 setGroupPrivate shp = modify (\hst -> hst { hstGroupPrivate = Just shp })
 
-setTLS13Group :: Group -> HandshakeM ()
-setTLS13Group g = modify (\hst -> hst { hstTLS13Group = Just g })
+setNegotiatedGroup :: Group -> HandshakeM ()
+setNegotiatedGroup g = modify (\hst -> hst { hstNegotiatedGroup = Just g })
 
-getTLS13Group :: HandshakeM (Maybe Group)
-getTLS13Group = gets hstTLS13Group
+getNegotiatedGroup :: HandshakeM (Maybe Group)
+getNegotiatedGroup = gets hstNegotiatedGroup
 
 -- | Type to show which handshake mode is used in TLS 1.3.
 data HandshakeMode13 =

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -90,9 +90,10 @@ knownHashSignatures = filter nonECDSA availableHashSignatures
 arbitraryHashSignatures :: Gen [HashAndSignatureAlgorithm]
 arbitraryHashSignatures = sublistOf knownHashSignatures
 
+-- for performance reason P521, FFDHE6144, FFDHE8192 are not tested
 knownGroups, knownECGroups, knownFFGroups :: [Group]
-knownECGroups = [P256,P384,P521,X25519,X448]
-knownFFGroups = [FFDHE2048,FFDHE3072,FFDHE4096,FFDHE6144,FFDHE8192]
+knownECGroups = [P256,P384,X25519,X448]
+knownFFGroups = [FFDHE2048,FFDHE3072,FFDHE4096]
 knownGroups   = knownECGroups ++ knownFFGroups
 
 arbitraryGroups :: Gen [Group]

--- a/debug/src/Common.hs
+++ b/debug/src/Common.hs
@@ -110,8 +110,8 @@ printHandshakeInfo ctx = do
             putStrLn ("version: " ++ show (infoVersion i))
             putStrLn ("cipher: " ++ show (infoCipher i))
             putStrLn ("compression: " ++ show (infoCompression i))
+            putStrLn ("group: " ++ maybe "(none)" show (infoNegotiatedGroup i))
             when (infoVersion i == TLS13) $ do
-                putStrLn ("group: " ++ show (fromJust (infoNegotiatedGroup i)))
                 putStrLn ("handshake emode: " ++ show (fromJust (infoTLS13HandshakeMode i)))
                 putStrLn ("early data accepted: " ++ show (infoIsEarlyDataAccepted i))
     sni <- getClientSNI ctx

--- a/debug/src/Common.hs
+++ b/debug/src/Common.hs
@@ -6,6 +6,7 @@ module Common
     , readNumber
     , readCiphers
     , readDHParams
+    , readGroups
     , printHandshakeInfo
     , makeAddrInfo
     , AddrInfo(..)
@@ -38,6 +39,20 @@ namedCiphersuites =
     , ("strong",    map cipherID ciphersuite_strong)
     ]
 
+namedGroups :: [(String, Group)]
+namedGroups =
+    [ ("ffdhe2048", FFDHE2048)
+    , ("ffdhe3072", FFDHE3072)
+    , ("ffdhe4096", FFDHE4096)
+    , ("ffdhe6144", FFDHE6144)
+    , ("ffdhe8192", FFDHE8192)
+    , ("p256", P256)
+    , ("p384", P384)
+    , ("p521", P521)
+    , ("x25519", X25519)
+    , ("x448", X448)
+    ]
+
 readNumber :: (Num a, Read a) => String -> Maybe a
 readNumber s
     | all isDigit s = Just $ read s
@@ -54,6 +69,9 @@ readDHParams s =
     case lookup s namedDHParams of
         Nothing -> (Just . read) `fmap` readFile s
         mparams -> return mparams
+
+readGroups :: String -> Maybe [Group]
+readGroups s = traverse (`lookup` namedGroups) (split ',' s)
 
 printCiphers :: IO ()
 printCiphers = do
@@ -102,3 +120,10 @@ makeAddrInfo maddr port = do
           , addrSocketType = Stream
           }
     head <$> getAddrInfo (Just hints) maddr (Just $ show port)
+
+split :: Char -> String -> [String]
+split _ "" = []
+split c s = case break (c==) s of
+    ("",r)  -> split c (tail r)
+    (s',"") -> [s']
+    (s',r)  -> s' : split c (tail r)

--- a/debug/src/Common.hs
+++ b/debug/src/Common.hs
@@ -3,6 +3,7 @@
 module Common
     ( printCiphers
     , printDHParams
+    , printGroups
     , readNumber
     , readCiphers
     , readDHParams
@@ -94,6 +95,12 @@ printDHParams = do
     putStrLn "====================================="
     forM_ namedDHParams $ \(name, _) -> putStrLn name
     putStrLn "(or /path/to/dhparams)"
+
+printGroups :: IO ()
+printGroups = do
+    putStrLn "Groups"
+    putStrLn "====================================="
+    forM_ namedGroups $ \(name, _) -> putStrLn name
 
 printHandshakeInfo ctx = do
     info <- contextGetInformation ctx

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -155,6 +155,7 @@ data Flag = Verbose | Debug | IODebug | NoValidateCert | Session | Http11
           | BenchData String
           | UseCipher String
           | ListCiphers
+          | ListGroups
           | DebugSeed String
           | DebugPrintSeed
           | Group String
@@ -191,6 +192,7 @@ options =
     , Option []     ["bench-data"] (ReqArg BenchData "amount") "amount of data to benchmark with"
     , Option []     ["use-cipher"] (ReqArg UseCipher "cipher-id") "use a specific cipher"
     , Option []     ["list-ciphers"] (NoArg ListCiphers) "list all ciphers supported and exit"
+    , Option []     ["list-groups"] (NoArg ListGroups) "list all groups supported and exit"
     , Option []     ["debug-seed"] (ReqArg DebugSeed "debug-seed") "debug: set a specific seed for randomness"
     , Option []     ["debug-print-seed"] (NoArg DebugPrintSeed) "debug: set a specific seed for randomness"
     ]
@@ -326,6 +328,10 @@ main = do
 
     when (ListCiphers `elem` opts) $ do
         printCiphers
+        exitSuccess
+
+    when (ListGroups `elem` opts) $ do
+        printGroups
         exitSuccess
 
     certStore <- getSystemCertificateStore

--- a/debug/src/SimpleServer.hs
+++ b/debug/src/SimpleServer.hs
@@ -147,6 +147,7 @@ data Flag = Verbose | Debug | IODebug | NoValidateCert | Http11
           | BenchData String
           | UseCipher String
           | ListCiphers
+          | ListGroups
           | ListDHParams
           | Certificate String
           | Key String
@@ -183,6 +184,7 @@ options =
     , Option []     ["bench-data"] (ReqArg BenchData "amount") "amount of data to benchmark with"
     , Option []     ["use-cipher"] (ReqArg UseCipher "cipher-id") "use a specific cipher"
     , Option []     ["list-ciphers"] (NoArg ListCiphers) "list all ciphers supported and exit"
+    , Option []     ["list-groups"] (NoArg ListGroups) "list all groups supported and exit"
     , Option []     ["list-dhparams"] (NoArg ListDHParams) "list all DH parameters supported and exit"
     , Option []     ["certificate"] (ReqArg Certificate "certificate") "certificate file"
     , Option []     ["debug-seed"] (ReqArg DebugSeed "debug-seed") "debug: set a specific seed for randomness"
@@ -328,6 +330,10 @@ main = do
 
     when (ListDHParams `elem` opts) $ do
         printDHParams
+        exitSuccess
+
+    when (ListGroups `elem` opts) $ do
+        printGroups
         exitSuccess
 
     certStore <- getSystemCertificateStore


### PR DESCRIPTION
This sets `infoNegotiatedGroup` to the FFDHE or ECDHE group for all TLS versions and adds a few improvements related to groups in the test suite and tls-debug utilities.