### PR TITLE
TLS 1.3 client authentication in the client side

### DIFF
--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 -- |
 -- Module      : Network.TLS.Handshake.Client
@@ -281,7 +282,143 @@ handshakeClient' cparams ctx groups mcrand = do
                         _ -> fail ("unexepected type received. expecting handshake and got: " ++ show p)
                 throwAlert a = usingState_ ctx $ throwError $ Error_Protocol ("expecting server hello, got alert : " ++ show a, True, HandshakeFailure)
 
--- | send client Data after receiving all server data (hello/certificates/key).
+-- | When the server requests a client certificate, we try to
+-- obtain a suitable certificate chain and private key via the
+-- callback in the client parameters.  It is OK for the callback
+-- to return an empty chain, in many cases the client certificate
+-- is optional.  If the client wishes to abort the handshake for
+-- lack of a suitable certificate, it can throw an exception in
+-- the callback.
+--
+-- The return value is 'Nothing' when no @CertificateRequest@ was
+-- received and no @Certificate@ message needs to be sent. An empty
+-- chain means that an empty @Certificate@ message needs to be sent
+-- to the server, naturally without a @CertificateVerify@.  A non-empty
+-- 'CertificateChain' is the chain to send to the server along with
+-- a corresponding 'CertificateVerify'.
+--
+-- With TLS < 1.2 the server's @CertificateRequest@ does not carry
+-- a signature algorithm list.  It has a list of supported public
+-- key signing algorithms in the @certificate_types@ field.  The
+-- hash is implicit.  It is 'SHA1' for DSS and 'SHA1_MD5' for RSA.
+--
+-- With TLS == 1.2 the server's @CertificateRequest@ always has a
+-- @supported_signature_algorithms@ list, as a fixed component of
+-- the structure.  This list is (wrongly) overloaded to also limit
+-- X.509 signatures in the client's certificate chain.  The BCP
+-- strategy is to find a compatible chain if possible, but else
+-- ignore the constraint, and let the server verify the chain as it
+-- sees fit.  The @supported_signature_algorithms@ field is only
+-- obligatory with respect to signatures on TLS messages, in this
+-- case the @CertificateVerify@ message.  The @certificate_types@
+-- field is still included.
+--
+-- With TLS 1.3 the server's @CertificateRequest@ has a mandatory
+-- @signature_algorithms@ extension, the @signature_algorithms_cert@
+-- extension, which is optional, carries a list of algorithms the
+-- server promises to support in verifying the certificate chain.
+-- As with TLS 1.2, the client's makes a /best-effort/ to deliver
+-- a compatible certificate chain where all the CA signatures are
+-- known to be supported, but it should not abort the connection
+-- just because the chain might not work out, just send the best
+-- chain you have and let the server worry about the rest.  The
+-- supported public key algorithms are now inferred from the
+-- @signature_algorithms@ extension and @certificate_types@ is
+-- gone.
+--
+-- With TLS 1.3, we synthesize and store a @certificate_types@
+-- field at the time that the server's @CertificateRequest@
+-- message is received.  This is then present across all the
+-- protocol versions, and can be used to determine whether
+-- a @CertificateRequest@ was received or not.
+--
+-- If @signature_algorithms@ is 'Nothing', then we're doing
+-- TLS 1.0 or 1.1.  The @signature_algorithms_cert@ extension
+-- is optional in TLS 1.3, and so the application callback
+-- will not be able to distinguish between TLS 1.[01] and
+-- TLS 1.3 with no certificate algorithm hints, but this
+-- just simplifies the chain selection process, all CA
+-- signatures are OK.
+--
+clientChain :: ClientParams -> Context -> IO (Maybe CertificateChain)
+clientChain cparams ctx = do
+    usingHState ctx getCertReqCBdata >>= \case
+        Nothing     -> return Nothing
+        Just cbdata -> do
+            let callback = onCertificateRequest $ clientHooks cparams
+            chain <- liftIO $ callback cbdata `catchException`
+                throwMiscErrorOnException "certificate request callback failed"
+            case chain of
+                Nothing
+                    -> return $ Just $ CertificateChain []
+                Just (CertificateChain [], _)
+                    -> return $ Just $ CertificateChain []
+                Just (cc, privkey)
+                    -> do
+                       let (cTypes, _, _) = cbdata
+                       storePrivInfo ctx (Just cTypes) cc privkey
+                       return $ Just cc
+
+-- | Return a most preferred 'HandAndSignatureAlgorithm' that is
+-- compatible with the private key and server's signature
+-- algorithms (both already saved).  Must only be called for TLS
+-- versions 1.2 and up.
+--
+-- The values in the server's @signature_algorithms@ extension are
+-- in descending order of preference.  However here the algorithms
+-- are selected by client preference in 'supportedHashSignatures'.
+--
+getLocalHashSigAlg :: Context
+                   -> DigitalSignatureAlg
+                   -> IO HashAndSignatureAlgorithm
+getLocalHashSigAlg ctx keyAlg = do
+    -- Must be present with TLS 1.2 and up.
+    (Just (_, Just hashSigs, _)) <- usingHState ctx getCertReqCBdata
+    let want = (&&) <$> signatureCompatible keyAlg
+                    <*> flip elem hashSigs
+    case find want $ supportedHashSignatures $ ctxSupported ctx of
+        Just best -> return best
+        Nothing   -> throwCore $ Error_Protocol
+                         ( keyerr $ show keyAlg
+                         , True
+                         , HandshakeFailure
+                         )
+  where
+    keyerr alg = "no " ++ alg ++ " hash algorithm in common with the server"
+
+-- | Return the supported 'CertificateType' values that are
+-- compatible with at least one supported signature algorithm.
+--
+supportedCtypes :: [HashAndSignatureAlgorithm]
+                -> [CertificateType]
+supportedCtypes hashAlgs =
+    nub $ foldr ctfilter [] hashAlgs
+  where
+    ctfilter x acc = case hashSigToCertType13 x of
+       Just cType | cType <= lastSupportedCertificateType
+                 -> cType : acc
+       _         -> acc
+--
+clientSupportedCtypes :: Context
+                      -> [CertificateType]
+clientSupportedCtypes ctx =
+    supportedCtypes $ supportedHashSignatures $ ctxSupported ctx
+--
+sigAlgsToCertTypes :: Context
+                   -> [HashAndSignatureAlgorithm]
+                   -> [CertificateType]
+sigAlgsToCertTypes ctx hashSigs =
+    filter (`elem` supportedCtypes hashSigs) $ clientSupportedCtypes ctx
+
+-- | TLS 1.2 and below.  Send the client handshake messages that
+-- follow the @ServerHello@, etc. except for @CCS@ and @Finished@.
+--
+-- XXX: Is any buffering done here to combined these messages into
+-- a single TCP packet?  Otherwise we're prone to Nagle delays, or
+-- in any case needlessly generate multiple small packets, where
+-- a single larger packet will do.  The TLS 1.3 code path seems
+-- to separating record generation and transmission and sending
+-- multiple records in a single packet.
 --
 --       -> [certificate]
 --       -> client key exchange
