### PR TITLE
Some thread-safety for writes

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,5 @@
+- arguments: [ --cpp-define=SSLV2_COMPATIBLE
+             , --cpp-define=INCLUDE_NETWORK
+             , --cpp-define=INCLUDE_HANS
+             ]
+- ignore: { name: Use camelCase }

--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -176,7 +176,7 @@ contextNewOnHandle :: (MonadIO m, TLSParams params)
                    => Handle -- ^ Handle of the connection.
                    -> params -- ^ Parameters of the context.
                    -> m Context
-contextNewOnHandle handle params = contextNew handle params
+contextNewOnHandle = contextNew
 {-# DEPRECATED contextNewOnHandle "use contextNew" #-}
 
 #ifdef INCLUDE_NETWORK

--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -143,7 +143,7 @@ contextNew backend params = liftIO $ do
     tx    <- newMVar newRecordState
     rx    <- newMVar newRecordState
     hs    <- newMVar Nothing
-    as    <- newMVar []
+    as    <- newIORef []
     lockWrite <- newMVar ()
     lockRead  <- newMVar ()
     lockState <- newMVar ()

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -187,10 +187,10 @@ ctxWithHooks :: Context -> (Hooks -> IO a) -> IO a
 ctxWithHooks ctx f = readIORef (ctxHooks ctx) >>= f
 
 contextModifyHooks :: Context -> (Hooks -> Hooks) -> IO ()
-contextModifyHooks ctx f = modifyIORef (ctxHooks ctx) f
+contextModifyHooks ctx = modifyIORef (ctxHooks ctx)
 
 setEstablished :: Context -> Established -> IO ()
-setEstablished ctx v = writeIORef (ctxEstablished_ ctx) v
+setEstablished ctx = writeIORef (ctxEstablished_ ctx)
 
 withLog :: Context -> (Logging -> IO ()) -> IO ()
 withLog ctx f = ctxWithHooks ctx (f . hookLogging)

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -116,7 +116,7 @@ data Context = Context
     , ctxLockRead         :: MVar ()       -- ^ lock to use for reading data (including updating the state)
     , ctxLockState        :: MVar ()       -- ^ lock used during read/write when receiving and sending packet.
                                            -- it is usually nested in a write or read lock.
-    , ctxPendingActions   :: MVar [PendingAction]
+    , ctxPendingActions   :: IORef [PendingAction]
     , ctxKeyLogger        :: String -> IO ()
     }
 

--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -274,8 +274,8 @@ data KeyUpdateRequest = OneWay -- ^ Unidirectional key update
 -- | Updating appication traffic secrets for TLS 1.3.
 --   If this API is called for TLS 1.3, 'True' is returned.
 --   Otherwise, 'False' is returned.
-updateKey :: Context -> KeyUpdateRequest -> IO Bool
-updateKey ctx way = do
+updateKey :: MonadIO m => Context -> KeyUpdateRequest -> m Bool
+updateKey ctx way = liftIO $ do
     tls13 <- tls13orLater ctx
     when tls13 $ do
         let req = case way of


### PR DESCRIPTION
Completes the use of read lock / write lock to handle concurrent calls sending and receiving data.

Hopefully it will be enough to solve the issue raised in #323.