### PR TITLE
Improvements to tests and tools

### DIFF
--- a/core/Benchmarks/Benchmarks.hs
+++ b/core/Benchmarks/Benchmarks.hs
@@ -34,9 +34,6 @@ blockCipher = Cipher
     , cipherMinVer      = Nothing
     }
 
-recvDataNonNull :: Context -> IO B.ByteString
-recvDataNonNull ctx = recvData ctx >>= \l -> if B.null l then recvDataNonNull ctx else return l
-
 getParams :: Version -> Cipher -> (ClientParams, ServerParams)
 getParams connectVer cipher = (cParams, sParams)
   where sParams = def { serverSupported = supported
@@ -71,7 +68,7 @@ runTLSPipeSimple :: (ClientParams, ServerParams) -> B.ByteString -> IO B.ByteStr
 runTLSPipeSimple params = runTLSPipe params tlsServer tlsClient
   where tlsServer ctx queue = do
             handshake ctx
-            d <- recvDataNonNull ctx
+            d <- recvData ctx
             writeChan queue d
             bye ctx
         tlsClient queue ctx = do

--- a/core/Benchmarks/Benchmarks.hs
+++ b/core/Benchmarks/Benchmarks.hs
@@ -68,18 +68,17 @@ runTLSPipe params tlsServer tlsClient d = do
     readResult
 
 runTLSPipeSimple :: (ClientParams, ServerParams) -> B.ByteString -> IO B.ByteString
-runTLSPipeSimple params bs = runTLSPipe params tlsServer tlsClient bs
+runTLSPipeSimple params = runTLSPipe params tlsServer tlsClient
   where tlsServer ctx queue = do
             handshake ctx
             d <- recvDataNonNull ctx
             writeChan queue d
-            return ()
+            bye ctx
         tlsClient queue ctx = do
             handshake ctx
             d <- readChan queue
             sendData ctx (L.fromChunks [d])
-            bye ctx
-            return ()
+            byeBye ctx
 
 benchConnection :: (ClientParams, ServerParams) -> B.ByteString -> String -> Benchmark
 benchConnection params !d name = bench name . nfIO $ runTLSPipeSimple params d

--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -102,8 +102,8 @@ sendData ctx dataToSend = liftIO $ do
         -- possibly large write.
         mapM_ (mapChunks_ 16384 sendP) (L.toChunks dataToSend)
 
--- | recvData get data out of Data packet, and automatically renegotiate if
--- a Handshake ClientHello is received
+-- | Get data out of Data packet, and automatically renegotiate if a Handshake
+-- ClientHello is received.  An empty result means EOF.
 recvData :: MonadIO m => Context -> m B.ByteString
 recvData ctx = liftIO $ do
     tls13 <- tls13orLater ctx

--- a/core/Network/TLS/Extension.hs
+++ b/core/Network/TLS/Extension.hs
@@ -570,8 +570,8 @@ instance EnumSafe8 PskKexMode where
     fromEnumSafe8 PSK_KE     = 0
     fromEnumSafe8 PSK_DHE_KE = 1
 
-    toEnumSafe8 1 = Just PSK_KE
-    toEnumSafe8 2 = Just PSK_DHE_KE
+    toEnumSafe8 0 = Just PSK_KE
+    toEnumSafe8 1 = Just PSK_DHE_KE
     toEnumSafe8 _ = Nothing
 
 newtype PskKeyExchangeModes = PskKeyExchangeModes [PskKexMode] deriving (Eq, Show)

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -57,7 +57,7 @@ runTLS debug ioDebug params hostname portNumber f =
 sessionRef ref = SessionManager
     { sessionEstablish      = \sid sdata -> writeIORef ref (sid,sdata)
     , sessionResume         = \sid       -> readIORef ref >>= \(s,d) -> if s == sid then return (Just d) else return Nothing
-    , sessionResumeOnlyOnce = \sid       -> fail "sessionResumeOnlyOnce not implemented for simple client"
+    , sessionResumeOnlyOnce = \_         -> fail "sessionResumeOnlyOnce not implemented for simple client"
     , sessionInvalidate     = \_         -> return ()
     }
 

--- a/debug/src/SimpleClient.hs
+++ b/debug/src/SimpleClient.hs
@@ -57,7 +57,7 @@ runTLS debug ioDebug params hostname portNumber f =
 sessionRef ref = SessionManager
     { sessionEstablish      = \sid sdata -> writeIORef ref (sid,sdata)
     , sessionResume         = \sid       -> readIORef ref >>= \(s,d) -> if s == sid then return (Just d) else return Nothing
-    , sessionResumeOnlyOnce = \sid       -> readIORef ref >>= \(s,d) -> if s == sid then return (Just d) else return Nothing
+    , sessionResumeOnlyOnce = \sid       -> fail "sessionResumeOnlyOnce not implemented for simple client"
     , sessionInvalidate     = \_         -> return ()
     }
 

--- a/debug/tls-debug.cabal
+++ b/debug/tls-debug.cabal
@@ -27,6 +27,7 @@ Executable           tls-stunnel
                    , data-default-class
                    , cryptonite >= 0.24
                    , tls >= 1.3.0 && < 1.5
+                   , tls-session-manager
   if os(windows)
     Buildable:       False
   else
@@ -73,7 +74,6 @@ Executable           tls-simpleclient
                    , cryptonite >= 0.14
                    , x509-system >= 1.0
                    , tls >= 1.3.6 && < 1.5
-                   , tls-session-manager
   Buildable:         True
   ghc-options:       -Wall -fno-warn-missing-signatures
 
@@ -91,6 +91,7 @@ Executable           tls-simpleserver
                    , x509-store
                    , x509-system >= 1.0
                    , tls >= 1.3 && < 1.5
+                   , tls-session-manager
   Buildable:         True
   ghc-options:       -Wall -fno-warn-missing-signatures
 


### PR DESCRIPTION
Improves the implementation of `sessionResumeOnlyOnce` to get the "only once" constraint.

Regarding connection termination, I realized that the correct pattern is actually to call `recvData` _after_ `bye`. Because this sequence will not deadlock when facing a peer doing exactly the same thing. The pattern is captured in a test utility and called every time the connection is terminated without calling `recvData`.