### PR TITLE
Strict handling of hash/signatures

### DIFF
--- a/core/Network/TLS/Credentials.hs
+++ b/core/Network/TLS/Credentials.hs
@@ -161,10 +161,10 @@ getHashSignature signed =
     convertHash sig X509.HashSHA512 = Just (TLS.HashSHA512, sig)
     convertHash _   _               = Nothing
 
--- | Checks whether certificates in the chain comply with a list of
--- hash/signature algorithm pairs.  Currently the verification applies only
--- to the leaf certificate, if it is not self-signed.  This may be extended
--- to additional chain elements in the future.
+-- | Checks whether certificate signatures in the chain comply with a list of
+-- hash/signature algorithm pairs.  Currently the verification applies only to
+-- the signature of the leaf certificate, and when not self-signed.  This may
+-- be extended to additional chain elements in the future.
 credentialMatchesHashSignatures :: [TLS.HashAndSignatureAlgorithm] -> Credential -> Bool
 credentialMatchesHashSignatures hashSigs (chain, _) =
     case chain of

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -408,7 +408,7 @@ supportedCtypes :: [HashAndSignatureAlgorithm]
 supportedCtypes hashAlgs =
     nub $ foldr ctfilter [] hashAlgs
   where
-    ctfilter x acc = case hashSigToCertType13 x of
+    ctfilter x acc = case hashSigToCertType x of
        Just cType | cType <= lastSupportedCertificateType
                  -> cType : acc
        _         -> acc

--- a/core/Network/TLS/Handshake/Common.hs
+++ b/core/Network/TLS/Handshake/Common.hs
@@ -163,10 +163,11 @@ extensionLookup toFind = fmap (\(ExtensionRaw _ content) -> content)
 -- actually match is left for the peer to discover.  We're not presently
 -- burning  CPU to detect that misconfiguration.  We verify only that the
 -- types of keys match.
-storePrivInfo :: Context
+storePrivInfo :: MonadIO m
+              => Context
               -> CertificateChain
               -> PrivKey
-              -> IO DigitalSignatureAlg
+              -> m DigitalSignatureAlg
 storePrivInfo ctx cc privkey = do
     let CertificateChain (c:_) = cc
         pubkey = certPubKey $ getCertificate c

--- a/core/Network/TLS/Handshake/Common13.hs
+++ b/core/Network/TLS/Handshake/Common13.hs
@@ -24,6 +24,7 @@ module Network.TLS.Handshake.Common13
        , checkFreshness
        , getCurrentTimeFromBase
        , getSessionData13
+       , isHashSignatureValid13
        , safeNonNegative32
        , RecvHandshake13M
        , runRecvHandshake13
@@ -124,6 +125,7 @@ checkCertVerify ctx sig hs signature hashValue = liftIO $ do
                | otherwise        = clientContextString
         target = makeTarget ctxStr hashValue
         sigParams = signatureParams sig (Just hs)
+    checkHashSignatureValid13 hs
     checkSupportedHashSignature ctx (Just hs)
     verifyPublic ctx sigParams target signature
 
@@ -302,3 +304,28 @@ runRecvHandshake13 (RecvHandshake13M f) = do
     (result, new) <- runStateT f []
     unless (null new) $ unexpected "spurious handshake 13" Nothing
     return result
+
+----------------------------------------------------------------
+
+-- some hash/signature combinations have been deprecated in TLS13 and should
+-- not be used
+checkHashSignatureValid13 :: HashAndSignatureAlgorithm -> IO ()
+checkHashSignatureValid13 hs =
+    unless (isHashSignatureValid13 hs) $
+        let msg = "invalid TLS13 hash and signature algorithm: " ++ show hs
+         in throwCore $ Error_Protocol (msg, True, IllegalParameter)
+
+isHashSignatureValid13 :: HashAndSignatureAlgorithm -> Bool
+isHashSignatureValid13 (HashIntrinsic, s) =
+    s `elem` [ SignatureRSApssRSAeSHA256
+             , SignatureRSApssRSAeSHA384
+             , SignatureRSApssRSAeSHA512
+             , SignatureEd25519
+             , SignatureEd448
+             , SignatureRSApsspssSHA256
+             , SignatureRSApsspssSHA384
+             , SignatureRSApsspssSHA512
+             ]
+isHashSignatureValid13 (h, SignatureECDSA) =
+    h `elem` [ HashSHA256, HashSHA384, HashSHA512 ]
+isHashSignatureValid13 _ = False

