### PR TITLE
Rework how handshake messages are handled in TLS13

### DIFF
--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -209,13 +209,13 @@ usingState ctx f =
 usingState_ :: Context -> TLSSt a -> IO a
 usingState_ ctx f = failOnEitherError $ usingState ctx f
 
-usingHState :: Context -> HandshakeM a -> IO a
+usingHState :: MonadIO m => Context -> HandshakeM a -> m a
 usingHState ctx f = liftIO $ modifyMVar (ctxHandshake ctx) $ \mst ->
     case mst of
         Nothing -> throwCore $ Error_Misc "missing handshake"
         Just st -> return $ swap (Just <$> runHandshake st f)
 
-getHState :: Context -> IO (Maybe HandshakeState)
+getHState :: MonadIO m => Context -> m (Maybe HandshakeState)
 getHState ctx = liftIO $ readMVar (ctxHandshake ctx)
 
 runTxState :: Context -> RecordM a -> IO (Either TLSError a)

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -842,9 +842,8 @@ handshakeClient13' cparams ctx usedCipher usedHash = do
           _ -> return (hkdfExtract usedHash zero zero, False)
 
     recvEncryptedExtensions = do
-        ee@(EncryptedExtensions13 eexts) <- recvHandshake13 ctx
+        EncryptedExtensions13 eexts <- recvHandshake13 ctx
         setALPN ctx eexts
-        updateHandshake13 ctx ee
         st <- usingHState ctx getTLS13RTT0Status
         if st == RTT0Sent then
             case extensionLookup extensionID_EarlyData eexts of
@@ -865,7 +864,6 @@ handshakeClient13' cparams ctx usedCipher usedHash = do
             CertRequest13 token exts -> do
                 let hsextID = extensionID_SignatureAlgorithms
                     -- caextID = extensionID_SignatureAlgorithmsCert
-                updateHandshake13 ctx hmsg
                 dNames <- canames exts
                 -- The @signature_algorithms@ extension is mandatory.
                 hsAlgs <- extalgs hsextID exts unsighash
@@ -893,15 +891,12 @@ handshakeClient13' cparams ctx usedCipher usedHash = do
         --
         let Certificate13 _ cc@(CertificateChain certChain) _ = cert
         _ <- processCertificate cparams ctx (Certificates cc)
-        updateHandshake13 ctx cert
         pubkey <- case certChain of
                     [] -> throwCore $ Error_Protocol ("server certificate missing", True, HandshakeFailure)
                     c:_ -> return $ certPubKey $ getCertificate c
-        certVerify <- recvHandshake13 ctx
-        let CertVerify13 ss sig = certVerify
         hChSc <- transcriptHash ctx
+        CertVerify13 ss sig <- recvHandshake13 ctx
         checkServerCertVerify ss sig pubkey hChSc
-        updateHandshake13 ctx certVerify
       where
         canames exts = case extensionLookup
                             extensionID_CertificateAuthorities exts of
@@ -933,13 +928,11 @@ handshakeClient13' cparams ctx usedCipher usedHash = do
         -}
 
     recvFinished serverHandshakeTrafficSecret = do
-        finished <- recvHandshake13 ctx
         hChSv <- transcriptHash ctx
         let verifyData' = makeVerifyData usedHash serverHandshakeTrafficSecret hChSv
