### PR TITLE
Avoid downgrade detection false-positive

### DIFF
--- a/core/Network/TLS/Handshake/Random.hs
+++ b/core/Network/TLS/Handshake/Random.hs
@@ -43,11 +43,13 @@ serverRandom ctx chosenVer suppVers
 
 -- | Test if the negotiated version was artificially downgraded (that is, for
 -- other reason than the versions supported by the client).
-isDowngraded :: [Version] -> ServerRandom -> Bool
-isDowngraded suppVers (ServerRandom sr)
-  | TLS13 `elem` suppVers = suffix12 `B.isSuffixOf` sr
+isDowngraded :: Version -> [Version] -> ServerRandom -> Bool
+isDowngraded ver suppVers (ServerRandom sr)
+  | ver <= TLS12
+  , TLS13 `elem` suppVers = suffix12 `B.isSuffixOf` sr
                          || suffix11 `B.isSuffixOf` sr
-  | TLS12 `elem` suppVers = suffix11 `B.isSuffixOf` sr
+  | ver <= TLS11
+  , TLS12 `elem` suppVers = suffix11 `B.isSuffixOf` sr
   | otherwise             = False
 
 suffix12 :: B.ByteString


### PR DESCRIPTION
Some TLS 1.3 servers return a TLS 1.2 downgrade sentinel in the
server hello along with TLS 1.3 in the supported_versions extension
and TLS 1.2 in the ServerHello legacy version.

When we would actually select 1.3, it is wrong to trigger downgrade
detection based solely on the server random.