### PR TITLE
Use constEq from package memory

### DIFF
--- a/core/Network/TLS/Util.hs
+++ b/core/Network/TLS/Util.hs
@@ -5,13 +5,13 @@ module Network.TLS.Util
         , partition3
         , partition6
         , fromJust
-        , and'
         , (&&!)
         , bytesEq
         , fmapEither
         , catchException
         ) where
 
+import qualified Data.ByteArray as BA
 import qualified Data.ByteString as B
 import Network.TLS.Imports
 
@@ -52,10 +52,6 @@ fromJust :: String -> Maybe a -> a
 fromJust what Nothing  = error ("fromJust " ++ what ++ ": Nothing") -- yuck
 fromJust _    (Just x) = x
 
--- | This is a strict version of and
-and' :: [Bool] -> Bool
-and' l = foldl' (&&!) True l
-
 -- | This is a strict version of &&.
 (&&!) :: Bool -> Bool -> Bool
 True  &&! True  = True
@@ -67,9 +63,7 @@ False &&! False = False
 -- it's a non lazy version, that will compare every bytes.
 -- arguments with different length will bail out early
 bytesEq :: ByteString -> ByteString -> Bool
-bytesEq b1 b2
-    | B.length b1 /= B.length b2 = False
-    | otherwise                  = and' $ B.zipWith (==) b1 b2
+bytesEq = BA.constEq
 
 fmapEither :: (a -> b) -> Either l a -> Either l b
 fmapEither f = fmap f


### PR DESCRIPTION
The function from memory has better runtime behavior compared to the existing bytesEq.

Before:
```
bytesEq/0                                mean 422.3 ns  ( +- 3.048 ns  )
bytesEq/2                                mean 453.2 ns  ( +- 5.238 ns  )
bytesEq/4                                mean 448.9 ns  ( +- 4.501 ns  )
bytesEq/8                                mean 451.7 ns  ( +- 5.345 ns  )
bytesEq/16                               mean 435.3 ns  ( +- 4.872 ns  )
```

After:
```
bytesEq/0                                mean 20.89 ns  ( +- 313.9 ps  )
bytesEq/2                                mean 20.72 ns  ( +- 478.8 ps  )
bytesEq/4                                mean 20.86 ns  ( +- 406.2 ps  )
bytesEq/8                                mean 20.78 ns  ( +- 394.5 ps  )
bytesEq/16                               mean 20.74 ns  ( +- 403.2 ps  )
```

Both measured with sample code:
```haskell
bgroup "bytesEq"
    [ benchBytesEq "0"  16 0
    , benchBytesEq "2"  16 2
    , benchBytesEq "4"  16 4
    , benchBytesEq "8"  16 8
    , benchBytesEq "16" 16 16
    ]

benchBytesEq name len i = bench name $ nf (bytesEq a) b
  where
    a = B.replicate len 0x00
    b = B.replicate i   0x00 `B.append` B.replicate (len - i) 0xFF
```