### PR TITLE
a new scheme to send new session tickets

### DIFF
--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -157,7 +157,7 @@ recvData13 ctx = liftIO $ do
                 maxSize = case extensionLookup extensionID_EarlyData exts >>= extensionDecode MsgTNewSessionTicket of
                   Just (EarlyDataIndication (Just ms)) -> fromIntegral $ safeNonNegative32 ms
                   _                                    -> 0
-            tinfo <- createTLS13TicketInfo life (Right add)
+            tinfo <- createTLS13TicketInfo life (Right add) Nothing
             sdata <- getSessionData13 ctx usedCipher tinfo maxSize psk
             sessionEstablish (sharedSessionManager $ ctxShared ctx) label sdata
             -- putStrLn $ "NewSessionTicket received: lifetime = " ++ show life ++ " sec"

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -829,7 +829,7 @@ doHandshake13 sparams (certChain, privKey) ctx chosenVersion usedCipher exts use
             is0RTTvalid = isSameVersion && isSameCipher && isSameALPN
         return (isPSKvalid, is0RTTvalid)
 
-    rtt0accept = serverEarlyDataSize sparams /= 0
+    rtt0accept = safeNonNegative32 (serverEarlyDataSize sparams) > 0
     rtt0 = case extensionLookup extensionID_EarlyData exts >>= extensionDecode MsgTClientHello of
              Just (EarlyDataIndication _) -> True
              Nothing                      -> False

--- a/core/Network/TLS/Sending13.hs
+++ b/core/Network/TLS/Sending13.hs
@@ -47,10 +47,15 @@ encodeRecord (Record13 ct bytes) = return ebytes
         putBytes bytes
 
 writePacket13 :: Context -> Packet13 -> IO (Either TLSError ByteString)
+writePacket13 ctx pkt@(Handshake13 [NewSessionTicket13 _ _ _ _ _]) = encodePacket13 ctx pkt
+writePacket13 ctx pkt@(Handshake13 [KeyUpdate13 _]) = encodePacket13 ctx pkt
 writePacket13 ctx pkt@(Handshake13 hss) = do
     forM_ hss $ updateHandshake13 ctx
-    prepareRecord ctx (makeRecord pkt >>= engageRecord >>= encodeRecord)
-writePacket13 ctx pkt = prepareRecord ctx (makeRecord pkt >>= engageRecord >>= encodeRecord)
+    encodePacket13 ctx pkt
+writePacket13 ctx pkt = encodePacket13 ctx pkt
+
+encodePacket13 :: Context -> Packet13 -> IO (Either TLSError ByteString)
+encodePacket13 ctx pkt = prepareRecord ctx (makeRecord pkt >>= engageRecord >>= encodeRecord)
 
 writeHandshakePacket13 :: MonadIO m => Context -> Handshake13 -> m ByteString
 writeHandshakePacket13 ctx hdsk = do

--- a/core/Network/TLS/Types.hs
+++ b/core/Network/TLS/Types.hs
@@ -20,7 +20,6 @@ module Network.TLS.Types
     , Millisecond
     ) where
 
-import Data.IORef (IORef)
 import Network.TLS.Imports
 import Network.TLS.Crypto.Types (Group)
 
@@ -53,16 +52,8 @@ data TLS13TicketInfo = TLS13TicketInfo
     { lifetime :: Second      -- NewSessionTicket.ticket_lifetime in seconds
     , ageAdd   :: Second      -- NewSessionTicket.ticket_age_add
     , txrxTime :: Millisecond -- serverSendTime or clientReceiveTime
-    , estimatedRTT :: IORef (Maybe Millisecond)
-    } deriving (Eq)
-
-instance Show TLS13TicketInfo where
-    showsPrec d s = showParen (d > 10) $
-             showString "TLS13TicketInfo { "
-           . showString   "lifetime = " . shows (lifetime s)
-           . showString ", ageAdd = "   . shows (ageAdd s)
-           . showString ", txrxTime = " . shows (txrxTime s)
-           . showString " }"
+    , estimatedRTT :: Maybe Millisecond
+    } deriving (Eq, Show)
 
 -- | Cipher identification
 type CipherID = Word16


### PR DESCRIPTION
This implements #296 and resolves one item in #282.

- Sending a new session ticket after receiving Client Finished.
- Sending another new session ticket after sending Server Finished
  in the case of 0RTT.
- Removing `IORef` from TLS13TicketInfo for serialization.

