### PR TITLE
More tests for TLS13

### DIFF
--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -12,6 +12,7 @@ module Connection
     , arbitraryPairParamsWithVersionsAndCiphers
     , arbitraryClientCredential
     , arbitraryRSACredentialWithUsage
+    , isVersionEnabled
     , isCustomDHParams
     , leafPublicKey
     , readClientSessionRef
@@ -157,6 +158,11 @@ arbitraryPairParamsAt connectVersion = do
         serAllowedVersions = [connectVersion]
     (clientCiphers, serverCiphers) <- arbitraryCipherPair connectVersion
     arbitraryPairParamsWithVersionsAndCiphers (allowedVersions, serAllowedVersions) (clientCiphers, serverCiphers)
+
+isVersionEnabled :: Version -> (ClientParams, ServerParams) -> Bool
+isVersionEnabled ver (cparams, sparams) =
+    (ver `elem` supportedVersions (serverSupported sparams)) &&
+    (ver `elem` supportedVersions (clientSupported cparams))
 
 arbitraryHashSignaturePair :: Gen ([HashAndSignatureAlgorithm], [HashAndSignatureAlgorithm])
 arbitraryHashSignaturePair = do

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -56,12 +56,6 @@ knownCiphers = filter nonECDSA (ciphersuite_all ++ ciphersuite_weak)
     -- arbitraryCredentialsOfEachType cannot generate ECDSA
     nonECDSA c = not ("ECDSA" `isInfixOf` cipherName c)
 
-knownCiphers13 :: [Cipher]
-knownCiphers13 = [
-    cipher_TLS13_AES128GCM_SHA256
-  , cipher_TLS13_AES256GCM_SHA384
-  ]
-
 arbitraryCiphers :: Gen [Cipher]
 arbitraryCiphers = listOf1 $ elements knownCiphers
 
@@ -159,10 +153,7 @@ arbitraryPairParams13 = do
     let connectVersion = TLS13
         allowedVersions = [connectVersion]
         serAllowedVersions = [connectVersion]
-    (clientCiphers', serverCiphers') <- arbitraryCipherPair connectVersion
-    cipher <- elements knownCiphers13
-    let clientCiphers = clientCiphers' ++ [cipher]
-        serverCiphers = serverCiphers' ++ [cipher]
+    (clientCiphers, serverCiphers) <- arbitraryCipherPair connectVersion
     arbitraryPairParamsWithVersionsAndCiphers (allowedVersions, serAllowedVersions) (clientCiphers, serverCiphers)
 
 arbitraryHashSignaturePair :: Gen ([HashAndSignatureAlgorithm], [HashAndSignatureAlgorithm])

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -149,9 +149,11 @@ arbitraryGroupPair = do
     arbitraryGroupsFrom list = listOf1 $ elements list
 
 arbitraryPairParams13 :: Gen (ClientParams, ServerParams)
-arbitraryPairParams13 = do
-    let connectVersion = TLS13
-        allowedVersions = [connectVersion]
+arbitraryPairParams13 = arbitraryPairParamsAt TLS13
+
+arbitraryPairParamsAt :: Version -> Gen (ClientParams, ServerParams)
+arbitraryPairParamsAt connectVersion = do
+    let allowedVersions = [connectVersion]
         serAllowedVersions = [connectVersion]
     (clientCiphers, serverCiphers) <- arbitraryCipherPair connectVersion
     arbitraryPairParamsWithVersionsAndCiphers (allowedVersions, serAllowedVersions) (clientCiphers, serverCiphers)

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -348,15 +348,16 @@ prop_handshake_ciphersuites = do
 
 prop_handshake_hashsignatures :: PropertyM IO ()
 prop_handshake_hashsignatures = do
-    let clientVersions = [TLS12]
-        serverVersions = [TLS12]
+    tls13 <- pick arbitrary
+    let versions = if tls13 then [TLS13] else [TLS12]
         ciphers = [ cipher_ECDHE_RSA_AES256GCM_SHA384
                   , cipher_ECDHE_RSA_AES128CBC_SHA
                   , cipher_DHE_RSA_AES128_SHA1
                   , cipher_DHE_DSS_AES128_SHA1
+                  , cipher_TLS13_AES128GCM_SHA256
                   ]
     (clientParam,serverParam) <- pick $ arbitraryPairParamsWithVersionsAndCiphers