--- a/core/Network/TLS/Handshake/Common13.hs
+++ b/core/Network/TLS/Handshake/Common13.hs
@@ -117,7 +117,7 @@ makeCertVerify ctx sig hs hashValue = do
         target = makeTarget ctxStr hashValue
     CertVerify13 hs <$> sign ctx sig hs target
 
-checkCertVerify :: MonadIO m => Context -> DigitalSignatureAlg -> HashAndSignatureAlgorithm -> ByteString -> ByteString -> m Bool
+checkCertVerify :: MonadIO m => Context -> DigitalSignatureAlg -> HashAndSignatureAlgorithm -> Signature -> ByteString -> m Bool
 checkCertVerify ctx sig hs signature hashValue = liftIO $ do
     cc <- usingState_ ctx isClientContext
     let ctxStr | cc == ClientRole = serverContextString -- opposite context
@@ -133,7 +133,7 @@ makeTarget contextString hashValue = runPut $ do
     putWord8 0
     putBytes hashValue
 
-sign :: MonadIO m => Context -> DigitalSignatureAlg -> HashAndSignatureAlgorithm -> ByteString -> m ByteString
+sign :: MonadIO m => Context -> DigitalSignatureAlg -> HashAndSignatureAlgorithm -> ByteString -> m Signature
 sign ctx sig hs target = liftIO $ do
     cc <- usingState_ ctx isClientContext
     let sigParams = signatureParams sig (Just hs)

--- a/core/Network/TLS/Handshake/Common13.hs
+++ b/core/Network/TLS/Handshake/Common13.hs
@@ -124,6 +124,7 @@ checkCertVerify ctx sig hs signature hashValue = liftIO $ do
                | otherwise        = clientContextString
         target = makeTarget ctxStr hashValue
         sigParams = signatureParams sig (Just hs)
+    checkSupportedHashSignature ctx (Just hs)
     verifyPublic ctx sigParams target signature
 
 makeTarget :: ByteString -> ByteString -> ByteString

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -678,7 +678,7 @@ handshakeServerWithTLS13 sparams ctx chosenVersion allCreds exts clientCiphers _
             Nothing ->
                 case credentialsFindForSigning13 hashSigs allCreds of
                     Just cs -> return cs
-                    Nothing -> throwCore $ Error_Protocol ("credential not found", True, IllegalParameter)
+                    Nothing -> throwCore $ Error_Protocol ("credential not found", True, HandshakeFailure)
         let usedHash = cipherHash usedCipher
         doHandshake13 sparams cred ctx chosenVersion usedCipher exts usedHash keyShare hashSig clientSession rtt0
   where

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -838,7 +838,7 @@ doHandshake13 sparams ctx allCreds chosenVersion usedCipher exts usedHash client
         -- certificates supported by the client, but fallback to all credentials
         -- if this produces no suitable result (see RFC 5246 section 7.4.2 and
         -- RFC 8446 section 4.4.2.2).
-        let sHashSigs = supportedHashSignatures $ ctxSupported ctx
+        let sHashSigs = filter isHashSignatureValid13 $ supportedHashSignatures $ ctxSupported ctx
             hashSigs = sHashSigs `intersect` cHashSigs
             cltCreds = filterCredentialsWithHashSignatures exts allCreds
         case credentialsFindForSigning13 hashSigs cltCreds of

--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -17,6 +17,7 @@ module Network.TLS.Handshake.Signature
     , checkSupportedHashSignature
     , certificateCompatible
     , signatureCompatible
+    , hashSigToCertType
     , signatureParams
     , fromPubKey
     , decryptError
@@ -67,6 +68,46 @@ signatureCompatible DS_ECDSA   (_, SignatureECDSA)            = True
 signatureCompatible DS_Ed25519 (_, SignatureEd25519)          = True
 signatureCompatible DS_Ed448   (_, SignatureEd448)            = True
 signatureCompatible _          (_, _)                         = False
