### PR TITLE
sending a new session ticket after client finished

### DIFF
--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -177,7 +177,7 @@ recvData13 ctx = liftIO $ do
                 maxSize = case extensionLookup extensionID_EarlyData exts >>= extensionDecode MsgTNewSessionTicket of
                   Just (EarlyDataIndication (Just ms)) -> fromIntegral $ safeNonNegative32 ms
                   _                                    -> 0
-            tinfo <- createTLS13TicketInfo life (Right add)
+            tinfo <- createTLS13TicketInfo life (Right add) Nothing
             sdata <- getSessionData13 ctx usedCipher tinfo maxSize psk
             sessionEstablish (sharedSessionManager $ ctxShared ctx) label sdata
             -- putStrLn $ "NewSessionTicket received: lifetime = " ++ show life ++ " sec"

--- a/core/Network/TLS/Handshake/Common13.hs
+++ b/core/Network/TLS/Handshake/Common13.hs
@@ -176,7 +176,7 @@ replacePSKBinder pskz binder = identities `B.append` binders
 
 ----------------------------------------------------------------
 
-createTLS13TicketInfo :: Word32 -> Either Context Word32 -> Maybe Millisecond -> IO TLS13TicketInfo
+createTLS13TicketInfo :: Second -> Either Context Second -> Maybe Millisecond -> IO TLS13TicketInfo
 createTLS13TicketInfo life ecw mrtt = do
     -- Left:  serverSendTime
     -- Right: clientReceiveTime
@@ -188,26 +188,26 @@ createTLS13TicketInfo life ecw mrtt = do
   where
     x *+ y = x * 256 + fromIntegral y
 
-ageToObfuscatedAge :: Word32 -> TLS13TicketInfo -> Word32
+ageToObfuscatedAge :: Second -> TLS13TicketInfo -> Second
 ageToObfuscatedAge age tinfo = obfage
   where
     !obfage = age + ageAdd tinfo
 
-obfuscatedAgeToAge :: Word32 -> TLS13TicketInfo -> Word32
+obfuscatedAgeToAge :: Second -> TLS13TicketInfo -> Second
 obfuscatedAgeToAge obfage tinfo = age
   where
     !age = obfage - ageAdd tinfo
 
-isAgeValid :: Word32 -> TLS13TicketInfo -> Bool
+isAgeValid :: Second -> TLS13TicketInfo -> Bool
 isAgeValid age tinfo = age <= lifetime tinfo * 1000
 
-getAge :: TLS13TicketInfo -> IO Word32
+getAge :: TLS13TicketInfo -> IO Second
 getAge tinfo = do
     let clientReceiveTime = txrxTime tinfo
     clientSendTime <- getCurrentTimeFromBase
     return $! fromIntegral (clientSendTime - clientReceiveTime) -- milliseconds
 
-checkFreshness :: TLS13TicketInfo -> Word32 -> IO Bool
+checkFreshness :: TLS13TicketInfo -> Second -> IO Bool
 checkFreshness tinfo obfAge = do
     serverReceiveTime <- getCurrentTimeFromBase
     let freshness = if expectedArrivalTime > serverReceiveTime

--- a/core/Network/TLS/Handshake/Common13.hs
+++ b/core/Network/TLS/Handshake/Common13.hs
@@ -36,7 +36,6 @@ import Data.Bits (finiteBitSize)
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as B
 import Data.Hourglass
-import Data.IORef (newIORef, readIORef)
 import Network.TLS.Context.Internal
 import Network.TLS.Cipher
 import Network.TLS.Crypto
@@ -177,16 +176,15 @@ replacePSKBinder pskz binder = identities `B.append` binders
 
 ----------------------------------------------------------------
 
-createTLS13TicketInfo :: Word32 -> Either Context Word32 -> IO TLS13TicketInfo
-createTLS13TicketInfo life ecw = do
+createTLS13TicketInfo :: Word32 -> Either Context Word32 -> Maybe Millisecond -> IO TLS13TicketInfo
+createTLS13TicketInfo life ecw mrtt = do
     -- Left:  serverSendTime
     -- Right: clientReceiveTime
     bTime <- getCurrentTimeFromBase
     add <- case ecw of
         Left ctx -> B.foldl' (*+) 0 <$> usingState_ ctx (genRandom 4)
         Right ad -> return ad