@@ -289,35 +426,14 @@ handshakeClient' cparams ctx groups mcrand = do
 sendClientData :: ClientParams -> Context -> IO ()
 sendClientData cparams ctx = sendCertificate >> sendClientKeyXchg >> sendCertificateVerify
   where
-        -- When the server requests a client certificate, we
-        -- fetch a certificate chain from the callback in the
-        -- client parameters and send it to the server.
-        -- Additionally, we store the private key associated
-        -- with the first certificate in the chain for later
-        -- use.
-        --
         sendCertificate = do
-            certRequested <- usingHState ctx getClientCertRequest
-            case certRequested of
-                Nothing ->
-                    return ()
-
-                Just req -> do
-                    certChain <- liftIO $ (onCertificateRequest $ clientHooks cparams) req `catchException`
-                                 throwMiscErrorOnException "certificate request callback failed"
-
-                    usingHState ctx $ setClientCertSent False
-                    case certChain of
-                        Nothing                       -> sendPacket ctx $ Handshake [Certificates (CertificateChain [])]
-                        Just (CertificateChain [], _) -> sendPacket ctx $ Handshake [Certificates (CertificateChain [])]
-                        Just (cc@(CertificateChain (c:_)), pk) -> do
-                            case certPubKey $ getCertificate c of
-                                PubKeyRSA _ -> return ()
-                                PubKeyDSA _ -> return ()
-                                _           -> throwCore $ Error_Protocol ("no supported certificate type", True, HandshakeFailure)
-                            usingHState ctx $ setPrivateKey pk
-                            usingHState ctx $ setClientCertSent True
-                            sendPacket ctx $ Handshake [Certificates cc]
+            usingHState ctx $ setClientCertSent False
+            clientChain cparams ctx >>= \case
+                Nothing                    -> return ()
+                Just cc@(CertificateChain certs) -> do
+                    when (not $ null certs) $
+                        usingHState ctx $ setClientCertSent True
+                    sendPacket ctx $ Handshake [Certificates cc]
 
         sendClientKeyXchg = do
             cipher <- usingHState ctx getPendingCipher