-                                            (clientVersions, serverVersions)
+                                            (versions, versions)
                                             (ciphers, ciphers)
     clientHashSigs <- pick arbitraryHashSignatures
     serverHashSigs <- pick arbitraryHashSignatures

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -291,8 +291,8 @@ prop_handshake13_rtt0 = do
     -- and resume
     sessionParams <- run $ readClientSessionRef sessionRefs
     assert (isJust sessionParams)
-    let earlyData = "Early data"
-        (pc,ps) = setPairParamsSessionResuming (fromJust sessionParams) params
+    earlyData <- B.pack <$> pick (someWords8 256)
+    let (pc,ps) = setPairParamsSessionResuming (fromJust sessionParams) params
         params2 = (pc { clientEarlyData = Just earlyData } , ps)
 
     runTLSPipeSimple13 params2 (RTT0, RTT0) (Just earlyData)
@@ -325,8 +325,8 @@ prop_handshake13_rtt0_fallback = do
     -- and resume
     sessionParams <- run $ readClientSessionRef sessionRefs
     assert (isJust sessionParams)
-    let earlyData = "Early data"
-        (pc,ps) = setPairParamsSessionResuming (fromJust sessionParams) params
+    earlyData <- B.pack <$> pick (someWords8 256)
+    let (pc,ps) = setPairParamsSessionResuming (fromJust sessionParams) params
         params2 = (pc { clientEarlyData = Just earlyData } , ps)
 
     runTLSPipeSimple13 params2 (PreSharedKey, PreSharedKey) Nothing

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -139,13 +139,13 @@ runTLSPipeSimpleKeyUpdate params = runTLSPipeN 3 params tlsServer tlsClient
             bye ctx
             return ()
 
-runTLSInitFailure :: (ClientParams, ServerParams) -> PropertyM IO ()
-runTLSInitFailure params = do
+runTLSInitFailureGen :: (ClientParams, ServerParams) -> (Context -> IO s) -> (Context -> IO c) -> PropertyM IO ()
+runTLSInitFailureGen params hsServer hsClient = do
     (cRes, sRes) <- run (initiateDataPipe params tlsServer tlsClient)
     assertIsLeft cRes
     assertIsLeft sRes
   where tlsServer ctx = do
