### PR TITLE
Deprotection of 0-RTT data with HRR

### DIFF
--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -121,8 +121,8 @@ data Context = Context
     }
 
 data Established = NotEstablished
-                 | EarlyDataAllowed Int
-                 | EarlyDataNotAllowed
+                 | EarlyDataAllowed Int    -- remaining 0-RTT bytes allowed
+                 | EarlyDataNotAllowed Int -- remaining 0-RTT packets allowed to skip
                  | Established
                  deriving (Eq, Show)
 

--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -164,7 +164,13 @@ recvData13 ctx = do
                 | otherwise ->
                     let reason = "early data overflow" in
                     terminate (Error_Misc reason) AlertLevel_Fatal UnexpectedMessage reason
-              EarlyDataNotAllowed -> recvData13 ctx -- ignore "x"
+              EarlyDataNotAllowed n
+                | n > 0     -> do
+                    setEstablished ctx $ EarlyDataNotAllowed (n - 1)
+                    recvData13 ctx -- ignore "x"
+                | otherwise ->
+                    let reason = "early data deprotect overflow" in
+                    terminate (Error_Misc reason) AlertLevel_Fatal UnexpectedMessage reason
               Established         -> return x
               NotEstablished      -> throwCore $ Error_Protocol ("data at not-established", True, UnexpectedMessage)
         process ChangeCipherSpec13 = recvData13 ctx

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -90,8 +90,10 @@ handshakeClient' cparams ctx groups mcrand = do
                   Just (KeyShareHRR selectedGroup)
                     | selectedGroup `elem` groups' -> do
                           usingHState ctx $ setTLS13HandshakeMode HelloRetryRequest
+                          clearTxState ctx
+                          let cparams' = cparams { clientEarlyData = Nothing }
                           crand <- usingHState ctx $ hstClientRandom <$> get
-                          handshakeClient' cparams ctx [selectedGroup] (Just crand)
+                          handshakeClient' cparams' ctx [selectedGroup] (Just crand)
                   _                    -> throwCore $ Error_Protocol ("server-selected group is not supported", True, IllegalParameter)
           else do
             handshakeClient13 cparams ctx

--- a/core/Network/TLS/Handshake/Common13.hs
+++ b/core/Network/TLS/Handshake/Common13.hs
@@ -29,7 +29,6 @@ module Network.TLS.Handshake.Common13
        , runRecvHandshake13
        , recvHandshake13preUpdate
        , recvHandshake13postUpdate
-       , lift13
        ) where
 
 import qualified Data.ByteArray as BA
@@ -260,9 +259,6 @@ safeNonNegative32 x
 
 newtype RecvHandshake13M m a = RecvHandshake13M (StateT [Handshake13] m a)
     deriving (Functor, Applicative, Monad, MonadIO)
-
-lift13 :: (Handshake13 -> IO a) -> Handshake13 -> RecvHandshake13M IO a
-lift13 action h = RecvHandshake13M $ liftIO $ action h
 
 recvHandshake13preUpdate :: MonadIO m
                          => Context

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -749,7 +749,7 @@ doHandshake13 sparams cred@(certChain, _) ctx chosenVersion usedCipher exts used
     ----------------------------------------------------------------
     let established
          | rtt0OK    = EarlyDataAllowed rtt0max
