### PR TITLE
Client auth server side

### DIFF
--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -126,7 +126,7 @@ data Established = NotEstablished
                  | Established
                  deriving (Eq, Show)
 
-type PendingAction = Handshake13 -> IO ()
+type PendingAction = Handshake13 -> IO (IO ())
 
 updateMeasure :: Context -> (Measurement -> Measurement) -> IO ()
 updateMeasure ctx f = do

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -126,7 +126,7 @@ data Established = NotEstablished
                  | Established
                  deriving (Eq, Show)
 
-type PendingAction = Handshake13 -> IO (IO ())
+type PendingAction = (Handshake13 -> IO (), IO ())
 
 updateMeasure :: Context -> (Measurement -> Measurement) -> IO ()
 updateMeasure ctx f = do

--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -217,11 +217,11 @@ recvData13 ctx = do
             case mPendingAction of
                 Nothing -> let reason = "unexpected handshake message " ++ show h in
                            terminate (Error_Misc reason) AlertLevel_Fatal UnexpectedMessage reason
-                Just pa -> do
+                Just (pa, postAction) -> do
                     -- Pending actions are executed with read+write locks, just
                     -- like regular handshake code.
                     withWriteLock ctx $ do
-                        postAction <- pa h
+                        pa h
                         processHandshake13 ctx h
                         postAction
                     loopHandshake13 hs

--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -148,7 +148,7 @@ recvData13 ctx = do
             setEOF ctx
             E.throwIO (Terminated True ("received fatal error: " ++ show desc) (Error_Protocol ("remote side fatal error", True, desc)))
         process (Handshake13 hs) = do
-            processHandshake13 hs
+            loopHandshake13 hs
             recvData13 ctx
         -- when receiving empty appdata, we just retry to get some data.
         process (AppData13 "") = recvData13 ctx
@@ -170,13 +170,13 @@ recvData13 ctx = do
         process p             = let reason = "unexpected message " ++ show p in
                                 terminate (Error_Misc reason) AlertLevel_Fatal UnexpectedMessage reason
 
-        processHandshake13 [] = return ()
-        processHandshake13 (ClientHello13{}:_) = do
+        loopHandshake13 [] = return ()
+        loopHandshake13 (ClientHello13{}:_) = do
             let reason = "Client hello is not allowed"
             terminate (Error_Misc reason) AlertLevel_Fatal UnexpectedMessage reason
         -- fixme: some implementations send multiple NST at the same time.
         -- Only the first one is used at this moment.
-        processHandshake13 (NewSessionTicket13 life add nonce label exts:hs) = do
+        loopHandshake13 (NewSessionTicket13 life add nonce label exts:hs) = do
             -- This part is similar to handshake code, so protected with
             -- read+write locks (which is also what we use for all calls to the
             -- session manager).
@@ -192,8 +192,8 @@ recvData13 ctx = do
                 sdata <- getSessionData13 ctx usedCipher tinfo maxSize psk
                 sessionEstablish (sharedSessionManager $ ctxShared ctx) label sdata
                 -- putStrLn $ "NewSessionTicket received: lifetime = " ++ show life ++ " sec"
-            processHandshake13 hs
-        processHandshake13 (KeyUpdate13 mode:hs) = do
+            loopHandshake13 hs
+        loopHandshake13 (KeyUpdate13 mode:hs) = do
             established <- ctxEstablished ctx
             -- Though RFC 8446 Sec 4.6.3 does not clearly says,
             -- unidirectional key update is legal.
@@ -207,11 +207,11 @@ recvData13 ctx = do
                 when (mode == UpdateRequested) $ withWriteLock ctx $ do
                     sendPacket13 ctx $ Handshake13 [KeyUpdate13 UpdateNotRequested]
                     keyUpdate ctx getTxState setTxState
-                processHandshake13 hs
+                loopHandshake13 hs
               else do
                 let reason = "received key update before established"
                 terminate (Error_Misc reason) AlertLevel_Fatal UnexpectedMessage reason