@@ -396,41 +512,22 @@ sendClientData cparams ctx = sendCertificate >> sendClientKeyXchg >> sendCertifi
         -- 4. Send it to the server.
         --
         sendCertificateVerify = do
-            usedVersion <- usingState_ ctx getVersion
+            ver <- usingState_ ctx getVersion
 
             -- Only send a certificate verify message when we
             -- have sent a non-empty list of certificates.
             --
             certSent <- usingHState ctx getClientCertSent
             when certSent $ do
-                sigAlg <- getLocalSignatureAlg
-
-                mhashSig <- case usedVersion of
-                    TLS12 -> do
-                        Just (_, Just hashSigs, _) <- usingHState ctx getClientCertRequest
-                        -- The values in the "signature_algorithms" extension
-                        -- are in descending order of preference.
-                        -- However here the algorithms are selected according
-                        -- to client preference in 'supportedHashSignatures'.
-                        let suppHashSigs = supportedHashSignatures $ ctxSupported ctx
-                            matchHashSigs = filter (sigAlg `signatureCompatible`) suppHashSigs
-                            hashSigs' = filter (`elem` hashSigs) matchHashSigs
-
-                        when (null hashSigs') $
-                            throwCore $ Error_Protocol ("no " ++ show sigAlg ++ " hash algorithm in common with the server", True, HandshakeFailure)
-                        return $ Just $ head hashSigs'
+                (_, keyAlg) <- usingHState ctx getLocalPrivateKey
+                mhashSig    <- case ver of
+                    TLS12 -> Just <$> getLocalHashSigAlg ctx keyAlg
                     _     -> return Nothing
 
                 -- Fetch all handshake messages up to now.
                 msgs   <- usingHState ctx $ B.concat <$> getHandshakeMessages
-                sigDig <- createCertificateVerify ctx usedVersion sigAlg mhashSig msgs
+                sigDig <- createCertificateVerify ctx ver keyAlg mhashSig msgs
                 sendPacket ctx $ Handshake [CertVerify sigDig]
-
-        getLocalSignatureAlg = do
-            pk <- usingHState ctx getLocalPrivateKey
-            case pk of
-                PrivKeyRSA _   -> return RSA
-                PrivKeyDSA _   -> return DSS
 
 processServerExtension :: ExtensionRaw -> TLSSt ()
 processServerExtension (ExtensionRaw extID content)
@@ -589,14 +686,20 @@ processServerKeyExchange ctx (ServerKeyXchg origSkx) = do
 processServerKeyExchange ctx p = processCertificateRequest ctx p
 
 processCertificateRequest :: Context -> Handshake -> IO (RecvState IO)
-processCertificateRequest ctx (CertRequest cTypes sigAlgs dNames) = do
-    -- When the server requests a client
-    -- certificate, we simply store the
-    -- information for later.
-    --
-    usingHState ctx $ setClientCertRequest (cTypes, sigAlgs, dNames)
+processCertificateRequest ctx (CertRequest cTypesSent sigAlgs dNames) = do
+    ver <- usingState_ ctx getVersion
+    when (ver == TLS12 && sigAlgs == Nothing) $
+        throwCore $ Error_Protocol
+            ( "missing TLS 1.2 certificate request signature algorithms"
+            , True
+            , InternalError
+            )
+    let cTypes = filter (<= lastSupportedCertificateType) cTypesSent
+    usingHState ctx $ setCertReqCBdata $ Just (cTypes, sigAlgs, dNames)
     return $ RecvStateHandshake (processServerHelloDone ctx)
-processCertificateRequest ctx p = processServerHelloDone ctx p
+processCertificateRequest ctx p = do
+    usingHState ctx $ setCertReqCBdata Nothing
+    processServerHelloDone ctx p
 
 processServerHelloDone :: Context -> Handshake -> IO (RecvState m)
 processServerHelloDone _ ServerHelloDone = return RecvStateDone
@@ -633,16 +736,47 @@ handshakeClient13' cparams ctx usedCipher usedHash = do
     when rtt0accepted $ do
         eoed <- writeHandshakePacket13 ctx EndOfEarlyData13
         sendBytes13 ctx eoed
+    setTxState ctx usedHash usedCipher clientHandshakeTrafficSecret
+    chain <- clientChain cparams ctx
+    cdata <- case chain of
+        Nothing -> return ""
+        Just cc -> usingHState ctx getCertReqToken >>= sendClientData13 cc
     -- putStrLn "---- setTxState ctx usedHash usedCipher clientHandshakeTrafficSecret"
     rawFinished <- makeFinished ctx usedHash clientHandshakeTrafficSecret
-    setTxState ctx usedHash usedCipher clientHandshakeTrafficSecret
-    writeHandshakePacket13 ctx rawFinished >>= sendBytes13 ctx
+    writeHandshakePacket13 ctx rawFinished >>=
+        sendBytes13 ctx. mappend cdata
     masterSecret <- switchToTrafficSecret handshakeSecret hChSf
     setResumptionSecret masterSecret
     setEstablished ctx Established
   where
     hashSize = hashDigestSize usedHash
     zero = B.replicate hashSize 0
+
+    sendClientData13 chain (Just token) = do
+        let (CertificateChain certs) = chain
+            certExts = replicate (length certs) []
+        certbytes <- writeHandshakePacket13 ctx $
+            Certificate13 token chain certExts
+        case certs of
+            [] -> return certbytes
+            _  -> do
+                  hChSc      <- transcriptHash ctx
+                  (salg, pk) <- getSigKey
+                  vfy        <- makeClientCertVerify ctx salg pk hChSc
+                  vrfybytes  <- writeHandshakePacket13 ctx vfy
+                  return $ mappend certbytes vrfybytes
+      where
+        getSigKey = do
+            (privkey, privalg) <- usingHState ctx getLocalPrivateKey
+            sigAlg  <- getLocalHashSigAlg ctx privalg
+            return (sigAlg, privkey)
+    --
+    sendClientData13 _ _ =
+        throwCore $ Error_Protocol
+            ( "missing TLS 1.3 certificate request context token"
+            , True
+            , InternalError
+            )
 
     switchToHandshakeSecret = do
         ecdhe <- calcSharedKey
@@ -717,7 +851,37 @@ handshakeClient13' cparams ctx usedCipher usedHash = do
             return False
 
     recvCertAndVerify = do
-        cert <- recvHandshake13 ctx
+        hmsg <- recvHandshake13 ctx
+        cert <- case hmsg of
+            CertRequest13 token exts -> do
+                let hsextID = extensionID_SignatureAlgorithms
+                    -- caextID = extensionID_SignatureAlgorithmsCert
+                updateHandshake13 ctx hmsg
+                dNames <- canames exts
+                -- The @signature_algorithms@ extension is mandatory.
+                hsAlgs <- extalgs hsextID exts unsighash
+                cTypes <- case hsAlgs of
+                    Just as -> return $ sigAlgsToCertTypes ctx as
+                    Nothing -> throwCore $ Error_Protocol
+                                   ( "invalid certificate request"
+                                   , True
+                                   , HandshakeFailure )
+                -- Unused:
+                -- caAlgs <- extalgs caextID exts uncertsig
+                usingHState ctx $ do
+                    setCertReqToken  $ Just token
+                    setCertReqCBdata $ Just (cTypes, hsAlgs, dNames)
+                    -- setCertReqSigAlgsCert caAlgs
+                recvHandshake13 ctx
+            _ -> do
+                usingHState ctx $ do
+                    setCertReqToken   Nothing
+                    setCertReqCBdata  Nothing
+                    -- setCertReqSigAlgsCert Nothing
+                return hmsg
+
+        -- FIXME: What happens when the pattern match fails?
+        --
         let Certificate13 _ cc@(CertificateChain certChain) _ = cert
         _ <- processCertificate cparams ctx (Certificates cc)
         updateHandshake13 ctx cert
@@ -729,6 +893,35 @@ handshakeClient13' cparams ctx usedCipher usedHash = do
         hChSc <- transcriptHash ctx
         checkServerCertVerify ss sig pubkey hChSc
         updateHandshake13 ctx certVerify
+      where
+        canames exts = case extensionLookup
+                            extensionID_CertificateAuthorities exts of
+            Nothing   -> return []
+            Just  ext -> case extensionDecode MsgTCertificateRequest ext of
+                             Just (CertificateAuthorities names) -> return names
+                             _ -> throwCore $ Error_Protocol
+                                      ( "invalid certificate request"
+                                      , True
+                                      , HandshakeFailure )
+        extalgs extID exts decons = case extensionLookup extID exts of
+            Nothing   -> return Nothing
+            Just  ext -> case extensionDecode MsgTCertificateRequest ext of
+                             Just e
+                               -> return    $ decons e
+                             _ -> throwCore $ Error_Protocol
+                                      ( "invalid certificate request"
+                                      , True
+                                      , HandshakeFailure )
+
+        unsighash :: SignatureAlgorithms
+                  -> Maybe [HashAndSignatureAlgorithm]
+        unsighash (SignatureAlgorithms a) = Just a
+
+        {- Unused for now
+        uncertsig :: SignatureAlgorithmsCert
+                  -> Maybe [HashAndSignatureAlgorithm]
+        uncertsig (SignatureAlgorithmsCert a) = Just a
+        -}
 
     recvFinished serverHandshakeTrafficSecret = do
         finished <- recvHandshake13 ctx

--- a/core/Network/TLS/Handshake/Key.hs
+++ b/core/Network/TLS/Handshake/Key.hs
@@ -42,7 +42,7 @@ encryptRSA ctx content = do
 
 signPrivate :: Context -> Role -> SignatureParams -> ByteString -> IO ByteString
 signPrivate ctx _ params content = do
-    privateKey <- usingHState ctx getLocalPrivateKey
+    (privateKey, _) <- usingHState ctx getLocalPrivateKey
     usingState_ ctx $ do
         r <- withRNG $ kxSign privateKey params content
         case r of
@@ -51,7 +51,7 @@ signPrivate ctx _ params content = do
 
 decryptRSA :: Context -> ByteString -> IO (Either KxError ByteString)
 decryptRSA ctx econtent = do
-    privateKey <- usingHState ctx getLocalPrivateKey
+    (privateKey, _) <- usingHState ctx getLocalPrivateKey
     usingState_ ctx $ do
         ver <- getVersion
         let cipher = if ver < TLS10 then econtent else B.drop 2 econtent

--- a/core/Network/TLS/Struct.hs
+++ b/core/Network/TLS/Struct.hs
@@ -18,6 +18,8 @@ module Network.TLS.Struct
     , ExtensionID
     , ExtensionRaw(..)
     , CertificateType(..)
+    , lastSupportedCertificateType
+    , hashSigToCertType13
     , HashAlgorithm(..)
     , SignatureAlgorithm(..)
     , HashAndSignatureAlgorithm
@@ -82,16 +84,40 @@ data CipherData = CipherData
     , cipherDataPadding :: Maybe ByteString
     } deriving (Show,Eq)
 