-        let Finished13 verifyData = finished
+        Finished13 verifyData <- recvHandshake13 ctx
         when (verifyData' /= verifyData) $
             throwCore $ Error_Protocol ("cannot verify finished", True, HandshakeFailure)
-        updateHandshake13 ctx finished
 
     setResumptionSecret masterSecret = do
         hChCf <- transcriptHash ctx
@@ -954,14 +947,14 @@ recvHandshake13 ctx = do
             epkt <- recvPacket13 ctx
             case epkt of
                 Right (Handshake13 [])     -> recvHandshake13 ctx
-                Right (Handshake13 (h:hs)) -> do
-                    usingHState ctx $ setTLS13HandshakeMsgs hs
-                    return h
+                Right (Handshake13 (h:hs)) -> found h hs
                 Right ChangeCipherSpec13   -> recvHandshake13 ctx
-                x                          -> error $ show x
-        h:hs -> do
-            usingHState ctx $ setTLS13HandshakeMsgs hs
-            return h
+                Right x                    -> unexpected (show x) (Just "Handshake13")
+                Left err                   -> throwCore err
+        h:hs -> found h hs
+  where
+    found h hs = do usingHState ctx $ setTLS13HandshakeMsgs hs
+                    updateHandshake13 ctx h >> return h
 
 setALPN :: Context -> [ExtensionRaw] -> IO ()
 setALPN ctx exts = case extensionLookup extensionID_ApplicationLayerProtocolNegotiation exts >>= extensionDecode MsgTServerHello of

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -23,7 +23,6 @@ import Network.TLS.Packet hiding (getExtensions)
 import Network.TLS.ErrT
 import Network.TLS.Extension
 import Network.TLS.IO
-import Network.TLS.Sending13
 import Network.TLS.Imports
 import Network.TLS.State
 import Network.TLS.Measurement
@@ -740,9 +739,11 @@ handshakeClient13 _cparams ctx = do
 handshakeClient13' :: ClientParams -> Context -> Cipher -> Hash -> IO ()
 handshakeClient13' cparams ctx usedCipher usedHash = do
     (resuming, handshakeSecret, clientHandshakeTrafficSecret, serverHandshakeTrafficSecret) <- switchToHandshakeSecret
-    rtt0accepted <- recvEncryptedExtensions
-    unless resuming recvCertAndVerify
-    recvFinished serverHandshakeTrafficSecret
+    rtt0accepted <- runRecvHandshake13 $ do
+        accepted <- recvHandshake13 ctx expectEncryptedExtensions
+        unless resuming $ recvHandshake13 ctx expectCertRequest
+        recvFinished serverHandshakeTrafficSecret
+        return accepted
     hChSf <- transcriptHash ctx
     when rtt0accepted $ sendPacket13 ctx (Handshake13 [EndOfEarlyData13])
     -- putStrLn "---- setTxState ctx usedHash usedCipher clientHandshakeTrafficSecret"
@@ -839,9 +840,8 @@ handshakeClient13' cparams ctx usedCipher usedHash = do
                 Just _                           -> throwCore $ Error_Protocol ("selected identity out of range", True, IllegalParameter)
           _ -> return (hkdfExtract usedHash zero zero, False)
 
-    recvEncryptedExtensions = do
-        EncryptedExtensions13 eexts <- recvHandshake13 ctx
-        setALPN ctx eexts
+    expectEncryptedExtensions (EncryptedExtensions13 eexts) = do
+        liftIO $ setALPN ctx eexts
         st <- usingHState ctx getTLS13RTT0Status
         if st == RTT0Sent then
             case extensionLookup extensionID_EarlyData eexts of
@@ -855,49 +855,30 @@ handshakeClient13' cparams ctx usedCipher usedHash = do
                   return False
           else
             return False
+    expectEncryptedExtensions p = unexpected (show p) (Just "encrypted extensions")
 
-    recvCertAndVerify = do
-        hmsg <- recvHandshake13 ctx
-        cert <- case hmsg of
-            CertRequest13 token exts -> do
-                let hsextID = extensionID_SignatureAlgorithms
-                    -- caextID = extensionID_SignatureAlgorithmsCert
-                dNames <- canames exts
-                -- The @signature_algorithms@ extension is mandatory.
-                hsAlgs <- extalgs hsextID exts unsighash
-                cTypes <- case hsAlgs of
-                    Just as -> return $ sigAlgsToCertTypes ctx as
-                    Nothing -> throwCore $ Error_Protocol
-                                   ( "invalid certificate request"
-                                   , True
-                                   , HandshakeFailure )
-                -- Unused:
-                -- caAlgs <- extalgs caextID exts uncertsig
-                usingHState ctx $ do
-                    setCertReqToken  $ Just token
-                    setCertReqCBdata $ Just (cTypes, hsAlgs, dNames)
-                    -- setCertReqSigAlgsCert caAlgs
-                recvHandshake13 ctx
-            _ -> do
-                usingHState ctx $ do
-                    setCertReqToken   Nothing
-                    setCertReqCBdata  Nothing
-                    -- setCertReqSigAlgsCert Nothing
-                return hmsg
-
-        -- FIXME: What happens when the pattern match fails?
-        --
-        let Certificate13 _ cc@(CertificateChain certChain) _ = cert
-        _ <- processCertificate cparams ctx (Certificates cc)
-        pubkey <- case certChain of
-                    [] -> throwCore $ Error_Protocol ("server certificate missing", True, HandshakeFailure)
-                    c:_ -> return $ certPubKey $ getCertificate c
-        hChSc <- transcriptHash ctx
-        CertVerify13 ss sig <- recvHandshake13 ctx
-        checkServerCertVerify ss sig pubkey hChSc
+    expectCertRequest (CertRequest13 token exts) = do
+        let hsextID = extensionID_SignatureAlgorithms
+            -- caextID = extensionID_SignatureAlgorithmsCert
+        dNames <- canames
+        -- The @signature_algorithms@ extension is mandatory.
+        hsAlgs <- extalgs hsextID unsighash
+        cTypes <- case hsAlgs of
+            Just as -> return $ sigAlgsToCertTypes ctx as
+            Nothing -> throwCore $ Error_Protocol
+                            ( "invalid certificate request"
+                            , True
+                            , HandshakeFailure )
+        -- Unused:
+        -- caAlgs <- extalgs caextID uncertsig
+        usingHState ctx $ do
+            setCertReqToken  $ Just token
+            setCertReqCBdata $ Just (cTypes, hsAlgs, dNames)
+            -- setCertReqSigAlgsCert caAlgs
+        recvHandshake13 ctx expectCertAndVerify
       where
-        canames exts = case extensionLookup
-                            extensionID_CertificateAuthorities exts of
+        canames = case extensionLookup
+                       extensionID_CertificateAuthorities exts of
             Nothing   -> return []
             Just  ext -> case extensionDecode MsgTCertificateRequest ext of
                              Just (CertificateAuthorities names) -> return names
@@ -905,7 +886,7 @@ handshakeClient13' cparams ctx usedCipher usedHash = do
                                       ( "invalid certificate request"
                                       , True
                                       , HandshakeFailure )
-        extalgs extID exts decons = case extensionLookup extID exts of
+        extalgs extID decons = case extensionLookup extID exts of
             Nothing   -> return Nothing
             Just  ext -> case extensionDecode MsgTCertificateRequest ext of
                              Just e
@@ -925,34 +906,40 @@ handshakeClient13' cparams ctx usedCipher usedHash = do
         uncertsig (SignatureAlgorithmsCert a) = Just a
         -}
 
