### PR TITLE
Early data over 16384 bytes

### DIFF
--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -145,7 +145,9 @@ recvData13 ctx = liftIO $ do
                 | chunkLen <= maxSize -> do
                     setEstablished ctx $ EarlyDataAllowed (maxSize - chunkLen)
                     return x
-                | otherwise              -> throwCore $ Error_Protocol ("early data overflow", True, UnexpectedMessage)
+                | otherwise ->
+                    let reason = "early data overflow" in
+                    terminate (Error_Misc reason) AlertLevel_Fatal UnexpectedMessage reason
               EarlyDataNotAllowed -> recvData13 ctx -- ignore "x"
               Established         -> return x
               NotEstablished      -> throwCore $ Error_Protocol ("data at not-established", True, UnexpectedMessage)

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -26,7 +26,7 @@ import Network.TLS.IO
 import Network.TLS.Imports
 import Network.TLS.State
 import Network.TLS.Measurement
-import Network.TLS.Util (bytesEq, catchException, fromJust)
+import Network.TLS.Util (bytesEq, catchException, fromJust, mapChunks_)
 import Network.TLS.Types
 import Network.TLS.X509
 import qualified Data.ByteString as B
@@ -267,7 +267,7 @@ handshakeClient' cparams ctx groups mcrand = do
                 -- dumpKey ctx "CLIENT_EARLY_TRAFFIC_SECRET" clientEarlyTrafficSecret
                 -- putStrLn "---- setTxState ctx usedHash usedCipher clientEarlyTrafficSecret"
                 setTxState ctx usedHash usedCipher clientEarlyTrafficSecret
-                sendPacket13 ctx $ AppData13 earlyData
+                mapChunks_ 16384 (sendPacket13 ctx . AppData13) earlyData
                 usingHState ctx $ setTLS13RTT0Status RTT0Sent
 
         recvServerHello sentExts = runRecvState ctx recvState

--- a/core/Network/TLS/Util.hs
+++ b/core/Network/TLS/Util.hs
@@ -9,6 +9,7 @@ module Network.TLS.Util
         , bytesEq
         , fmapEither
         , catchException
+        , mapChunks_
         ) where
 
 import qualified Data.ByteArray as BA
@@ -70,3 +71,11 @@ fmapEither f = fmap f
 
 catchException :: IO a -> (SomeException -> IO a) -> IO a
 catchException action handler = withAsync action waitCatch >>= either handler return
+
+mapChunks_ :: Monad m
+           => Int -> (B.ByteString -> m a) -> B.ByteString -> m ()
+mapChunks_ len f bs
+    | B.length bs > len =
+        let (chunk, remain) = B.splitAt len bs
+         in f chunk >> mapChunks_ len f remain
+    | otherwise = void (f bs)


### PR DESCRIPTION
This splits 0-RTT data in 16384-byte chunks like regular data.

Additionally the PR fixes server-side handling of early-data overflow:
- alert was not sent to the client
- overflow check must be based on the total size received, not the individual segments