+-- | Some of the IANA registered code points for 'CertificateType' are not
+-- currently supported by the library.  Nor should they be, they're are either
+-- unwise, obsolete or both.  There's no point in conveying these to the user
+-- in the client certificate request callback.  The request callback will be
+-- filtered to exclude unsupported values.  If the user cannot find a certificate
+-- for a supported code point, we'll go ahead without a client certificate and
+-- hope for the best, unless the user's callback decides to throw an exception.
+--
 data CertificateType =
-      CertificateType_RSA_Sign         -- TLS10
-    | CertificateType_DSS_Sign         -- TLS10
-    | CertificateType_RSA_Fixed_DH     -- TLS10
-    | CertificateType_DSS_Fixed_DH     -- TLS10
-    | CertificateType_RSA_Ephemeral_DH -- TLS12
-    | CertificateType_DSS_Ephemeral_DH -- TLS12
-    | CertificateType_fortezza_dms     -- TLS12
-    | CertificateType_Unknown Word8
-    deriving (Show,Eq)
+      CertificateType_RSA_Sign         -- ^ TLS10 and up, RFC5246
+    | CertificateType_DSS_Sign         -- ^ TLS10 and up, RFC5246
+    | CertificateType_ECDSA_Sign       -- ^ TLS10 and up, RFC8422
+    | CertificateType_Ed25519_Sign     -- ^ TLS13 and up, synthetic
+    | CertificateType_Ed448_Sign       -- ^ TLS13 and up, synthetic
+    -- | None of the below will ever be presented to the callback.  Any future
+    -- public key algorithms valid for client certificates go above this line.
+    | CertificateType_RSA_Fixed_DH     -- Obsolete, unsupported
+    | CertificateType_DSS_Fixed_DH     -- Obsolete, unsupported
+    | CertificateType_RSA_Ephemeral_DH -- Obsolete, unsupported
+    | CertificateType_DSS_Ephemeral_DH -- Obsolete, unsupported
+    | CertificateType_fortezza_dms     -- Obsolete, unsupported
+    | CertificateType_RSA_Fixed_ECDH   -- Obsolete, unsupported
+    | CertificateType_ECDSA_Fixed_ECDH -- Obsolete, unsupported
+    | CertificateType_Unknown Word8    -- Obsolete, unsupported
+    deriving (Eq, Ord, Show)
+
+-- | Last supported certificate type, no 'CertificateType that
+-- compares greater than this one (based on the 'Ord' instance,
+-- not on the wire code point) will be reported to the application
+-- via the client certificate request callback.
+--
+lastSupportedCertificateType :: CertificateType
+lastSupportedCertificateType = CertificateType_DSS_Sign
+
 
 data HashAlgorithm =
       HashNone