-        processHandshake13 (h:hs) = do
+        loopHandshake13 (h:hs) = do
             mPendingAction <- popPendingAction ctx
             case mPendingAction of
                 Nothing -> let reason = "unexpected handshake message " ++ show h in
@@ -219,7 +219,7 @@ recvData13 ctx = do
                 Just pa ->
                     -- Pending actions are executed with read+write locks, just
                     -- like regular handshake code.
-                    withWriteLock ctx (pa h) >> processHandshake13 hs
+                    withWriteLock ctx (pa h) >> loopHandshake13 hs
 
         terminate = terminateWithWriteLock ctx (sendPacket13 ctx . Alert13)
 

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -806,7 +806,7 @@ handshakeClient13' cparams ctx usedCipher usedHash = do
                   hChSc      <- transcriptHash ctx
                   keyAlg     <- getLocalDigitalSignatureAlg ctx
                   sigAlg     <- liftIO $ getLocalHashSigAlg ctx keyAlg
-                  vfy        <- makeClientCertVerify ctx keyAlg sigAlg hChSc
+                  vfy        <- makeCertVerify ctx keyAlg sigAlg hChSc
                   loadPacket13 ctx $ Handshake13 [vfy]
     --
     sendClientData13 _ _ =
@@ -948,7 +948,7 @@ handshakeClient13' cparams ctx usedCipher usedHash = do
 
     expectCertVerify pubkey hChSc (CertVerify13 sigAlg sig) = do
         let keyAlg = fromJust "fromPubKey" (fromPubKey pubkey)
-        ok <- checkServerCertVerify ctx keyAlg sigAlg sig hChSc
+        ok <- checkCertVerify ctx keyAlg sigAlg sig hChSc
         unless ok $ decryptError "cannot verify CertificateVerify"
     expectCertVerify _ _ p = unexpected (show p) (Just "certificate verify")
 

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -775,8 +775,8 @@ handshakeClient13' :: ClientParams -> Context -> Cipher -> Hash -> IO ()
 handshakeClient13' cparams ctx usedCipher usedHash = do
     (resuming, handshakeSecret, clientHandshakeTrafficSecret, serverHandshakeTrafficSecret) <- switchToHandshakeSecret
     rtt0accepted <- runRecvHandshake13 $ do
-        accepted <- recvHandshake13 ctx True expectEncryptedExtensions
-        unless resuming $ recvHandshake13 ctx True expectCertRequest
+        accepted <- recvHandshake13preUpdate ctx expectEncryptedExtensions
+        unless resuming $ recvHandshake13preUpdate ctx expectCertRequest
         recvFinished serverHandshakeTrafficSecret
         return accepted
     hChSf <- transcriptHash ctx
@@ -898,7 +898,7 @@ handshakeClient13' cparams ctx usedCipher usedHash = do
             setCertReqToken  $ Just token
             setCertReqCBdata $ Just (cTypes, hsAlgs, dNames)
             -- setCertReqSigAlgsCert caAlgs
-        recvHandshake13 ctx True expectCertAndVerify
+        recvHandshake13preUpdate ctx expectCertAndVerify
       where
         canames = case extensionLookup
                        extensionID_CertificateAuthorities exts of
@@ -943,7 +943,7 @@ handshakeClient13' cparams ctx usedCipher usedHash = do
                     c:_ -> return $ certPubKey $ getCertificate c
         usingHState ctx $ setPublicKey pubkey
         hChSc <- transcriptHash ctx
-        recvHandshake13 ctx True $ expectCertVerify pubkey hChSc
+        recvHandshake13preUpdate ctx $ expectCertVerify pubkey hChSc
     expectCertAndVerify p = unexpected (show p) (Just "server certificate")
 
     expectCertVerify pubkey hChSc (CertVerify13 sigAlg sig) = do
@@ -955,7 +955,7 @@ handshakeClient13' cparams ctx usedCipher usedHash = do
     recvFinished serverHandshakeTrafficSecret = do
         hChSv <- transcriptHash ctx
         let verifyData' = makeVerifyData usedHash serverHandshakeTrafficSecret hChSv