-    rttref <- newIORef Nothing
-    return $ TLS13TicketInfo life add bTime rttref
+    return $ TLS13TicketInfo life add bTime mrtt
   where
     x *+ y = x * 256 + fromIntegral y
 
@@ -211,23 +209,20 @@ getAge tinfo = do
 
 checkFreshness :: TLS13TicketInfo -> Word32 -> IO Bool
 checkFreshness tinfo obfAge = do
-    mrtt <- readIORef $ estimatedRTT tinfo
-    case mrtt of
-      Nothing -> return False
-      Just rtt -> do
-        let expectedArrivalTime = serverSendTime + rtt + fromIntegral age
-        serverReceiveTime <- getCurrentTimeFromBase
-        let freshness = if expectedArrivalTime > serverReceiveTime
-                        then expectedArrivalTime - serverReceiveTime
-                        else serverReceiveTime - expectedArrivalTime
-        -- Some implementations round age up to second.
-        -- We take max of 2000 and rtt in the case where rtt is too small.
-        let tolerance = max 2000 rtt
-            isFresh = freshness < tolerance
-        return $ isAlive && isFresh
+    serverReceiveTime <- getCurrentTimeFromBase
+    let freshness = if expectedArrivalTime > serverReceiveTime
+                    then expectedArrivalTime - serverReceiveTime
+                    else serverReceiveTime - expectedArrivalTime
+    -- Some implementations round age up to second.
+    -- We take max of 2000 and rtt in the case where rtt is too small.
+    let tolerance = max 2000 rtt
+        isFresh = freshness < tolerance
+    return $ isAlive && isFresh
   where
     serverSendTime = txrxTime tinfo
+    Just rtt = estimatedRTT tinfo
     age = obfuscatedAgeToAge obfAge tinfo
+    expectedArrivalTime = serverSendTime + rtt + fromIntegral age
     isAlive = isAgeValid age tinfo
 
 getCurrentTimeFromBase :: IO Millisecond

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -850,7 +850,7 @@ doHandshake13 sparams (certChain, privKey) ctx chosenVersion usedCipher exts use
             is0RTTvalid = isSameVersion && isSameCipher && isSameALPN
         return (isPSKvalid, is0RTTvalid)
 
-    rtt0accept = serverEarlyDataSize sparams /= 0
+    rtt0accept = safeNonNegative32 (serverEarlyDataSize sparams) > 0
     rtt0 = case extensionLookup extensionID_EarlyData exts >>= extensionDecode MsgTClientHello of
              Just (EarlyDataIndication _) -> True
              Nothing                      -> False

--- a/core/Network/TLS/Types.hs
+++ b/core/Network/TLS/Types.hs
@@ -20,7 +20,6 @@ module Network.TLS.Types
     , Millisecond
     ) where
 
-import Data.IORef (IORef)
 import Network.TLS.Imports
 import Network.TLS.Crypto.Types (Group)
 
@@ -53,16 +52,8 @@ data TLS13TicketInfo = TLS13TicketInfo
     { lifetime :: Second      -- NewSessionTicket.ticket_lifetime in seconds
     , ageAdd   :: Second      -- NewSessionTicket.ticket_age_add
     , txrxTime :: Millisecond -- serverSendTime or clientReceiveTime
-    , estimatedRTT :: IORef (Maybe Millisecond)
-    } deriving (Eq)
-
-instance Show TLS13TicketInfo where
-    showsPrec d s = showParen (d > 10) $
-             showString "TLS13TicketInfo { "
-           . showString   "lifetime = " . shows (lifetime s)
-           . showString ", ageAdd = "   . shows (ageAdd s)
-           . showString ", txrxTime = " . shows (txrxTime s)
-           . showString " }"
+    , estimatedRTT :: Maybe Millisecond
+    } deriving (Show, Eq)
 
 -- | Cipher identification
 type CipherID = Word16


### PR DESCRIPTION
A server sends only one NST after receiving client finished. This fixes the issue of `IORef` and old RTT but gives up interoperability somewhat. This pach is consistent with client authentication since transcript hash is calculated in the finish action.