@@ -122,6 +148,58 @@ data SignatureAlgorithm =
     deriving (Show,Eq)
 
 type HashAndSignatureAlgorithm = (HashAlgorithm, SignatureAlgorithm)
+
+------------------------------------------------------------
+
+-- | For TLS 1.3, translate a 'HashAndSignatureAlgorithm' to an
+-- acceptable 'CertificateType'.  Perhaps this needs to take
+-- supported groups into account, so that, for example, if we
+-- don't support any shared ECDSA groups with the server, we
+-- return 'Nothing' rather than 'CertificateType_ECDSA_Sign'.
+--
+-- Therefore, this interface is preliminary.  It gets us moving
+-- in the right direction.  The interplay between all the various
+-- TLS extensions and certificate selection is rather complex.
+--
+-- The goal is to ensure that the client certificate request
+-- callback only sees 'CertificateType' values that are supported
+-- by the library and also compatible with the server signature
+-- algorithms extension.
+--
+-- Since we don't yet support ECDSA private keys, the caller
+-- will use 'lastSupportedCertificateType' to filter those
+-- out for now, leaving just @RSA@ as the only supported
+-- client certificate algorithm for TLS 1.3.
+--
+-- FIXME: Add RSA_PSS_PSS signatures when supported.
+--
+hashSigToCertType13 :: HashAndSignatureAlgorithm
+                    -> Maybe CertificateType
+--
+hashSigToCertType13 (HashIntrinsic, hashsig)
+    | hashsig ==  SignatureRSApssRSAeSHA256
+      = Just $ CertificateType_RSA_Sign
+    | hashsig ==  SignatureRSApssRSAeSHA384
+      = Just $ CertificateType_RSA_Sign
+    | hashsig == SignatureRSApssRSAeSHA512
+      = Just $ CertificateType_RSA_Sign
+    | hashsig ==  SignatureEd25519
+      = Just CertificateType_Ed25519_Sign
+    | hashsig ==  SignatureEd448
+      = Just CertificateType_Ed448_Sign
+    | otherwise = Nothing
+--
+hashSigToCertType13 (hashalg, SignatureECDSA)
+    | hashalg == HashSHA256
+      = Just $ CertificateType_ECDSA_Sign
+    | hashalg == HashSHA384
+      = Just $ CertificateType_ECDSA_Sign
+    | hashalg == HashSHA512
+      = Just $ CertificateType_ECDSA_Sign
+    | otherwise = Nothing
+--
+hashSigToCertType13 _ = Nothing
+------------------------------------------------------------
 
 type Signature = ByteString
 
