### PR TITLE
Improve pending-action mechanism

### DIFF
--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -21,6 +21,7 @@ module Network.TLS.Context.Internal
     , Context(..)
     , Hooks(..)
     , Established(..)
+    , PendingAction
     , ctxEOF
     , ctxHasSSLv2ClientHello
     , ctxDisableSSLv2ClientHello
@@ -61,6 +62,7 @@ import Network.TLS.Backend
 import Network.TLS.Extension
 import Network.TLS.Cipher
 import Network.TLS.Struct
+import Network.TLS.Struct13
 import Network.TLS.Compression (Compression)
 import Network.TLS.State
 import Network.TLS.Handshake.State
@@ -114,7 +116,7 @@ data Context = Context
     , ctxLockRead         :: MVar ()       -- ^ lock to use for reading data (including updating the state)
     , ctxLockState        :: MVar ()       -- ^ lock used during read/write when receiving and sending packet.
                                            -- it is usually nested in a write or read lock.
-    , ctxPendingActions   :: MVar [ByteString -> IO ()]
+    , ctxPendingActions   :: MVar [PendingAction]
     }
 
 data Established = NotEstablished
@@ -122,6 +124,8 @@ data Established = NotEstablished
                  | EarlyDataNotAllowed
                  | Established
                  deriving (Eq, Show)
+
+type PendingAction = Handshake13 -> IO ()
 
 updateMeasure :: Context -> (Measurement -> Measurement) -> IO ()
 updateMeasure ctx f = do

--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -201,7 +201,7 @@ recvData13 ctx = liftIO $ do
             case mPendingAction of
                 Nothing -> let reason = "unexpected handshake message " ++ show h in
                            terminate (Error_Misc reason) AlertLevel_Fatal UnexpectedMessage reason
-                Just pa -> pa h >> processHandshake13 hs
+                Just pa -> withRWLock ctx (pa h) >> processHandshake13 hs
 
         terminate = terminate' ctx (sendPacket13 ctx . Alert13)
 

--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -159,14 +159,6 @@ recvData13 ctx = liftIO $ do
         processHandshake13 (ClientHello13{}:_) = do
             let reason = "Client hello is not allowed"
             terminate (Error_Misc reason) AlertLevel_Fatal UnexpectedMessage reason
-        processHandshake13 (EndOfEarlyData13:hs) = do
-            alertAction <- popPendingAction ctx
-            alertAction "dummy"
-            processHandshake13 hs
-        processHandshake13 (Finished13 verifyData':hs) = do
-            finishedAction <- popPendingAction ctx
-            finishedAction verifyData'
-            processHandshake13 hs
         -- fixme: some implementations send multiple NST at the same time.
         -- Only the first one is used at this moment.
         processHandshake13 (NewSessionTicket13 life add nonce label exts:hs) = do
@@ -204,9 +196,12 @@ recvData13 ctx = liftIO $ do
               else do
                 let reason = "received key update before established"
                 terminate (Error_Misc reason) AlertLevel_Fatal UnexpectedMessage reason
-        processHandshake13 hhs = do
-            let reason = "unexpected message " ++ show hhs
-            terminate (Error_Misc reason) AlertLevel_Fatal UnexpectedMessage reason
+        processHandshake13 (h:hs) = do
+            mPendingAction <- popPendingAction ctx
+            case mPendingAction of
+                Nothing -> let reason = "unexpected handshake message " ++ show h in
+                           terminate (Error_Misc reason) AlertLevel_Fatal UnexpectedMessage reason
+                Just pa -> pa h >> processHandshake13 hs
 
         terminate = terminate' ctx (sendPacket13 ctx . Alert13)
 

--- a/core/Network/TLS/Handshake/State13.hs
+++ b/core/Network/TLS/Handshake/State13.hs
@@ -113,10 +113,11 @@ transcriptHash ctx = do
       HandshakeDigestContext hashCtx -> return $ hashFinal hashCtx
       HandshakeMessages      _       -> error "un-initialized handshake digest"
 
-setPendingActions :: Context -> [ByteString -> IO ()] -> IO ()
+setPendingActions :: Context -> [PendingAction] -> IO ()
 setPendingActions ctx bss =
     modifyMVar_ (ctxPendingActions ctx) (\_ -> return bss)
 
-popPendingAction :: Context -> IO (ByteString -> IO ())
-popPendingAction ctx =
-    modifyMVar (ctxPendingActions ctx) (\(bs:bss) -> return (bss,bs)) -- fixme
+popPendingAction :: Context -> IO (Maybe PendingAction)
+popPendingAction ctx = modifyMVar (ctxPendingActions ctx) f
+  where f (bs:bss) = return (bss, Just bs)
+        f []       = return ([], Nothing)


### PR DESCRIPTION
Pending actions are now able to verify what message type is received before executing the action.