### PR TITLE
Certificate selection for TLS13

### DIFF
--- a/core/Network/TLS/Extension.hs
+++ b/core/Network/TLS/Extension.hs
@@ -46,7 +46,7 @@ module Network.TLS.Extension
     , HeartBeat(..)
     , HeartBeatMode(..)
     , SignatureAlgorithms(..)
-    , SignatureAlgorithmsCert
+    , SignatureAlgorithmsCert(..)
     , SupportedVersions(..)
     , KeyShare(..)
     , KeyShareEntry(..)

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -112,7 +112,7 @@ handshakeServerWith sparams ctx clientHello@(ClientHello clientVersion _ clientS
     -- TLS_FALLBACK_SCSV: {0x56, 0x00}
     when (supportedFallbackScsv (ctxSupported ctx) &&
           (0x5600 `elem` ciphers) &&
-          clientVersion /= maxBound) $
+          clientVersion < TLS12) $
         throwCore $ Error_Protocol ("fallback is not allowed", True, InappropriateFallback)
     -- choosing TLS version
     let clientVersions = case extensionLookup extensionID_SupportedVersions exts >>= extensionDecode MsgTClientHello of

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -617,7 +617,7 @@ filterCredentialsWithHashSignatures exts =
 -- returns True if "signature_algorithms" certificate filtering produced no
 -- ephemeral D-H nor TLS13 cipher (so handshake with lower security)
 cipherListCredentialFallback :: [Cipher] -> Bool
-cipherListCredentialFallback xs = all nonDH xs
+cipherListCredentialFallback = all nonDH
   where
     nonDH x = case cipherKeyExchange x of
         CipherKeyExchange_DHE_RSA     -> False

--- a/core/Network/TLS/KeySchedule.hs
+++ b/core/Network/TLS/KeySchedule.hs
@@ -1,10 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
-
-module Network.TLS.KeySchedule (
-    hkdfExtract
-  , hkdfExpandLabel
-  , deriveSecret
-  ) where
+-- |
+-- Module      : Network.TLS.KeySchedule
+-- License     : BSD-style
+-- Maintainer  : Vincent Hanquez <vincent@snarc.org>
+-- Stability   : experimental
+-- Portability : unknown
+--
+module Network.TLS.KeySchedule
+    ( hkdfExtract
+    , hkdfExpandLabel
+    , deriveSecret
+    ) where
 
 import qualified Crypto.Hash as H
 import Crypto.KDF.HKDF

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -13,7 +13,7 @@ module Connection
     , arbitraryClientCredential
     , arbitraryRSACredentialWithUsage
     , isCustomDHParams
-    , leafPublicKey
+    , isLeafRSA
     , readClientSessionRef
     , twoSessionRefs
     , twoSessionManagers
@@ -118,6 +118,11 @@ isCustomDHParams params = params == dhParams
 leafPublicKey :: CertificateChain -> Maybe PubKey
 leafPublicKey (CertificateChain [])       = Nothing
 leafPublicKey (CertificateChain (leaf:_)) = Just (certPubKey $ signedObject $ getSigned leaf)