@@ -506,13 +584,22 @@ instance TypeValuable AlertDescription where
 
 instance TypeValuable CertificateType where
     valOfType CertificateType_RSA_Sign         = 1
+    valOfType CertificateType_ECDSA_Sign       = 64
     valOfType CertificateType_DSS_Sign         = 2
     valOfType CertificateType_RSA_Fixed_DH     = 3
     valOfType CertificateType_DSS_Fixed_DH     = 4
     valOfType CertificateType_RSA_Ephemeral_DH = 5
     valOfType CertificateType_DSS_Ephemeral_DH = 6
     valOfType CertificateType_fortezza_dms     = 20
+    valOfType CertificateType_RSA_Fixed_ECDH   = 65
+    valOfType CertificateType_ECDSA_Fixed_ECDH = 66
     valOfType (CertificateType_Unknown i)      = i
+    -- | There are no code points that map to the below synthetic types, these
+    -- are inferred indirectly from the @signature_algorithms@ extension of the
+    -- TLS 1.3 @CertificateRequest@ message.  the value assignments are there
+    -- only to avoid partial function warnings.
+    valOfType CertificateType_Ed25519_Sign     = 0
+    valOfType CertificateType_Ed448_Sign       = 0
 
     valToType 1  = Just CertificateType_RSA_Sign
     valToType 2  = Just CertificateType_DSS_Sign
