### PR TITLE
preventing Logjam attack.

### DIFF
--- a/core/Network/TLS/Crypto/DH.hs
+++ b/core/Network/TLS/Crypto/DH.hs
@@ -12,6 +12,7 @@ module Network.TLS.Crypto.DH
     , dhParams
     , dhParamsGetP
     , dhParamsGetG
+    , dhParamsGetBits
     , dhGenerateKeyPair
     , dhGetShared
     , dhValid
@@ -66,6 +67,9 @@ dhParamsGetP (DH.Params p _ _) = p
 
 dhParamsGetG :: DHParams -> Integer
 dhParamsGetG (DH.Params _ g _) = g
+
+dhParamsGetBits :: DHParams -> Int
+dhParamsGetBits (DH.Params _ _ b) = b
 
 dhUnwrapPublic :: DHPublic -> Integer
 dhUnwrapPublic (DH.PublicNumber y) = y

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -263,6 +263,8 @@ defaultGroupUsage params public
     | even $ dhParamsGetP params                   = return $ GroupUsageUnsupported "invalid odd prime"
     | not $ dhValid params (dhParamsGetG params)   = return $ GroupUsageUnsupported "invalid generator"
     | not $ dhValid params (dhUnwrapPublic public) = return   GroupUsageInvalidPublic
+    -- To prevent Logjam attack
+    | dhParamsGetBits params < 1024                = return   GroupUsageInsecure
     | otherwise                                    = return   GroupUsageValid
 
 -- | A set of callbacks run by the clients for various corners of TLS establishment


### PR DESCRIPTION
This fixes the following FAILs of trytls:

```
 FAIL protect against the Logjam attack [reject www.ssllabs.com:10445]
      output: 200 OK
 FAIL denies use of 480 bit Diffie-Hellman (DH) [reject dh480.badssl.com:443]
      output: 200 OK
 FAIL denies use of 512 bit Diffie-Hellman (DH) [reject dh512.badssl.com:443]
      output: 200 OK
```

Relating to #299