-        recvHandshake13 ctx True $ expectFinished verifyData'
+        recvHandshake13preUpdate ctx $ expectFinished verifyData'
 
     expectFinished verifyData' (Finished13 verifyData) =
         when (verifyData' /= verifyData) $ decryptError "cannot verify finished"

--- a/core/Network/TLS/Handshake/Common13.hs
+++ b/core/Network/TLS/Handshake/Common13.hs
@@ -122,9 +122,8 @@ makeClientCertVerify ctx sig hs hashValue =
     target = makeTarget clientContextString hashValue
 
 checkServerCertVerify :: MonadIO m => Context -> DigitalSignatureAlg -> HashAndSignatureAlgorithm -> ByteString -> ByteString -> m Bool
-checkServerCertVerify ctx sig hs signature hashValue = liftIO $ do
-    cc <- usingState_ ctx isClientContext
-    verifyPublic ctx cc sigParams target signature
+checkServerCertVerify ctx sig hs signature hashValue =
+    liftIO $ verifyPublic ctx sigParams target signature
   where
     sigParams = signatureParams sig (Just hs)
     target = makeTarget serverContextString hashValue

--- a/core/Network/TLS/Handshake/Common13.hs
+++ b/core/Network/TLS/Handshake/Common13.hs
@@ -16,6 +16,7 @@ module Network.TLS.Handshake.Common13
        , makeServerCertVerify
        , makeClientCertVerify
        , checkServerCertVerify
+       , checkClientCertVerify
        , makePSKBinder
        , replacePSKBinder
        , createTLS13TicketInfo
@@ -122,11 +123,17 @@ makeClientCertVerify ctx sig hs hashValue =
     target = makeTarget clientContextString hashValue
 
 checkServerCertVerify :: MonadIO m => Context -> DigitalSignatureAlg -> HashAndSignatureAlgorithm -> ByteString -> ByteString -> m Bool
-checkServerCertVerify ctx sig hs signature hashValue =
+checkServerCertVerify = checkCertVerify serverContextString
+
+checkClientCertVerify :: MonadIO m => Context -> DigitalSignatureAlg -> HashAndSignatureAlgorithm -> ByteString -> ByteString -> m Bool
+checkClientCertVerify = checkCertVerify clientContextString
+
+checkCertVerify :: MonadIO m => ByteString -> Context -> DigitalSignatureAlg -> HashAndSignatureAlgorithm -> ByteString -> ByteString -> m Bool
+checkCertVerify ctxStr ctx sig hs signature hashValue =
     liftIO $ verifyPublic ctx sigParams target signature
   where
     sigParams = signatureParams sig (Just hs)
-    target = makeTarget serverContextString hashValue
+    target = makeTarget ctxStr hashValue
 
 makeTarget :: ByteString -> ByteString -> ByteString
 makeTarget contextString hashValue = runPut $ do

--- a/core/Network/TLS/Handshake/Common13.hs
+++ b/core/Network/TLS/Handshake/Common13.hs
@@ -27,7 +27,8 @@ module Network.TLS.Handshake.Common13
        , safeNonNegative32
        , RecvHandshake13M
        , runRecvHandshake13
-       , recvHandshake13
+       , recvHandshake13preUpdate
+       , recvHandshake13postUpdate
        , lift13
        ) where
 
@@ -263,16 +264,20 @@ newtype RecvHandshake13M m a = RecvHandshake13M (StateT [Handshake13] m a)
 lift13 :: (Handshake13 -> IO a) -> Handshake13 -> RecvHandshake13M IO a
 lift13 action h = RecvHandshake13M $ liftIO $ action h
 
-recvHandshake13 :: MonadIO m
-                => Context
-                -> Bool
-                -> (Handshake13 -> RecvHandshake13M m a)
-                -> RecvHandshake13M m a
-recvHandshake13 ctx True f = do
+recvHandshake13preUpdate :: MonadIO m
+                         => Context
+                         -> (Handshake13 -> RecvHandshake13M m a)
+                         -> RecvHandshake13M m a
+recvHandshake13preUpdate ctx f = do
     h <- getHandshake13 ctx
     liftIO $ processHandshake13 ctx h
     f h