+    expectCertRequest other = do
+        usingHState ctx $ do
+            setCertReqToken   Nothing
+            setCertReqCBdata  Nothing
+            -- setCertReqSigAlgsCert Nothing
+        expectCertAndVerify other
+
+    expectCertAndVerify (Certificate13 _ cc@(CertificateChain certChain) _) = do
+        _ <- liftIO $ processCertificate cparams ctx (Certificates cc)
+        pubkey <- case certChain of
+                    [] -> throwCore $ Error_Protocol ("server certificate missing", True, HandshakeFailure)
+                    c:_ -> return $ certPubKey $ getCertificate c
+        hChSc <- transcriptHash ctx
+        recvHandshake13 ctx $ expectCertVerify pubkey hChSc
+    expectCertAndVerify p = unexpected (show p) (Just "server certificate")
+
+    expectCertVerify pubkey hChSc (CertVerify13 ss sig) =
+        checkServerCertVerify ss sig pubkey hChSc
+    expectCertVerify _ _ p = unexpected (show p) (Just "certificate verify")
+
     recvFinished serverHandshakeTrafficSecret = do
         hChSv <- transcriptHash ctx
         let verifyData' = makeVerifyData usedHash serverHandshakeTrafficSecret hChSv
-        Finished13 verifyData <- recvHandshake13 ctx
+        recvHandshake13 ctx $ expectFinished verifyData'
+
+    expectFinished verifyData' (Finished13 verifyData) =
         when (verifyData' /= verifyData) $
             throwCore $ Error_Protocol ("cannot verify finished", True, HandshakeFailure)
+    expectFinished _ p = unexpected (show p) (Just "server finished")
 
     setResumptionSecret masterSecret = do
         hChCf <- transcriptHash ctx
         let resumptionMasterSecret = deriveSecret usedHash masterSecret "res master" hChCf
         usingHState ctx $ setTLS13Secret $ ResuptionSecret resumptionMasterSecret
-
-recvHandshake13 :: Context -> IO Handshake13
-recvHandshake13 ctx = do
-    msgs <- usingHState ctx getTLS13HandshakeMsgs
-    case msgs of
-        [] -> do
-            epkt <- recvPacket13 ctx
-            case epkt of
-                Right (Handshake13 [])     -> recvHandshake13 ctx
-                Right (Handshake13 (h:hs)) -> found h hs
-                Right ChangeCipherSpec13   -> recvHandshake13 ctx
-                Right x                    -> unexpected (show x) (Just "Handshake13")
-                Left err                   -> throwCore err
-        h:hs -> found h hs
-  where
-    found h hs = do usingHState ctx $ setTLS13HandshakeMsgs hs
-                    updateHandshake13 ctx h >> return h
 
 setALPN :: Context -> [ExtensionRaw] -> IO ()
 setALPN ctx exts = case extensionLookup extensionID_ApplicationLayerProtocolNegotiation exts >>= extensionDecode MsgTServerHello of

--- a/core/Network/TLS/Handshake/Common.hs
+++ b/core/Network/TLS/Handshake/Common.hs
@@ -48,7 +48,7 @@ errorToAlert :: TLSError -> [(AlertLevel, AlertDescription)]
 errorToAlert (Error_Protocol (_, _, ad)) = [(AlertLevel_Fatal, ad)]
 errorToAlert _                           = [(AlertLevel_Fatal, InternalError)]
 
-unexpected :: String -> Maybe String -> IO a
+unexpected :: MonadIO m => String -> Maybe String -> m a
 unexpected msg expected = throwCore $ Error_Packet_unexpected msg (maybe "" (" expected: " ++) expected)
 
 newSession :: Context -> IO Session

--- a/core/Network/TLS/Handshake/Process.hs
+++ b/core/Network/TLS/Handshake/Process.hs
@@ -9,6 +9,7 @@
 --
 module Network.TLS.Handshake.Process
     ( processHandshake
+    , processHandshake13
     , startHandshake
     , getHandshakeDigest
     ) where
@@ -23,6 +24,7 @@ import Network.TLS.Util
 import Network.TLS.Packet
 import Network.TLS.ErrT
 import Network.TLS.Struct
+import Network.TLS.Struct13
 import Network.TLS.State
 import Network.TLS.Context.Internal
 import Network.TLS.Crypto
@@ -33,6 +35,7 @@ import Network.TLS.Handshake.State13
 import Network.TLS.Handshake.Key
 import Network.TLS.Extension
 import Network.TLS.Parameters
+import Network.TLS.Sending13
 import Data.X509 (CertificateChain(..), Certificate(..), getCertificate)
 
 processHandshake :: Context -> Handshake -> IO ()
@@ -78,6 +81,9 @@ processHandshake ctx hs = do
 
         isHRR (ServerHello TLS12 srand _ _ _ _) = isHelloRetryRequest srand
         isHRR _                                 = False
+
+processHandshake13 :: Context -> Handshake13 -> IO ()
+processHandshake13 = updateHandshake13
 
 -- process the client key exchange message. the protocol expects the initial
 -- client version received in ClientHello, not the negotiated version.

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -24,7 +24,6 @@ import Network.TLS.Crypto
 import Network.TLS.Extension
 import Network.TLS.Util (catchException, fromJust)
 import Network.TLS.IO
-import Network.TLS.Sending13
 import Network.TLS.Types
 import Network.TLS.State
 import Network.TLS.Handshake.State
@@ -776,7 +775,7 @@ doHandshake13 sparams (certChain, privKey) ctx chosenVersion usedCipher exts use
     ----------------------------------------------------------------
     let masterSecret = hkdfExtract usedHash (deriveSecret usedHash handshakeSecret "derived" (hash usedHash "")) zero
     hChSf <- transcriptHash ctx
-    when rtt0OK $ updateHandshake13 ctx EndOfEarlyData13
+    when rtt0OK $ processHandshake13 ctx EndOfEarlyData13
     hChEoed <- transcriptHash ctx
     let clientApplicationTrafficSecret0 = deriveSecret usedHash masterSecret "c ap traffic" hChSf
         serverApplicationTrafficSecret0 = deriveSecret usedHash masterSecret "s ap traffic" hChSf
@@ -924,7 +923,7 @@ doHandshake13 sparams (certChain, privKey) ctx chosenVersion usedCipher exts use
 
     sendNewSessionTicket masterSecret pendingHandshake
       | sendNST = do
-        updateHandshake13 ctx pendingHandshake
+        processHandshake13 ctx pendingHandshake
         hChCf <- transcriptHash ctx
         nonce <- usingState_ ctx $ genRandom 32
         let resumptionMasterSecret = deriveSecret usedHash masterSecret "res master" hChCf

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -764,8 +764,8 @@ doHandshake13 sparams (certChain, privKey) ctx chosenVersion usedCipher exts use
     setRxState ctx usedHash usedCipher $ if rtt0OK then clientEarlyTrafficSecret else clientHandshakeTrafficSecret
     setTxState ctx usedHash usedCipher serverHandshakeTrafficSecret
     ----------------------------------------------------------------
-    serverHandshake <- makeServerHandshake authenticated serverHandshakeTrafficSecret rtt0OK
     Right ccs <- writePacket13 ctx ChangeCipherSpec13
+    serverHandshake <- makeServerHandshake authenticated serverHandshakeTrafficSecret rtt0OK
     sendBytes13 ctx $ B.concat (helo : ccs : serverHandshake)
     sfSentTime <- getCurrentTimeFromBase
     ----------------------------------------------------------------

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -745,28 +745,33 @@ doHandshake13 sparams (certChain, privKey) ctx chosenVersion usedCipher exts use
              return ()
     (ecdhe,keyShare) <- makeServerKeyShare ctx clientKeyShare
     let handshakeSecret = hkdfExtract usedHash (deriveSecret usedHash earlySecret "derived" (hash usedHash "")) ecdhe
-    helo <- makeServerHello keyShare srand extensions >>= writeHandshakePacket13 ctx
+    clientHandshakeTrafficSecret <- runPacketFlight ctx $ do
+        sendServerHello keyShare srand extensions
     ----------------------------------------------------------------
-    hChSh <- transcriptHash ctx
-    let clientHandshakeTrafficSecret = deriveSecret usedHash handshakeSecret "c hs traffic" hChSh
-        serverHandshakeTrafficSecret = deriveSecret usedHash handshakeSecret "s hs traffic" hChSh
-    -- putStrLn $ "handshakeSecret: " ++ showBytesHex handshakeSecret
-    -- putStrLn $ "hChSh: " ++ showBytesHex hChSh
-    -- usingHState ctx getHandshakeMessages >>= mapM_ (putStrLn . showBytesHex)
-    -- dumpKey ctx "SERVER_HANDSHAKE_TRAFFIC_SECRET" serverHandshakeTrafficSecret
-    -- dumpKey ctx "CLIENT_HANDSHAKE_TRAFFIC_SECRET" clientHandshakeTrafficSecret
+        hChSh <- transcriptHash ctx
+        let clientHandshakeTrafficSecret = deriveSecret usedHash handshakeSecret "c hs traffic" hChSh
+            serverHandshakeTrafficSecret = deriveSecret usedHash handshakeSecret "s hs traffic" hChSh
+        -- putStrLn $ "handshakeSecret: " ++ showBytesHex handshakeSecret
+        -- putStrLn $ "hChSh: " ++ showBytesHex hChSh
+        -- usingHState ctx getHandshakeMessages >>= mapM_ (putStrLn . showBytesHex)
+        -- dumpKey ctx "SERVER_HANDSHAKE_TRAFFIC_SECRET" serverHandshakeTrafficSecret
+        -- dumpKey ctx "CLIENT_HANDSHAKE_TRAFFIC_SECRET" clientHandshakeTrafficSecret
 {-
-    if rtt0OK then
-       putStrLn "---- setRxState ctx usedHash usedCipher clientEarlyTrafficSecret"
-     else
-       putStrLn "---- setRxState ctx usedHash usedCipher clientHandshakeTrafficSecret"
+        if rtt0OK then
+           putStrLn "---- setRxState ctx usedHash usedCipher clientEarlyTrafficSecret"
+         else
+           putStrLn "---- setRxState ctx usedHash usedCipher clientHandshakeTrafficSecret"
 -}
-    setRxState ctx usedHash usedCipher $ if rtt0OK then clientEarlyTrafficSecret else clientHandshakeTrafficSecret
-    setTxState ctx usedHash usedCipher serverHandshakeTrafficSecret
+        liftIO $ do
+            setRxState ctx usedHash usedCipher $ if rtt0OK then clientEarlyTrafficSecret else clientHandshakeTrafficSecret
+            setTxState ctx usedHash usedCipher serverHandshakeTrafficSecret
     ----------------------------------------------------------------
-    Right ccs <- writePacket13 ctx ChangeCipherSpec13
-    serverHandshake <- makeServerHandshake authenticated serverHandshakeTrafficSecret rtt0OK
-    sendBytes13 ctx $ B.concat (helo : ccs : serverHandshake)
+        loadPacket13 ctx ChangeCipherSpec13
+        sendExtensions rtt0OK
+        unless authenticated sendCertAndVerify
+        rawFinished <- makeFinished ctx usedHash serverHandshakeTrafficSecret
+        loadPacket13 ctx $ Handshake13 [rawFinished]
+        return clientHandshakeTrafficSecret
     sfSentTime <- getCurrentTimeFromBase
     ----------------------------------------------------------------
     let masterSecret = hkdfExtract usedHash (deriveSecret usedHash handshakeSecret "derived" (hash usedHash "")) zero
@@ -885,31 +890,26 @@ doHandshake13 sparams (certChain, privKey) ctx chosenVersion usedCipher exts use
         let selectedIdentity = extensionEncode $ PreSharedKeyServerHello $ fromIntegral n
         return [ExtensionRaw extensionID_PreSharedKey selectedIdentity]
 
-    makeServerHello keyShare srand extensions = do
+    sendServerHello keyShare srand extensions = do
         let serverKeyShare = extensionEncode $ KeyShareServerHello keyShare
             selectedVersion = extensionEncode $ SupportedVersionsServerHello chosenVersion
             extensions' = ExtensionRaw extensionID_KeyShare serverKeyShare
                         : ExtensionRaw extensionID_SupportedVersions selectedVersion
                         : extensions
-        return $ ServerHello13 srand clientSession (cipherID usedCipher) extensions'
+            helo = ServerHello13 srand clientSession (cipherID usedCipher) extensions'
+        loadPacket13 ctx $ Handshake13 [helo]
 
-    makeServerHandshake False serverHandshakeTrafficSecret rtt0OK = do
-        eext <- makeExtensions rtt0OK >>= writeHandshakePacket13 ctx
+    sendCertAndVerify = do
         let CertificateChain cs = certChain
             ess = replicate (length cs) []
-        cert <- writeHandshakePacket13 ctx $ Certificate13 "" certChain ess
+        loadPacket13 ctx $ Handshake13 [Certificate13 "" certChain ess]
         hChSc <- transcriptHash ctx
-        vrfy <- makeServerCertVerify ctx sigAlgo privKey hChSc >>= writeHandshakePacket13 ctx
-        fish <- makeFinished ctx usedHash serverHandshakeTrafficSecret >>= writeHandshakePacket13 ctx
-        return [eext, cert, vrfy, fish]
-    makeServerHandshake True serverHandshakeTrafficSecret rtt0OK = do
-        eext <- makeExtensions rtt0OK >>= writeHandshakePacket13 ctx
-        fish <- makeFinished ctx usedHash serverHandshakeTrafficSecret >>= writeHandshakePacket13 ctx
-        return [eext, fish]
+        vrfy <- makeServerCertVerify ctx sigAlgo privKey hChSc
+        loadPacket13 ctx $ Handshake13 [vrfy]
 
-    makeExtensions rtt0OK = do
-        extensions' <- applicationProtocol ctx exts sparams
-        msni <- usingState_ ctx getClientSNI
+    sendExtensions rtt0OK = do
+        extensions' <- liftIO $ applicationProtocol ctx exts sparams
+        msni <- liftIO $ usingState_ ctx getClientSNI
         let extensions'' = case msni of
               -- RFC6066: In this event, the server SHALL include
               -- an extension of type "server_name" in the
@@ -920,7 +920,7 @@ doHandshake13 sparams (certChain, privKey) ctx chosenVersion usedCipher exts use
         let extensions
               | rtt0OK = ExtensionRaw extensionID_EarlyData (extensionEncode (EarlyDataIndication Nothing)) : extensions''
               | otherwise = extensions''
-        return $ EncryptedExtensions13 extensions
+        loadPacket13 ctx $ Handshake13 [EncryptedExtensions13 extensions]
 
     sendNewSessionTicket masterSecret pendingHandshake
       | sendNST = do

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -1032,7 +1032,7 @@ applicationProtocol ctx exts sparams
         suggest <- usingState_ ctx getClientALPNSuggest
         case (onALPNClientSuggest $ serverHooks sparams, suggest) of
             (Just io, Just protos) -> do
-                proto <- liftIO $ io protos
+                proto <- io protos
                 usingState_ ctx $ do
                     setExtensionALPN True
                     setNegotiatedProtocol proto

--- a/core/Network/TLS/Handshake/State.hs
+++ b/core/Network/TLS/Handshake/State.hs
@@ -63,15 +63,12 @@ module Network.TLS.Handshake.State
     , getTLS13HandshakeMode
     , setTLS13RTT0Status
     , getTLS13RTT0Status
-    , setTLS13HandshakeMsgs
-    , getTLS13HandshakeMsgs
     , setTLS13Secret
     , getTLS13Secret
     ) where
 
 import Network.TLS.Util
 import Network.TLS.Struct