-            handshake ctx
+            _ <- hsServer ctx
             minfo <- contextGetInformation ctx
             -- Note: with TLS13 server needs to call recvData in order to detect
             -- handshake alert messages sent by the client (consequence of 0RTT
@@ -154,29 +154,13 @@ runTLSInitFailure params = do
             bye ctx
             return $ "server success: " ++ show minfo
         tlsClient ctx = do
-            handshake ctx
+            _ <- hsClient ctx
             minfo <- contextGetInformation ctx
             bye ctx
             return $ "client success: " ++ show minfo
 
-runTLSInitFailureRenego :: (ClientParams, ServerParams) -> PropertyM IO ()
-runTLSInitFailureRenego params = do
-    (cRes, sRes) <- run (initiateDataPipe params tlsServer tlsClient)
-    assertIsLeft cRes
-    assertIsLeft sRes
-  where tlsServer ctx = do
-            handshake ctx
-            minfo <- contextGetInformation ctx
-            -- same above Note regarding recvData
-            _ <- recvData ctx
-            bye ctx
-            return $ "server success: " ++ show minfo
-        tlsClient ctx = do
-            handshake ctx
-            handshake ctx
-            minfo <- contextGetInformation ctx
-            bye ctx
-            return $ "client success: " ++ show minfo
+runTLSInitFailure :: (ClientParams, ServerParams) -> PropertyM IO ()
+runTLSInitFailure params = runTLSInitFailureGen params handshake handshake
 
 prop_handshake_initiate :: PropertyM IO ()
 prop_handshake_initiate = do
@@ -596,20 +580,21 @@ prop_handshake_renegotiation = do
     let shouldFail = (TLS13 `elem` supportedVersions (serverSupported sparams'))
                   && (TLS13 `elem` supportedVersions (clientSupported cparams))
     if shouldFail
-        then runTLSInitFailureRenego (cparams, sparams')
+        then runTLSInitFailureGen (cparams, sparams') hsServer hsClient
         else runTLSPipe (cparams, sparams') tlsServer tlsClient
   where tlsServer ctx queue = do
-            handshake ctx
+            hsServer ctx
             d <- recvDataNonNull ctx
             writeChan queue [d]
             return ()
         tlsClient queue ctx = do
-            handshake ctx
-            handshake ctx
+            hsClient ctx
             d <- readChan queue
             sendData ctx (L.fromChunks [d])
             bye ctx
             return ()
+        hsServer     = handshake
+        hsClient ctx = handshake ctx >> handshake ctx
 
 prop_handshake_session_resumption :: PropertyM IO ()
 prop_handshake_session_resumption = do

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -147,6 +147,10 @@ runTLSInitFailure params = do
   where tlsServer ctx = do
             handshake ctx
             minfo <- contextGetInformation ctx
+            -- Note: with TLS13 server needs to call recvData in order to detect
+            -- handshake alert messages sent by the client (consequence of 0RTT
+            -- design with pending actions)
+            _ <- recvData ctx
             bye ctx
             return $ "server success: " ++ show minfo
         tlsClient ctx = do
@@ -157,11 +161,14 @@ runTLSInitFailure params = do
 
 runTLSInitFailureRenego :: (ClientParams, ServerParams) -> PropertyM IO ()
 runTLSInitFailureRenego params = do
-    (cRes, _sRes) <- run (initiateDataPipe params tlsServer tlsClient)
+    (cRes, sRes) <- run (initiateDataPipe params tlsServer tlsClient)
     assertIsLeft cRes
+    assertIsLeft sRes
   where tlsServer ctx = do
             handshake ctx
             minfo <- contextGetInformation ctx
+            -- same above Note regarding recvData
+            _ <- recvData ctx
             bye ctx
             return $ "server success: " ++ show minfo
         tlsClient ctx = do
@@ -457,8 +464,10 @@ prop_handshake_dh = do
 
 prop_handshake_srv_key_usage :: PropertyM IO ()
 prop_handshake_srv_key_usage = do
-    let versions = [SSL3,TLS10,TLS11,TLS12]
+    tls13 <- pick arbitrary
+    let versions = if tls13 then [TLS13] else [SSL3,TLS10,TLS11,TLS12]
         ciphers = [ cipher_ECDHE_RSA_AES128CBC_SHA
+                  , cipher_TLS13_AES128GCM_SHA256
                   , cipher_DHE_RSA_AES128_SHA1
                   , cipher_AES256_SHA256
                   ]
@@ -472,8 +481,9 @@ prop_handshake_srv_key_usage = do
                   { sharedCredentials = Credentials [cred]
                   }
             }
-        shouldSucceed = KeyUsage_digitalSignature `elem` usageFlags
-                            || KeyUsage_keyEncipherment `elem` usageFlags
+        hasDS = KeyUsage_digitalSignature `elem` usageFlags
+        hasKE = KeyUsage_keyEncipherment  `elem` usageFlags
+        shouldSucceed = hasDS || (hasKE && not tls13)
     if shouldSucceed
         then runTLSPipeSimple  (clientParam,serverParam')
         else runTLSInitFailure (clientParam,serverParam')

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -569,13 +569,14 @@ prop_handshake_sni = do
 
 prop_handshake_renegotiation :: PropertyM IO ()
 prop_handshake_renegotiation = do
+    renegDisabled <- pick arbitrary
     (cparams, sparams) <- pick arbitraryPairParams
     let sparams' = sparams {
             serverSupported = (serverSupported sparams) {
-                 supportedClientInitiatedRenegotiation = True
+                 supportedClientInitiatedRenegotiation = not renegDisabled
                }
           }
-    if isVersionEnabled TLS13 (cparams, sparams')
+    if renegDisabled || isVersionEnabled TLS13 (cparams, sparams')
         then runTLSInitFailureGen (cparams, sparams') hsServer hsClient
         else runTLSPipe (cparams, sparams') tlsServer tlsClient
   where tlsServer ctx queue = do

--- a/test-scripts/TestClient.hs
+++ b/test-scripts/TestClient.hs
@@ -22,7 +22,7 @@ import System.IO
 
 import qualified Data.ByteString.UTF8 as UTF8
 
-data Version = SSL3 | TLS10 | TLS11 | TLS12
+data Version = SSL3 | TLS10 | TLS11 | TLS12 | TLS13
     deriving (Show,Eq,Ord)
 
 data Option = Everything
@@ -105,6 +105,7 @@ userAgent = "--user-agent=haskell tls 1.2"
               --tls10                  use TLS 1.0
               --tls11                  use TLS 1.1
               --tls12                  use TLS 1.2 (default)
+              --tls13                  use TLS 1.3
               --bogocipher=cipher-id   add a bogus cipher id for testing
   -x          --no-version-downgrade   do not allow version downgrade
               --uri=URI                optional URI requested by default /
@@ -134,6 +135,7 @@ simpleClient clientPort clientHost uri ver certVal clientCert =
                 TLS10 -> "--tls10"
                 TLS11 -> "--tls11"
                 TLS12 -> "--tls12"
+                TLS13 -> "--tls13"
 
 opensslServer :: String -> Int -> String -> String -> Version -> Bool -> Bool -> IO (ExitCode, ByteString, ByteString)
 opensslServer readyFile port cert key ver useClientCert useDhe =
@@ -149,6 +151,7 @@ opensslServer readyFile port cert key ver useClientCert useDhe =
                 TLS10 -> "tls-1.0"
                 TLS11 -> "tls-1.1"
                 TLS12 -> "tls-1.2"
+                _     -> error ("opensslServer: unsupported version: " ++ show ver)
 
 data FailStatus = FailStatus
     { failName     :: String
@@ -180,8 +183,8 @@ wrapResult name f = do
         Nothing                        -> return $ Timeout name
 
 test :: String -> Option -> [IO Result]
-test url opt = do
-    map runOne [SSL3, TLS10, TLS11, TLS12]
+test url opt =
+    map runOne [SSL3, TLS10, TLS11, TLS12, TLS13]
   where
     runOne ver = if doesRun then reallyRunOne ver else return (Skipped (show ver))
       where
@@ -252,7 +255,7 @@ data Cred = Cred
 runLocal logFile pid = do
     putStrLn "running local test against OpenSSL"
     let combi = [ (ver, cert, dhe, serverCert)
-                | ver  <- [SSL3, TLS10, TLS11, TLS12]
+                | ver  <- [SSL3, TLS10, TLS11, TLS12] -- no TLS13 yet for local
                 , cert <- [Nothing, Just ("test-certs/client.crt", "test-certs/client.key") ]
                 , dhe  <- [False,True]
                 , serverCert <- [Cred "RSA" "test-certs/server.rsa.crt" "test-certs/server.rsa.key"
@@ -309,13 +312,15 @@ main = do
         -- Everything supported
         --t2 Everything [] ++
         -- SSL3 not supported
-        t2 (LowerBound TLS10)
+        t2 (RangeBound TLS10 TLS13)
+            [ "www.facebook.com"
+            ] ++
+        t2 (RangeBound TLS10 TLS12)
             [ "www.google.com"
-            , "www.facebook.com"
             , "mail.office365.com"
             , "www.udacity.com"
             ] ++
-        t2 (LowerBound TLS12)
+        t2 (RangeBound TLS12 TLS12)
             [ "developer.apple.com"
             , "www.github.com"
             , "login.live.com"


### PR DESCRIPTION
Continues from the discussion on #283 and adds TLS13 to existing test cases where possible.
This ensures that usage patterns which previously work are still possible with the new version.

Which is actually not true: currently we need to add a few `recvData` is some places not to break the scenarios. After this, for example it's possible to restore the missing `assertIsLeft sRes` in the renegotiation test.

Possible long-term solution to replace the `recvData` workaround I think is to move it directly into `bye`. But getting this right and safe may prove difficult.