-         | otherwise = EarlyDataNotAllowed
+         | otherwise = EarlyDataNotAllowed 3 -- hardcoding
     setEstablished ctx established
 
     let expectFinished (Finished13 verifyData') = do

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -764,7 +764,7 @@ doHandshake13 sparams cred@(certChain, _) ctx chosenVersion usedCipher exts used
     let expectFinished (Finished13 verifyData') = do
             hChBeforeCf <- transcriptHash ctx
             let verifyData = makeVerifyData usedHash clientHandshakeTrafficSecret hChBeforeCf
-            if verifyData == verifyData' then do
+            if verifyData == verifyData' then liftIO $ do
                 setEstablished ctx Established
                 setRxState ctx usedHash usedCipher clientApplicationTrafficSecret0
                else
@@ -780,7 +780,7 @@ doHandshake13 sparams cred@(certChain, _) ctx chosenVersion usedCipher exts used
         runRecvHandshake13 $ do
           skip <- recvHandshake13postUpdate ctx expectCertificate
           unless skip $ recvHandshake13postUpdate ctx expectCertVerify
-          recvHandshake13postUpdate ctx $ lift13 expectFinished
+          recvHandshake13postUpdate ctx expectFinished
           liftIO sendNST
       else if rtt0OK then
         setPendingActions ctx [(expectEndOfEarlyData, return ())

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -86,7 +86,7 @@ handshakeServerWith sparams ctx clientHello@(ClientHello clientVersion _ clientS
     established <- ctxEstablished ctx
     -- renego is not allowed in TLS 1.3
     when (established /= NotEstablished) $ do
-        ver <- usingState_ ctx getVersion
+        ver <- usingState_ ctx (getVersionWithDefault TLS10)
         when (ver == TLS13) $ throwCore $ Error_Protocol ("renegotiation is not allowed in TLS 1.3", False, NoRenegotiation)
     -- rejecting client initiated renegotiation to prevent DOS.
     unless (supportedClientInitiatedRenegotiation (ctxSupported ctx)) $ do
@@ -653,6 +653,13 @@ handshakeServerWithTLS13 sparams ctx chosenVersion allCreds exts clientCiphers _
     when (null ciphersFilteredVersion) $ throwCore $
         Error_Protocol ("no cipher in common with the client", True, HandshakeFailure)
     let usedCipher = (onCipherChoosing $ serverHooks sparams) chosenVersion ciphersFilteredVersion
+        rtt0 = case extensionLookup extensionID_EarlyData exts >>= extensionDecode MsgTClientHello of
+                 Just (EarlyDataIndication _) -> True
+                 Nothing                      -> False
+    when rtt0 $
+        -- mark a 0-RTT attempt before a possible HRR, and before updating the
+        -- status again if 0-RTT successful
+        setEstablished ctx (EarlyDataNotAllowed 3) -- hardcoding
     -- Deciding key exchange from key shares
     keyShares <- case extensionLookup extensionID_KeyShare exts >>= extensionDecode MsgTClientHello of
           Just (KeyShareClientHello kses) -> return kses
@@ -673,7 +680,7 @@ handshakeServerWithTLS13 sparams ctx chosenVersion allCreds exts clientCiphers _
                     Just cs -> return cs
                     Nothing -> throwCore $ Error_Protocol ("credential not found", True, IllegalParameter)
         let usedHash = cipherHash usedCipher
-        doHandshake13 sparams cred ctx chosenVersion usedCipher exts usedHash keyShare hashSig clientSession
+        doHandshake13 sparams cred ctx chosenVersion usedCipher exts usedHash keyShare hashSig clientSession rtt0
   where
     ciphersFilteredVersion = filter ((`elem` clientCiphers) . cipherID) serverCiphers
     serverCiphers = filter (cipherAllowedForVersion chosenVersion) (supportedCiphers $ serverSupported sparams)
@@ -686,9 +693,9 @@ handshakeServerWithTLS13 sparams ctx chosenVersion allCreds exts clientCiphers _
 doHandshake13 :: ServerParams -> Credential -> Context -> Version
               -> Cipher -> [ExtensionRaw]
               -> Hash -> KeyShareEntry -> HashAndSignatureAlgorithm
-              -> Session
+              -> Session -> Bool
               -> IO ()
-doHandshake13 sparams cred@(certChain, _) ctx chosenVersion usedCipher exts usedHash clientKeyShare hashSig clientSession = do
+doHandshake13 sparams cred@(certChain, _) ctx chosenVersion usedCipher exts usedHash clientKeyShare hashSig clientSession rtt0 = do
     newSession ctx >>= \ss -> usingState_ ctx (setSession ss False)
     usingHState ctx $ setNegotiatedGroup $ keyShareEntryGroup clientKeyShare
     srand <- setServerParameter
@@ -698,10 +705,12 @@ doHandshake13 sparams cred@(certChain, _) ctx chosenVersion usedCipher exts used
         clientEarlyTrafficSecret = deriveSecret usedHash earlySecret "c e traffic" hCh
     logKey ctx (ClientEarlyTrafficSecret clientEarlyTrafficSecret)
     extensions <- checkBinder earlySecret binderInfo
+    hrr <- usingState_ ctx getTLS13HRR
     let authenticated = isJust binderInfo
-        rtt0OK = authenticated && rtt0 && rtt0accept && is0RTTvalid
+        rtt0OK = authenticated && not hrr && rtt0 && rtt0accept && is0RTTvalid
     ----------------------------------------------------------------
-    if rtt0 then
+    established <- ctxEstablished ctx
+    if established /= NotEstablished then
          if rtt0OK then do
              usingHState ctx $ setTLS13HandshakeMode RTT0
              usingHState ctx $ setTLS13RTT0Status RTT0Accepted
@@ -747,10 +756,10 @@ doHandshake13 sparams cred@(certChain, _) ctx chosenVersion usedCipher exts used
     logKey ctx (ClientTrafficSecret0 clientApplicationTrafficSecret0)
     setTxState ctx usedHash usedCipher serverApplicationTrafficSecret0
     ----------------------------------------------------------------
-    let established
-         | rtt0OK    = EarlyDataAllowed rtt0max
-         | otherwise = EarlyDataNotAllowed 3 -- hardcoding
-    setEstablished ctx established
+    if rtt0OK then
+        setEstablished ctx (EarlyDataAllowed rtt0max)
+      else when (established == NotEstablished) $
+        setEstablished ctx (EarlyDataNotAllowed 3) -- hardcoding
 
     let expectFinished (Finished13 verifyData') = do
             hChBeforeCf <- transcriptHash ctx
@@ -823,9 +832,6 @@ doHandshake13 sparams cred@(certChain, _) ctx chosenVersion usedCipher exts used
 
     rtt0max = safeNonNegative32 $ serverEarlyDataSize sparams
     rtt0accept = serverEarlyDataSize sparams > 0
-    rtt0 = case extensionLookup extensionID_EarlyData exts >>= extensionDecode MsgTClientHello of
-             Just (EarlyDataIndication _) -> True
-             Nothing                      -> False
 
     checkBinder _ Nothing = return []
     checkBinder earlySecret (Just (binder,n,tlen)) = do

--- a/core/Network/TLS/Handshake/State13.hs
+++ b/core/Network/TLS/Handshake/State13.hs
@@ -12,6 +12,8 @@ module Network.TLS.Handshake.State13
        , getRxState
        , setTxState
        , setRxState
+       , clearTxState
+       , clearRxState
        , setHelloParameters13
        , transcriptHash
        , wrapAsMessageHash13
@@ -77,6 +79,16 @@ setXState func encOrDec ctx h cipher secret =
       , stCipher      = Just cipher
       , stCompression = nullCompression
       }
+
+clearTxState :: Context -> IO ()
+clearTxState = clearXState ctxTxState
+
+clearRxState :: Context -> IO ()
+clearRxState = clearXState ctxRxState
+
+clearXState :: (Context -> MVar RecordState) -> Context -> IO ()
+clearXState func ctx =
+    modifyMVar_ (func ctx) (\rt -> return rt { stCipher = Nothing })
 
 setHelloParameters13 :: Cipher -> HandshakeM ()
 setHelloParameters13 cipher = modify update

--- a/core/Network/TLS/IO.hs
+++ b/core/Network/TLS/IO.hs
@@ -33,7 +33,6 @@ import Network.TLS.Receiving
 import Network.TLS.Imports
 import Network.TLS.Receiving13
 import Network.TLS.State
-import Network.TLS.Handshake.State
 import qualified Data.ByteString as B
 
 import Data.IORef
@@ -182,26 +181,24 @@ recvRecord13 ctx = readExact ctx 5 >>= either (return . Left) (recvLengthE . dec
 
 recvPacket13 :: MonadIO m => Context -> m (Either TLSError Packet13)
 recvPacket13 ctx = liftIO $ do
-    st <- usingHState ctx getTLS13RTT0Status
-    -- If the server decides to reject RTT0 data but accepts RTT1
-    -- data, the server should skip all records for RTT0 data.
-    -- Currently, the server tries to skip 3 RTT0 data at maximum.
-    let n = if st == RTT0Rejected then 3 else 0 -- hardcoding
-    loop n
-  where
-    loop :: Int -> IO (Either TLSError Packet13)
-    loop n = do
-        erecord <- recvRecord13 ctx
-        case erecord of
-            Left (Error_Protocol (_, True, BadRecordMac))
-                | n > 0  -> loop (n - 1)
-            Left err     -> return $ Left err
-            Right record -> do
-                pkt <- processPacket13 ctx record
-                case pkt of
-                    Right p -> withLog ctx $ \logging -> loggingPacketRecv logging $ show p
-                    _       -> return ()
-                return pkt
+    erecord <- recvRecord13 ctx
+    case erecord of
+        Left err@(Error_Protocol (_, True, BadRecordMac)) -> do
+            -- If the server decides to reject RTT0 data but accepts RTT1
+            -- data, the server should skip all records for RTT0 data.
+            established <- ctxEstablished ctx
+            case established of
+                EarlyDataNotAllowed n
+                    | n > 0 -> do setEstablished ctx $ EarlyDataNotAllowed (n - 1)
+                                  recvPacket13 ctx
+                _           -> return $ Left err
+        Left err      -> return $ Left err
+        Right record -> do
+            pkt <- processPacket13 ctx record
+            case pkt of
+                Right p -> withLog ctx $ \logging -> loggingPacketRecv logging $ show p
+                _       -> return ()
+            return pkt
 
 -- | State monad used to group several packets together and send them on wire as
 -- single flight.  When packets are loaded in the monad, they are logged


### PR DESCRIPTION
Adds more deprotection scenarios of 0-RTT data, notably the ones with HRR response.

The deprotection limit is now on total record count but is still hardcoded.

I'm thinking it is not really possible to move to a limit about total bytes of plaintext.
Because of the variable-size padding that can exist in encrypted data records.
So maybe we just have to make the hardcoded limit `3` configurable.