-import Network.TLS.Struct13
 import Network.TLS.Record.State
 import Network.TLS.Packet
 import Network.TLS.Crypto
@@ -126,7 +123,6 @@ data HandshakeState = HandshakeState
     , hstNegotiatedGroup     :: Maybe Group
     , hstTLS13HandshakeMode  :: HandshakeMode13
     , hstTLS13RTT0Status     :: !RTT0Status
-    , hstTLS13HandshakeMsgs  :: [Handshake13]
     , hstTLS13Secret         :: Secret13
     } deriving (Show)
 
@@ -215,7 +211,6 @@ newEmptyHandshake ver crand = HandshakeState
     , hstNegotiatedGroup     = Nothing
     , hstTLS13HandshakeMode  = FullHandshake
     , hstTLS13RTT0Status     = RTT0None
-    , hstTLS13HandshakeMsgs  = []
     , hstTLS13Secret         = NoSecret
     }
 
@@ -295,12 +290,6 @@ setTLS13RTT0Status s = modify (\hst -> hst { hstTLS13RTT0Status = s })
 
 getTLS13RTT0Status :: HandshakeM RTT0Status
 getTLS13RTT0Status = gets hstTLS13RTT0Status
-
-setTLS13HandshakeMsgs :: [Handshake13] -> HandshakeM ()
-setTLS13HandshakeMsgs hmsgs = modify (\hst -> hst { hstTLS13HandshakeMsgs = hmsgs })
-
-getTLS13HandshakeMsgs :: HandshakeM [Handshake13]
-getTLS13HandshakeMsgs = gets hstTLS13HandshakeMsgs
 
 setTLS13Secret :: Secret13 -> HandshakeM ()
 setTLS13Secret secret = modify (\hst -> hst { hstTLS13Secret = secret })

