### PR TITLE
Fix PSK binder with HRR

### DIFF
--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -606,7 +606,7 @@ onServerHello ctx cparams sentExts (ServerHello rver serverRan serverSession cip
         Nothing -> throwCore $ Error_Protocol ("server version " ++ show ver ++ " is not supported", True, ProtocolVersion)
         Just _  -> return ()
     if ver == TLS13 then do
-        usingHState ctx $ setHelloParameters13 cipherAlg isHRR
+        usingHState ctx $ setHelloParameters13 cipherAlg
         return RecvStateDone
       else do
         usingHState ctx $ setServerHelloParameters rver serverRan cipherAlg compressAlg

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -834,7 +834,7 @@ doHandshake13 sparams (certChain, privKey) ctx chosenVersion usedCipher exts use
         srand <- serverRandom ctx chosenVersion $ supportedVersions $ serverSupported sparams
         storePrivInfo ctx Nothing certChain privKey
         usingState_ ctx $ setVersion chosenVersion
-        usingHState ctx $ setHelloParameters13 usedCipher False
+        usingHState ctx $ setHelloParameters13 usedCipher
         return srand
 
     choosePSK = case extensionLookup extensionID_PreSharedKey exts >>= extensionDecode MsgTClientHello of
@@ -963,7 +963,7 @@ helloRetryRequest sparams ctx chosenVersion usedCipher exts serverGroups clientS
     when twice $
         throwCore $ Error_Protocol ("Hello retry not allowed again", True, HandshakeFailure)
     usingState_ ctx $ setTLS13HRR True
-    usingHState ctx $ setHelloParameters13 usedCipher True
+    usingHState ctx $ setHelloParameters13 usedCipher
     let clientGroups = case extensionLookup extensionID_NegotiatedGroups exts >>= extensionDecode MsgTClientHello of
           Just (NegotiatedGroups gs) -> gs
           Nothing                    -> []

--- a/core/Network/TLS/Sending13.hs
+++ b/core/Network/TLS/Sending13.hs
@@ -26,7 +26,9 @@ import Network.TLS.Packet
 import Network.TLS.Packet13
 import Network.TLS.Hooks
 import Network.TLS.Context.Internal
+import Network.TLS.Handshake.Random
 import Network.TLS.Handshake.State
+import Network.TLS.Handshake.State13
 import Network.TLS.Wire
 import Network.TLS.Imports
 
@@ -67,7 +69,11 @@ prepareRecord = runTxState
 
 updateHandshake13 :: Context -> Handshake13 -> IO ()
 updateHandshake13 ctx hs = usingHState ctx $ do
+    when (isHRR hs) wrapAsMessageHash13
     updateHandshakeDigest encoded
     addHandshakeMessage encoded
   where
     encoded = encodeHandshake13 hs
+
+    isHRR (ServerHello13 srand _ _ _) = isHelloRetryRequest srand
+    isHRR _                           = False


### PR DESCRIPTION
Currently resumption fails with error `PSK binder validation failed` when PSK is combined with HRR.

A simple scenario to show this is to launch a server with:
```
tls-simpleserver --key test-certs/server.rsa.key --certificate test-certs/server.rsa.crt --tls13 --group p384 4433
```
and to try to resume a session like this:
```
$ openssl s_client -sess_out /tmp/session.dat
$ openssl s_client -sess_in /tmp/session.dat
```

The reason is that the "message hash" wrapping is applied only when the transcript is used for key schedule but not when computing PSK binders. This PR changes the implementation to perform the "message hash" substitution directly in the pending transcript as soon as HRR is sent/received.

With something like this, the scenario above succeeds.  And it also becomes possible to launch a FFDHE-only server and connect to it with Firefox Nightly (e.g. `--group ffdhe3072`).