+
+-- | Translate a 'HashAndSignatureAlgorithm' to an acceptable 'CertificateType'.
+-- Perhaps this needs to take supported groups into account, so that, for
+-- example, if we don't support any shared ECDSA groups with the server, we
+-- return 'Nothing' rather than 'CertificateType_ECDSA_Sign'.
+--
+-- Therefore, this interface is preliminary.  It gets us moving in the right
+-- direction.  The interplay between all the various TLS extensions and
+-- certificate selection is rather complex.
+--
+-- The goal is to ensure that the client certificate request callback only sees
+-- 'CertificateType' values that are supported by the library and also
+-- compatible with the server signature algorithms extension.
+--
+-- Since we don't yet support ECDSA private keys, the caller will use
+-- 'lastSupportedCertificateType' to filter those out for now, leaving just
+-- @RSA@ as the only supported client certificate algorithm for TLS 1.3.
+--
+-- FIXME: Add RSA_PSS_PSS signatures when supported.
+--
+hashSigToCertType :: HashAndSignatureAlgorithm -> Maybe CertificateType
+--
+hashSigToCertType (_, SignatureRSA)   = Just CertificateType_RSA_Sign
+--
+hashSigToCertType (_, SignatureDSS)   = Just CertificateType_DSS_Sign
+--
+hashSigToCertType (_, SignatureECDSA) = Just CertificateType_ECDSA_Sign
+--
+hashSigToCertType (HashIntrinsic, SignatureRSApssRSAeSHA256)
+    = Just CertificateType_RSA_Sign
+hashSigToCertType (HashIntrinsic, SignatureRSApssRSAeSHA384)
+    = Just CertificateType_RSA_Sign
+hashSigToCertType (HashIntrinsic, SignatureRSApssRSAeSHA512)
+    = Just CertificateType_RSA_Sign
+hashSigToCertType (HashIntrinsic, SignatureEd25519)
+    = Just CertificateType_Ed25519_Sign
+hashSigToCertType (HashIntrinsic, SignatureEd448)
+    = Just CertificateType_Ed448_Sign
+--
+hashSigToCertType _ = Nothing
 
 checkCertificateVerify :: Context
                        -> Version

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -173,11 +173,14 @@ data Supported = Supported
       -- certificate verification and server signature in (EC)DHE,
       -- ordered by decreasing priority.
       --
-      -- This list is sent to the peer as part of the signature_algorithms
-      -- extension.  It is also used to restrict the choice of server
-      -- credential, signature and hash algorithm, but only when the TLS
-      -- version is 1.2 or above.  In order to disable SHA-1 one must then
+      -- This list is sent to the peer as part of the "signature_algorithms"
+      -- extension.  It is used to restrict accepted signatures received from
+      -- the peer at TLS level (not in X.509 certificates), but only when the
+      -- TLS version is 1.2 or above.  In order to disable SHA-1 one must then
       -- also disable earlier protocol versions in 'supportedVersions'.
+      --
+      -- The list also impacts the selection of possible algorithms when
+      -- generating signatures.
     , supportedHashSignatures :: [HashAndSignatureAlgorithm]
       -- | Secure renegotiation defined in RFC5746.
       --   If 'True', clients send the renegotiation_info extension.

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -181,6 +181,9 @@ data Supported = Supported
       --
       -- The list also impacts the selection of possible algorithms when
       -- generating signatures.
+      --
+      -- Note: with TLS 1.3 some algorithms have been deprecated and will not be
+      -- used even when listed in the parameter: MD5, SHA-1, RSA PKCS#1, DSS.
     , supportedHashSignatures :: [HashAndSignatureAlgorithm]
       -- | Secure renegotiation defined in RFC5746.
       --   If 'True', clients send the renegotiation_info extension.

--- a/core/Network/TLS/Struct.hs
+++ b/core/Network/TLS/Struct.hs
@@ -24,6 +24,7 @@ module Network.TLS.Struct
     , SignatureAlgorithm(..)
     , HashAndSignatureAlgorithm
     , DigitallySigned(..)
+    , Signature
     , ProtocolType(..)
     , TLSError(..)
     , TLSException(..)

--- a/core/Network/TLS/Struct.hs
+++ b/core/Network/TLS/Struct.hs
@@ -19,7 +19,6 @@ module Network.TLS.Struct
     , ExtensionRaw(..)
     , CertificateType(..)
     , lastSupportedCertificateType
-    , hashSigToCertType13
     , HashAlgorithm(..)
     , SignatureAlgorithm(..)
     , HashAndSignatureAlgorithm
@@ -147,56 +146,6 @@ data SignatureAlgorithm =
 
 type HashAndSignatureAlgorithm = (HashAlgorithm, SignatureAlgorithm)
 