--- a/core/Network/TLS/Handshake/State13.hs
+++ b/core/Network/TLS/Handshake/State13.hs
@@ -106,7 +106,7 @@ wrapAsMessageHash13 = do
                             , dig
                             ]
 
-transcriptHash :: Context -> IO ByteString
+transcriptHash :: MonadIO m => Context -> m ByteString
 transcriptHash ctx = do
     hst <- fromJust "HState" <$> getHState ctx
     case hstHandshakeDigest hst of

--- a/core/Network/TLS/IO.hs
+++ b/core/Network/TLS/IO.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -- |
 -- Module      : Network.TLS.IO
 -- License     : BSD-style
@@ -10,9 +11,12 @@ module Network.TLS.IO
     ( checkValid
     , sendPacket
     , sendPacket13
-    , sendBytes13
     , recvPacket
     , recvPacket13
+    -- * Grouping multiple packets in the same flight
+    , PacketFlightM
+    , runPacketFlight
+    , loadPacket13
     ) where
 
 import Network.TLS.Context.Internal
@@ -142,23 +146,22 @@ sendPacket ctx pkt = do
                         writePacket ctx pkt
     case edataToSend of
         Left err         -> throwCore err
-        Right dataToSend -> liftIO $ do
-            withLog ctx $ \logging -> loggingIOSent logging dataToSend
-            contextSend ctx dataToSend
+        Right dataToSend -> sendBytes ctx dataToSend
   where isNonNullAppData (AppData b) = not $ B.null b
         isNonNullAppData _           = False
 
 sendPacket13 :: MonadIO m => Context -> Packet13 -> m ()
