### PR TITLE
More test conditions for version downgrade

### DIFF
--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -567,7 +567,7 @@ throwMiscErrorOnException msg e =
 onServerHello :: Context -> ClientParams -> [ExtensionID] -> Handshake -> IO (RecvState IO)
 onServerHello ctx cparams sentExts (ServerHello rver serverRan serverSession cipher compression exts) = do
     when (isDowngraded (supportedVersions $ clientSupported cparams) serverRan) $
-        throwCore $ Error_Protocol ("verion downgrade detected", True, IllegalParameter)
+        throwCore $ Error_Protocol ("version downgrade detected", True, IllegalParameter)
     when (rver == SSL2) $ throwCore $ Error_Protocol ("ssl2 is not supported", True, ProtocolVersion)
     -- find the compression and cipher methods that the server want to use.
     cipherAlg <- case find ((==) cipher . cipherID) (supportedCiphers $ ctxSupported ctx) of

--- a/core/Network/TLS/Handshake/Random.hs
+++ b/core/Network/TLS/Handshake/Random.hs
@@ -24,13 +24,14 @@ serverRandom ctx chosenVer suppVers
       TLS12  -> ServerRandom <$> genServRand suffix12
       _      -> ServerRandom <$> genServRand suffix11
   | TLS12 `elem` suppVers = case chosenVer of
+      TLS13  -> ServerRandom <$> getStateRNG ctx 32
       TLS12  -> ServerRandom <$> getStateRNG ctx 32
       _      -> ServerRandom <$> genServRand suffix11
   | otherwise = ServerRandom <$> getStateRNG ctx 32
   where
     genServRand suff = do
         pref <- getStateRNG ctx 24
-        return $ (pref `B.append` suff)
+        return (pref `B.append` suff)
 
 isDowngraded :: [Version] -> ServerRandom -> Bool
 isDowngraded suppVers (ServerRandom sr)

--- a/core/Network/TLS/Handshake/Random.hs
+++ b/core/Network/TLS/Handshake/Random.hs
@@ -17,6 +17,14 @@ import qualified Data.ByteString as B
 import Network.TLS.Context.Internal
 import Network.TLS.Struct
 
+-- | Generate a server random suitable for the version selected by the server
+-- and its supported versions.  We use an 8-byte downgrade suffix when the
+-- selected version is lowered because of incomplete client support, but also
+-- when a version downgrade has been forced with 'debugVersionForced'.  This
+-- second part allows to test that the client implementation correctly detects
+-- downgrades.  The suffix is not used when forcing TLS13 to a server not
+-- officially supporting TLS13 (this is not a downgrade scenario but only the
+-- consequence of our debug API allowing this).
 serverRandom :: Context -> Version -> [Version] -> IO ServerRandom
 serverRandom ctx chosenVer suppVers
   | TLS13 `elem` suppVers = case chosenVer of
@@ -33,6 +41,8 @@ serverRandom ctx chosenVer suppVers
         pref <- getStateRNG ctx 24
         return (pref `B.append` suff)
 
+-- | Test if the negotiated version was artificially downgraded (that is, for
+-- other reason than the versions supported by the client).
 isDowngraded :: [Version] -> ServerRandom -> Bool
 isDowngraded suppVers (ServerRandom sr)
   | TLS13 `elem` suppVers = suffix12 `B.isSuffixOf` sr

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -190,7 +190,7 @@ prop_handshake13_downgrade = do
         sparam' = sparam { serverDebug = debug' }
         params = (cparam,sparam')
         downgraded = (isVersionEnabled TLS13 params && versionForced < TLS13) ||
-                     (isVersionEnabled TLS12 params && versionForced /= TLS12)
+                     (isVersionEnabled TLS12 params && versionForced < TLS12)
     if downgraded
         then runTLSInitFailure params
         else runTLSPipeSimple params


### PR DESCRIPTION
Extends the version-downgrade test case to all combinations.

The conditions look nicer if we also handle the case where version is forced to TLS13 in a TLS12 handshake.