+
+isLeafRSA :: Maybe CertificateChain -> Bool
+isLeafRSA chain = case chain >>= leafPublicKey of
+                        Just (PubKeyRSA _) -> True
+                        _                  -> False
 
 arbitraryCipherPair :: Version -> Gen ([Cipher], [Cipher])
 arbitraryCipherPair connectVersion = do

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -348,10 +348,47 @@ prop_handshake_cert_fallback = do
     runTLSPipeSimple (clientParam',serverParam)
     serverChain <- run $ readIORef chainRef
     dssDisallowed `assertEq` isLeafRSA serverChain
-  where
-    isLeafRSA chain = case chain >>= leafPublicKey of
-                          Just (PubKeyRSA _) -> True
-                          _                  -> False
+
+-- Same as above but testing with supportedHashSignatures directly instead of
+-- ciphers, and thus allowing TLS13.  Peers accept RSA with SHA-256 but the
+-- server RSA certificate has a SHA-1 signature.  When DSS is allowed by both
+-- client and server, the DSA certificate is selected.  Otherwise the server
+-- fallbacks to RSA.
+--
+-- Note: DSA and SHA-1 are supposed to be disallowed with TLS13.  Currently this
+-- is not enforced by the library, which is useful to test this scenario until
+-- ECDSA or EdDSA support is added.  SHA-1 could be replaced by another
+-- algorithm.
+prop_handshake_cert_fallback_hs :: PropertyM IO ()
+prop_handshake_cert_fallback_hs = do
+    tls13 <- pick arbitrary
+    let versions = if tls13 then [TLS13] else [TLS12]
+        ciphers  = [ cipher_ECDHE_RSA_AES128GCM_SHA256
+                   , cipher_DHE_DSS_AES128_SHA1
+                   , cipher_TLS13_AES128GCM_SHA256
+                   ]
+        commonHS = [ (HashSHA256, SignatureRSA) ]
+        otherHS  = [ (HashSHA1, SignatureDSS) ]
+    chainRef <- run $ newIORef Nothing
+    clientHS <- pick $ sublistOf otherHS
+    serverHS <- pick $ sublistOf otherHS
+    (clientParam,serverParam) <- pick $ arbitraryPairParamsWithVersionsAndCiphers
+                                            (versions, versions)
+                                            (ciphers, ciphers)
+    let clientParam' = clientParam { clientSupported = (clientSupported clientParam)
+                                       { supportedHashSignatures = commonHS ++ clientHS }
+                                   , clientHooks = (clientHooks clientParam)
+                                       { onServerCertificate = \_ _ _ chain ->
+                                             writeIORef chainRef (Just chain) >> return [] }
+                                   }
+        serverParam' = serverParam { serverSupported = (serverSupported serverParam)
+                                       { supportedHashSignatures = commonHS ++ serverHS }
+                                   }
+        dssDisallowed = (HashSHA1, SignatureDSS) `notElem` clientHS
+                            || (HashSHA1, SignatureDSS) `notElem` serverHS
+    runTLSPipeSimple (clientParam',serverParam')
+    serverChain <- run $ readIORef chainRef
+    dssDisallowed `assertEq` isLeafRSA serverChain
 
 prop_handshake_groups :: PropertyM IO ()
 prop_handshake_groups = do
@@ -576,7 +613,8 @@ main = defaultMain $ testGroup "tls"
             , testProperty "Hash and signatures" (monadicIO prop_handshake_hashsignatures)
             , testProperty "Cipher suites" (monadicIO prop_handshake_ciphersuites)
             , testProperty "Groups" (monadicIO prop_handshake_groups)
-            , testProperty "Certificate fallback" (monadicIO prop_handshake_cert_fallback)
+            , testProperty "Certificate fallback (ciphers)" (monadicIO prop_handshake_cert_fallback)
+            , testProperty "Certificate fallback (hash and signatures)" (monadicIO prop_handshake_cert_fallback_hs)
             , testProperty "Server key usage" (monadicIO prop_handshake_srv_key_usage)
             , testProperty "Client authentication" (monadicIO prop_handshake_client_auth)
             , testProperty "Client key usage" (monadicIO prop_handshake_clt_key_usage)

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -140,9 +140,7 @@ Test-Suite test-tls
                      PipeChan
                      PubKey
   Build-Depends:     base >= 3 && < 5
-                   , mtl
                    , async >= 2.0
-                   , cereal >= 0.3
                    , data-default-class
                    , tasty
                    , tasty-quickcheck
@@ -160,6 +158,10 @@ Benchmark bench-tls
   hs-source-dirs:    Benchmarks Tests
   Main-Is:           Benchmarks.hs
   type:              exitcode-stdio-1.0
+  other-modules:     Certificate
+                     Connection
+                     PipeChan
+                     PubKey
   Build-depends:     base >= 4 && < 5
                    , tls
                    , x509
@@ -167,7 +169,6 @@ Benchmark bench-tls
                    , data-default-class
                    , cryptonite
                    , criterion >= 1.0
-                   , mtl
                    , bytestring
                    , asn1-types
                    , async >= 2.0

--- a/debug/tls-debug.cabal
+++ b/debug/tls-debug.cabal
@@ -52,9 +52,7 @@ Executable           tls-retrievecertificate
   Build-Depends:     base >= 4 && < 5
                    , network
                    , bytestring
-                   , time
                    , pem
-                   , cryptonite
                    , x509
                    , x509-system >= 1.4
                    , x509-validation >= 1.5.0


### PR DESCRIPTION
Adds support for extension "signature_algorithms_cert" and uses hash/signature pairs when deciding about the server certificate (for preference only, not enforcement).

I include an unrelated fix of Fallback SCSV because clientVersion will not be TLS13.