-sendPacket13 ctx pkt = do
+sendPacket13 ctx pkt = writePacketBytes13 ctx pkt >>= sendBytes ctx
+
+writePacketBytes13 :: MonadIO m => Context -> Packet13 -> m ByteString
+writePacketBytes13 ctx pkt = do
     edataToSend <- liftIO $ do
                         withLog ctx $ \logging -> loggingPacketSent logging (show pkt)
                         writePacket13 ctx pkt
-    case edataToSend of
-        Left err         -> throwCore err
-        Right dataToSend -> sendBytes13 ctx dataToSend
+    either throwCore return edataToSend
 
-sendBytes13 :: MonadIO m => Context -> ByteString -> m ()
-sendBytes13 ctx dataToSend = liftIO $ do
+sendBytes :: MonadIO m => Context -> ByteString -> m ()
+sendBytes ctx dataToSend = liftIO $ do
     withLog ctx $ \logging -> loggingIOSent logging dataToSend
     contextSend ctx dataToSend
 
@@ -198,3 +201,21 @@ recvPacket13 ctx = liftIO $ do
                     Right p -> withLog ctx $ \logging -> loggingPacketRecv logging $ show p
                     _       -> return ()
                 return pkt
+
+-- | State monad used to group several packets together and send them on wire as
+-- single flight.  When packets are loaded in the monad, they are logged
+-- immediately, update the context digest and transcript, but actual sending is
+-- deferred.  Packets are sent all at once when the monadic computation ends.
+newtype PacketFlightM m a = PacketFlightM (StateT [ByteString] m a)
+    deriving (Functor, Applicative, Monad, MonadIO)
+
+runPacketFlight :: MonadIO m => Context -> PacketFlightM m a -> m a
+runPacketFlight ctx (PacketFlightM f) = do
+    (result, st) <- runStateT f []
+    unless (null st) $ sendBytes ctx $ B.concat $ reverse st
+    return result
+
+loadPacket13 :: MonadIO m => Context -> Packet13 -> PacketFlightM m ()
+loadPacket13 ctx pkt = PacketFlightM $ do
+    bs <- writePacketBytes13 ctx pkt
+    modify (bs :)