-recvHandshake13 ctx False f = do
+
+recvHandshake13postUpdate :: MonadIO m
+                          => Context
+                          -> (Handshake13 -> RecvHandshake13M m a)
+                          -> RecvHandshake13M m a
+recvHandshake13postUpdate ctx f = do
     h <- getHandshake13 ctx
     v <- f h
     liftIO $ processHandshake13 ctx h

--- a/core/Network/TLS/Handshake/Key.hs
+++ b/core/Network/TLS/Handshake/Key.hs
@@ -63,8 +63,8 @@ decryptRSA ctx econtent = do
         let cipher = if ver < TLS10 then econtent else B.drop 2 econtent
         withRNG $ kxDecrypt privateKey cipher
 
-verifyPublic :: Context -> Role -> SignatureParams -> ByteString -> ByteString -> IO Bool
-verifyPublic ctx _ params econtent sign = do
+verifyPublic :: Context -> SignatureParams -> ByteString -> ByteString -> IO Bool
+verifyPublic ctx params econtent sign = do
     publicKey <- usingHState ctx getRemotePublicKey
     return $ kxVerify publicKey params econtent sign
 

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -791,7 +791,7 @@ doHandshake13 sparams cred@(certChain, _) ctx chosenVersion usedCipher exts used
             setRxState ctx usedHash usedCipher clientHandshakeTrafficSecret
         expectEndOfEarlyData hs = unexpected (show hs) (Just "end of early data")
 
-    if serverWantClientCert sparams then
+    if not authenticated && serverWantClientCert sparams then
         setPendingActions ctx [expectCertificate, expectCertVerify, expectFinished]
       else if rtt0OK then
         setPendingActions ctx [expectEndOfEarlyData, expectFinished]

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -791,7 +791,7 @@ doHandshake13 sparams cred@(certChain, _) ctx chosenVersion usedCipher exts used
             setRxState ctx usedHash usedCipher clientHandshakeTrafficSecret
         expectEndOfEarlyData hs = unexpected (show hs) (Just "end of early data")
 
-    if (serverWantClientCert sparams) then
+    if serverWantClientCert sparams then
         setPendingActions ctx [expectCertificate, expectCertVerify, expectFinished]
       else if rtt0OK then
         setPendingActions ctx [expectEndOfEarlyData, expectFinished]

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -789,9 +789,9 @@ doHandshake13 sparams cred@(certChain, _) ctx chosenVersion usedCipher exts used
 
     if not authenticated && serverWantClientCert sparams then
         runRecvHandshake13 $ do
