### PR TITLE
Use gauge instead of criterion

### DIFF
--- a/core/Benchmarks/Benchmarks.hs
+++ b/core/Benchmarks/Benchmarks.hs
@@ -4,7 +4,7 @@ module Main where
 import Connection
 import Certificate
 import PubKey
-import Criterion.Main
+import Gauge.Main
 import Control.Concurrent.Chan
 import Network.TLS
 import Data.X509

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -169,7 +169,7 @@ Benchmark bench-tls
                    , x509-validation
                    , data-default-class
                    , cryptonite
-                   , criterion >= 1.0
+                   , gauge
                    , bytestring
                    , asn1-types
                    , async >= 2.0


### PR DESCRIPTION
This removes many dependencies.

Before:
```
$ stack ls dependencies --test --bench | wc -l
      94
```

After:
```
$ stack ls dependencies --test --bench | wc -l
      60
```