--- a/core/Network/TLS/Sending13.hs
+++ b/core/Network/TLS/Sending13.hs
@@ -10,7 +10,6 @@
 --
 module Network.TLS.Sending13
        ( writePacket13
-       , writeHandshakePacket13
        , updateHandshake13
        ) where
 
@@ -24,7 +23,6 @@ import Network.TLS.Record.Types13
 import Network.TLS.Record.Engage13
 import Network.TLS.Packet
 import Network.TLS.Packet13
-import Network.TLS.Hooks
 import Network.TLS.Context.Internal
 import Network.TLS.Handshake.Random
 import Network.TLS.Handshake.State
@@ -53,16 +51,6 @@ writePacket13 ctx pkt@(Handshake13 hss) = do
     forM_ hss $ updateHandshake13 ctx
     prepareRecord ctx (makeRecord pkt >>= engageRecord >>= encodeRecord)
 writePacket13 ctx pkt = prepareRecord ctx (makeRecord pkt >>= engageRecord >>= encodeRecord)
-
-writeHandshakePacket13 :: MonadIO m => Context -> Handshake13 -> m ByteString
-writeHandshakePacket13 ctx hdsk = do
-    let pkt = Handshake13 [hdsk]
-    edataToSend <- liftIO $ do
-        withLog ctx $ \logging -> loggingPacketSent logging (show pkt)
-        writePacket13 ctx pkt
-    case edataToSend of
-        Left err         -> throwCore err
-        Right dataToSend -> return dataToSend
 
 prepareRecord :: Context -> RecordM a -> IO (Either TLSError a)
 prepareRecord = runTxState


### PR DESCRIPTION
Uses monads in 1.3 handshake code to encapsulate two aspects currently existing:

- Unprocessed Handshake13 messages are buffered in hstTLS13HandshakeMsgs but nothing verifies that the messages have all been consumed. With runRecvHandshake13 we can instead delimit the point where messages are all expected to be processed.  With the new recvHandshake13 function, the call to updateHandshake13 is now automatic and it is possible to test if the message type received is the type expected (explicit error instead of pattern-match failure).

- No more direct concatenation of encoded packets as bytestrings in handshake code. With PacketFlightM, packets are buffered and update the transcript, but are sent all at once on wire when the monadic computation ends.