@@ -521,7 +608,17 @@ instance TypeValuable CertificateType where
     valToType 5  = Just CertificateType_RSA_Ephemeral_DH
     valToType 6  = Just CertificateType_DSS_Ephemeral_DH
     valToType 20 = Just CertificateType_fortezza_dms
+    valToType 64 = Just CertificateType_ECDSA_Sign
+    valToType 65 = Just CertificateType_RSA_Fixed_ECDH
+    valToType 66 = Just CertificateType_ECDSA_Fixed_ECDH
     valToType i  = Just (CertificateType_Unknown i)
+    -- | There are no code points that map to the below synthetic types, these
+    -- are inferred indirectly from the @signature_algorithms@ extension of the
+    -- TLS 1.3 @CertificateRequest@ message.
+    -- @
+    -- CertificateType_Ed25519_Sign
+    -- CertificateType_Ed448_Sign
+    -- @
 
 instance TypeValuable HashAlgorithm where
     valOfType HashNone      = 0


### PR DESCRIPTION
Tested with and without client certificates against an OpenSSL (Postfix) server that requested client certificates.  Both cases work.

This is a large patch, please study it carefully.  It would also be great if someone implemented the server side support for requesting TLS13 client auth. Then this could be covered by the tests.

The code could perhaps use more polish.  Perhaps some helper functions should be moved to other modules?  And more work remains...

All the various ways of referring to public key algorithms could really use a more uniform treatment.  As it stands there's
```
DigitalSignatureAlg         (e.g. RSA)
PubkeyAlg                   (e.g. PubKeyRSA)
HashAndSignatureAlgorithm   (e.g. (Intrinsic, SignatureRSApssRSAeSHA256))
CertificateType             (e.g. CertificateType_RSA_Sign)
...
```
and conversions between these are a hit or miss afair.  One area of cleanup might to systematically map out clean interfaces for moving between all these related things.

Another thing that seems to be rather missing is an API for loading a certificate chain from a single file, rather than an array of files with a single certificate in each...  Is something like that provided by X.509?  TLS seems to have `credentialLoadX509Chain`, which is far from ideal.