-          recvHandshake13 ctx False $ lift13 expectCertificate
-          recvHandshake13 ctx False $ lift13 expectCertVerify
-          recvHandshake13 ctx False $ lift13 expectFinished
+          recvHandshake13postUpdate ctx $ lift13 expectCertificate
+          recvHandshake13postUpdate ctx $ lift13 expectCertVerify
+          recvHandshake13postUpdate ctx $ lift13 expectFinished
           liftIO sendNST
       else if rtt0OK then
         setPendingActions ctx [(expectEndOfEarlyData, return ())

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -752,8 +752,8 @@ doHandshake13 sparams cred@(certChain, _) ctx chosenVersion usedCipher exts used
          | otherwise = EarlyDataNotAllowed
     setEstablished ctx established
 
-    let expectCertificate hs@(Certificate13 _certctx certs _ext) = do
-            -- fixme checking _certctx
+    let expectCertificate hs@(Certificate13 certCtx certs _ext) = do
+            when (certCtx /= "") $ throwCore $ Error_Protocol ("certificate request context MUST be empty", True, IllegalParameter)
             -- fixme checking _ext
             processHandshake13 ctx hs
             clientCertificate sparams ctx certs

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -768,7 +768,7 @@ doHandshake13 sparams cred@(certChain, _) ctx chosenVersion usedCipher exts used
                         c:_ -> return $ certPubKey $ getCertificate c
             usingHState ctx $ setPublicKey pubkey
             let keyAlg = fromJust "fromPubKey" (fromPubKey pubkey)
-            verif <- checkClientCertVerify ctx keyAlg sigAlg sig hChCc
+            verif <- checkCertVerify ctx keyAlg sigAlg sig hChCc
             clientCertVerify sparams ctx certs verif
         expectCertVerify hs = unexpected (show hs) (Just "certificate verify 13")
 
@@ -876,7 +876,7 @@ doHandshake13 sparams cred@(certChain, _) ctx chosenVersion usedCipher exts used
         loadPacket13 ctx $ Handshake13 [Certificate13 "" certChain ess]
         hChSc <- transcriptHash ctx
         sigAlg <- getLocalDigitalSignatureAlg ctx
-        vrfy <- makeServerCertVerify ctx sigAlg hashSig hChSc
+        vrfy <- makeCertVerify ctx sigAlg hashSig hChSc
         loadPacket13 ctx $ Handshake13 [vrfy]
 
     sendExtensions rtt0OK = do

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -873,6 +873,13 @@ doHandshake13 sparams cred@(certChain, _) ctx chosenVersion usedCipher exts used
         loadPacket13 ctx $ Handshake13 [helo]
 
     sendCertAndVerify = do
+        when (serverWantClientCert sparams) $ do
+            let certReqCtx = "" -- this must be zero length here.
+            let sigAlgs = extensionEncode $ SignatureAlgorithms $ supportedHashSignatures $ ctxSupported ctx
+                crexts = [ExtensionRaw extensionID_SignatureAlgorithms sigAlgs]
+            loadPacket13 ctx $ Handshake13 [CertRequest13 certReqCtx crexts]
+            usingHState ctx $ setCertReqSent True
+
         let CertificateChain cs = certChain
             ess = replicate (length cs) []
         loadPacket13 ctx $ Handshake13 [Certificate13 "" certChain ess]

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -762,7 +762,7 @@ doHandshake13 sparams cred@(certChain, _) ctx chosenVersion usedCipher exts used
     let expectCertVerify hs@(CertVerify13 sigAlg sig) = do
             hChCc <- transcriptHash ctx
             processHandshake13 ctx hs
-            certs@(CertificateChain cc) <- checkValidClientCertChain ctx "change cipher message expected"
+            certs@(CertificateChain cc) <- checkValidClientCertChain ctx "finished 13 message expected"
             pubkey <- case cc of
                         [] -> throwCore $ Error_Protocol ("client certificate missing", True, HandshakeFailure)
                         c:_ -> return $ certPubKey $ getCertificate c

--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -35,12 +35,12 @@ import Network.TLS.Util
 import Control.Monad.State.Strict
 
 fromPubKey :: PubKey -> Maybe DigitalSignatureAlg
-fromPubKey (PubKeyRSA _) = Just DS_RSA
-fromPubKey (PubKeyDSA _) = Just DS_DSS
-fromPubKey (PubKeyEC  _) = Just DS_ECDSA
-fromPubKey (PubKeyEd25519 _) = return DS_Ed25519
-fromPubKey (PubKeyEd448   _) = return DS_Ed448
-fromPubKey _             = Nothing
+fromPubKey (PubKeyRSA _)     = Just DS_RSA
+fromPubKey (PubKeyDSA _)     = Just DS_DSS
+fromPubKey (PubKeyEC  _)     = Just DS_ECDSA
+fromPubKey (PubKeyEd25519 _) = Just DS_Ed25519
+fromPubKey (PubKeyEd448   _) = Just DS_Ed448
+fromPubKey _                 = Nothing
 
 decryptError :: MonadIO m => String -> m a
 decryptError msg = throwCore $ Error_Protocol (msg, True, DecryptError)

--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -186,9 +186,7 @@ signatureVerifyWithCertVerifyData :: Context
                                   -> DigitallySigned
                                   -> CertVerifyData
                                   -> IO Bool
-signatureVerifyWithCertVerifyData ctx (DigitallySigned _ bs) (sigParam, toVerify) = do
-    cc <- usingState_ ctx isClientContext
-    verifyPublic ctx cc sigParam toVerify bs
+signatureVerifyWithCertVerifyData ctx (DigitallySigned _ bs) (sigParam, toVerify) = verifyPublic ctx sigParam toVerify bs
 
 digitallySignParams :: Context -> ByteString -> DigitalSignatureAlg -> Maybe HashAndSignatureAlgorithm -> IO DigitallySigned
 digitallySignParams ctx signatureData sigAlg hashSigAlg =

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -16,6 +16,7 @@ module Connection
     , isVersionEnabled
     , isCustomDHParams
     , isLeafRSA
+    , isCredentialDSA
     , readClientSessionRef
     , twoSessionRefs
     , twoSessionManagers
@@ -96,6 +97,10 @@ knownGroups   = knownECGroups ++ knownFFGroups
 
 arbitraryGroups :: Gen [Group]
 arbitraryGroups = listOf1 $ elements knownGroups
+
+isCredentialDSA :: (CertificateChain, PrivKey) -> Bool
+isCredentialDSA (_, PrivKeyDSA _) = True
+isCredentialDSA _                 = False
 
 arbitraryCredentialsOfEachType :: Gen [(CertificateChain, PrivKey)]
 arbitraryCredentialsOfEachType = do

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -626,7 +626,10 @@ prop_handshake_client_auth = do
                                    , serverHooks = (serverHooks serverParam)
                                         { onClientCertificate = validateChain cred }
                                    }
