### PR TITLE
PSK fallback to full or HRR handshake

### DIFF
--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -57,10 +57,11 @@ handshakeClientWith _       _   _            = throwCore $ Error_Protocol ("unex
 handshakeClient :: ClientParams -> Context -> IO ()
 handshakeClient cparams ctx = do
     let groups = case clientWantSessionResume cparams of
-              Nothing         -> supportedGroups (ctxSupported ctx)
+              Nothing         -> groupsSupported
               Just (_, sdata) -> case sessionGroup sdata of
                   Nothing  -> [] -- TLS 1.2 or earlier
-                  Just grp -> [grp]
+                  Just grp -> grp : filter (/= grp) groupsSupported
+        groupsSupported = supportedGroups (ctxSupported ctx)
     handshakeClient' cparams ctx groups Nothing
 
 -- https://tools.ietf.org/html/rfc8446#section-4.1.2 says:

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -22,7 +22,7 @@ import Network.TLS.Compression
 import Network.TLS.Credentials
 import Network.TLS.Crypto
 import Network.TLS.Extension
-import Network.TLS.Util (catchException, fromJust)
+import Network.TLS.Util (bytesEq, catchException, fromJust)
 import Network.TLS.IO
 import Network.TLS.Sending13
 import Network.TLS.Types
@@ -880,7 +880,7 @@ doHandshake13 sparams (certChain, privKey) ctx chosenVersion usedCipher exts use
     checkBinder _ Nothing = return []
     checkBinder earlySecret (Just (binder,n,tlen)) = do
         binder' <- makePSKBinder ctx earlySecret usedHash tlen Nothing
-        when (binder /= binder') $
+        unless (binder `bytesEq` binder') $
             throwCore $ Error_Protocol ("PSK binder validation failed", True, HandshakeFailure)
         let selectedIdentity = extensionEncode $ PreSharedKeyServerHello $ fromIntegral n
         return [ExtensionRaw extensionID_PreSharedKey selectedIdentity]

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -852,8 +852,8 @@ doHandshake13 sparams (certChain, privKey) ctx chosenVersion usedCipher exts use
                 if isPSKvalid && isFresh then
                     return (psk, Just (bnd,0::Int,len),is0RTTvalid)
                   else
-                    -- fixme: fall back to full handshake
-                    throwCore $ Error_Protocol ("PSK validation failed", True, HandshakeFailure)
+                    -- fall back to full handshake
+                    return (zero, Nothing, False)
             _      -> return (zero, Nothing, False)
       _ -> return (zero, Nothing, False)
 


### PR DESCRIPTION
I don't see any reason why this transition is not enabled in the server.

In the client, the scenario just needs to use the full list of supported groups. Currently it is unnecessarily restricted.

Additionally, I change comparison of PSK binders to constant time `bytesEq`, otherwise I think it completely defeats the purpose.