-------------------------------------------------------------
-
--- | For TLS 1.3, translate a 'HashAndSignatureAlgorithm' to an
--- acceptable 'CertificateType'.  Perhaps this needs to take
--- supported groups into account, so that, for example, if we
--- don't support any shared ECDSA groups with the server, we
--- return 'Nothing' rather than 'CertificateType_ECDSA_Sign'.
---
--- Therefore, this interface is preliminary.  It gets us moving
--- in the right direction.  The interplay between all the various
--- TLS extensions and certificate selection is rather complex.
---
--- The goal is to ensure that the client certificate request
--- callback only sees 'CertificateType' values that are supported
--- by the library and also compatible with the server signature
--- algorithms extension.
---
--- Since we don't yet support ECDSA private keys, the caller
--- will use 'lastSupportedCertificateType' to filter those
--- out for now, leaving just @RSA@ as the only supported
--- client certificate algorithm for TLS 1.3.
---
--- FIXME: Add RSA_PSS_PSS signatures when supported.
---
-hashSigToCertType13 :: HashAndSignatureAlgorithm
-                    -> Maybe CertificateType
---
-hashSigToCertType13 (HashIntrinsic, hashsig)
-    | hashsig ==  SignatureRSApssRSAeSHA256
-      = Just CertificateType_RSA_Sign
-    | hashsig ==  SignatureRSApssRSAeSHA384
-      = Just CertificateType_RSA_Sign
-    | hashsig == SignatureRSApssRSAeSHA512
-      = Just CertificateType_RSA_Sign
-    | hashsig ==  SignatureEd25519
-      = Just CertificateType_Ed25519_Sign
-    | hashsig ==  SignatureEd448
-      = Just CertificateType_Ed448_Sign
-    | otherwise = Nothing
---
-hashSigToCertType13 (hashalg, SignatureECDSA)
-    | hashalg == HashSHA256
-      = Just CertificateType_ECDSA_Sign
-    | hashalg == HashSHA384
-      = Just CertificateType_ECDSA_Sign
-    | hashalg == HashSHA512
-      = Just CertificateType_ECDSA_Sign
-    | otherwise = Nothing
---
-hashSigToCertType13 _ = Nothing
 ------------------------------------------------------------
 
 type Signature = ByteString

--- a/core/Network/TLS/Struct13.hs
+++ b/core/Network/TLS/Struct13.hs
@@ -32,16 +32,19 @@ data KeyUpdate = UpdateNotRequested
                | UpdateRequested
                deriving (Show,Eq)
 
--- fixme: convert ByteString to proper data types.
+type TicketNonce = ByteString
+type CertReqContext = ByteString
+
+-- fixme: convert Word32 to proper data type
 data Handshake13 =
       ClientHello13 !Version !ClientRandom !Session ![CipherID] [ExtensionRaw]
     | ServerHello13 !ServerRandom !Session !CipherID [ExtensionRaw]
-    | NewSessionTicket13 Word32 Word32 ByteString ByteString [ExtensionRaw]
+    | NewSessionTicket13 Second Word32 TicketNonce SessionID [ExtensionRaw]
     | EndOfEarlyData13
     | EncryptedExtensions13 [ExtensionRaw]
-    | CertRequest13 ByteString [ExtensionRaw]
-    | Certificate13 ByteString CertificateChain [[ExtensionRaw]]
-    | CertVerify13 HashAndSignatureAlgorithm ByteString
+    | CertRequest13 CertReqContext [ExtensionRaw]
+    | Certificate13 CertReqContext CertificateChain [[ExtensionRaw]]
+    | CertVerify13 HashAndSignatureAlgorithm Signature
     | Finished13 FinishedData
     | KeyUpdate13 KeyUpdate
     deriving (Show,Eq)

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -88,8 +88,14 @@ knownHashSignatures = filter nonECDSA availableHashSignatures
     -- arbitraryCredentialsOfEachType cannot generate ECDSA
     nonECDSA (_,s) = s /= SignatureECDSA
 
-arbitraryHashSignatures :: Gen [HashAndSignatureAlgorithm]
-arbitraryHashSignatures = sublistOf knownHashSignatures
+knownHashSignatures13 :: [HashAndSignatureAlgorithm]
+knownHashSignatures13 = filter compat knownHashSignatures
+  where
+    compat (h,s) = h /= TLS.HashSHA1 && s /= SignatureDSS && s /= SignatureRSA
+
+arbitraryHashSignatures :: Version -> Gen [HashAndSignatureAlgorithm]
+arbitraryHashSignatures v = sublistOf l
+    where l = if v < TLS13 then knownHashSignatures else knownHashSignatures13
 
 -- for performance reason P521, FFDHE6144, FFDHE8192 are not tested
 knownGroups, knownECGroups, knownFFGroups :: [Group]


### PR DESCRIPTION
This PR:
- Restricts received hash/signatures to make sure the peer selected from what was advertised in the "signature_algorithms" extension.
- With TLS13, rejects use of MD5, SHA-1, RSA PKCS#1, DSS as TLS level. This is done regardless of `supportedHashSignatures`, which may include the algorithms for earlier protocol versions.
- Use `supportedHashSignatures` to send a list of certificate types with TLS12, like was done with TLS13.
- Aborts TLS13 without "signature_algorithms" extension (instead of using SHA-1 algorithms as default) but only when CertVerify messages are required.

Related to #194.