-    runTLSPipeSimple (clientParam',serverParam')
+    let shouldFail = version == TLS13 && isCredentialDSA cred
+    if shouldFail
+        then runTLSInitFailure (clientParam',serverParam')
+        else runTLSPipeSimple  (clientParam',serverParam')
   where validateChain cred chain
             | chain == fst cred = return CertificateUsageAccept
             | otherwise         = return (CertificateUsageReject CertificateRejectUnknownCA)

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -167,6 +167,9 @@ runTLSInitFailureGen params hsServer hsClient = do
         tlsClient ctx = do
             _ <- hsClient ctx
             minfo <- contextGetInformation ctx
+            -- Note: with TLS13 server needs to call recvData in order to detect
+            -- handshake alert messages sent by the server
+            _ <- recvData ctx
             bye ctx
             return $ "client success: " ++ show minfo
 
@@ -636,10 +639,7 @@ prop_handshake_client_auth = do
 
 prop_handshake_clt_key_usage :: PropertyM IO ()
 prop_handshake_clt_key_usage = do
-    (clientParam,serverParam) <- pick $
-        -- Client authentication is not implemented for TLS 1.3.
-        -- Let's skip this test for TLS 1.3 temporarily.
-        arbitraryPairParams `suchThat` (not . isVersionEnabled TLS13)
+    (clientParam,serverParam) <- pick arbitraryPairParams
     usageFlags <- pick arbitraryKeyUsage
     cred <- pick $ arbitraryRSACredentialWithUsage usageFlags
     let clientParam' = clientParam { clientHooks = (clientHooks clientParam)


### PR DESCRIPTION
Passing test cases of client auth and usage.

Interoperability with OpenSSL is confirmed:

```
% stack exec tls-simpleserver -- -v --key=$SOMEWHERE/serverkey.pem --certificate=$SOMEWHERE/servercert.pem 13443 --tls13 --trust-anchor=$SOMEWHERE/cacert.pem
```

NG:

```
% ./opensslwrap.sh s_client 127.0.0.1:13443

OK:

```
% ./opensslwrap.sh s_client -cert=$SOMEWHERE/clientcert.pem -key=$SOMEWHERE/clientkey.pem 127.0.0.1:13443
```