### PR TITLE
Strict handling of D-H groups

### DIFF
--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -505,7 +505,7 @@ sendClientData cparams ctx = sendCertificate >> sendClientKeyXchg >> sendCertifi
                                  usingHState ctx $ setNegotiatedGroup grp
                                  dhePair <- generateFFDHEShared ctx grp srvpub
                                  case dhePair of
-                                     Nothing   -> throwCore $ Error_Protocol ("invalid server public key", True, HandshakeFailure)
+                                     Nothing   -> throwCore $ Error_Protocol ("invalid server " ++ show grp ++ " public key", True, HandshakeFailure)
                                      Just pair -> return pair
 
                     masterSecret <- usingHState ctx $ setMasterSecretFromPre xver ClientRole premaster
@@ -518,7 +518,7 @@ sendClientData cparams ctx = sendCertificate >> sendClientKeyXchg >> sendCertifi
                     usingHState ctx $ setNegotiatedGroup grp
                     ecdhePair <- generateECDHEShared ctx srvpub
                     case ecdhePair of
-                        Nothing                  -> throwCore $ Error_Protocol ("invalid server public key", True, HandshakeFailure)
+                        Nothing                  -> throwCore $ Error_Protocol ("invalid server " ++ show grp ++ " public key", True, HandshakeFailure)
                         Just (clipub, premaster) -> do
                             xver <- usingState_ ctx getVersion
                             masterSecret <- usingHState ctx $ setMasterSecretFromPre xver ClientRole premaster

--- a/core/Network/TLS/Handshake/Process.hs
+++ b/core/Network/TLS/Handshake/Process.hs
@@ -130,7 +130,7 @@ processClientKeyXchg ctx (CKX_ECDH bytes) = do
                   role <- usingState_ ctx isClientContext
                   masterSecret <- usingHState ctx $ setMasterSecretFromPre rver role premaster
                   liftIO $ logKey ctx (MasterSecret masterSecret)
-              Nothing -> throwCore $ Error_Protocol ("cannote generate a shared secret on ECDH", True, HandshakeFailure)
+              Nothing -> throwCore $ Error_Protocol ("cannot generate a shared secret on ECDH", True, HandshakeFailure)
 
 processClientFinished :: Context -> FinishedData -> IO ()
 processClientFinished ctx fdata = do

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -204,6 +204,11 @@ data Supported = Supported
     , supportedEmptyPacket         :: Bool
       -- | A list of supported elliptic curves and finite-field groups in the
       --   preferred order.
+      --
+      --   The list is sent to the server as part of the "supported_groups"
+      --   extension.  It is used in both clients and servers to restrict
+      --   accepted groups in DH key exchange.
+      --
       --   The default value is ['X25519','P256','P384','P521'].
       --   'X25519' and 'P256' provide 128-bit security which is strong
       --   enough until 2030.  Both curves are fast because their
@@ -343,10 +348,13 @@ data ClientHooks = ClientHooks
       -- | This action is called when the client sends ClientHello
       --   to determine ALPN values such as '["h2", "http/1.1"]'.
     , onSuggestALPN :: IO (Maybe [B.ByteString])
-      -- | This action is called to validate DHE parameters when
-      --   the server selected a finite-field group not part of
-      --   the "Supported Groups Registry".
-      --   See RFC 7919 section 3.1 for recommandations.
+      -- | This action is called to validate DHE parameters when the server
+      --   selected a finite-field group not part of the "Supported Groups
+      --   Registry" or not part of 'supportedGroups' list.
+      --
+      --   With TLS 1.3 custom groups have been removed from the protocol, so
+      --   this callback is only used when the version negotiated is 1.2 or
+      --   below.
       --
       --   The default behavior with (dh_p, dh_g, dh_size) and pub as follows:
       --
@@ -354,6 +362,8 @@ data ClientHooks = ClientHooks
       --   (2) rejecting unless 1 < dh_g && dh_g < dh_p - 1
       --   (3) rejecting unless 1 < dh_p && pub < dh_p - 1
       --   (4) rejecting if dh_size < 1024 (to prevent Logjam attack)
+      --
+      --   See RFC 7919 section 3.1 for recommandations.
     , onCustomFFDHEGroup :: DHParams -> DHPublic -> IO GroupUsage
     }
 

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -13,6 +13,7 @@ module Connection
     , arbitraryClientCredential
     , arbitraryCredentialsOfEachCurve
     , arbitraryRSACredentialWithUsage
+    , dhParamsGroup
     , isVersionEnabled
     , isCustomDHParams
     , isLeafRSA
@@ -129,6 +130,12 @@ arbitraryCredentialsOfEachCurve = do
          ) [ (PubKeyEd25519 ed25519Pub, PrivKeyEd25519 ed25519Priv)
            , (PubKeyEd448 ed448Pub, PrivKeyEd448 ed448Priv)
            ]
+
+dhParamsGroup :: DHParams -> Maybe Group
+dhParamsGroup params
+    | params == ffdhe2048 = Just FFDHE2048
+    | params == ffdhe3072 = Just FFDHE3072
+    | otherwise           = Nothing
 
 isCustomDHParams :: DHParams -> Bool
 isCustomDHParams params = params == dhParams512

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -560,8 +560,10 @@ prop_handshake_groups = do
                                        { supportedGroups = serverGroups }
                                    }
         isCustom = maybe True isCustomDHParams (serverDHEParams serverParam')
+        mCustomGroup = serverDHEParams serverParam' >>= dhParamsGroup
+        isClientCustom = maybe True (`notElem` clientGroups) mCustomGroup
         commonGroups = clientGroups `intersect` serverGroups
-        shouldFail = null commonGroups && (tls13 || isCustom && denyCustom)
+        shouldFail = null commonGroups && (tls13 || isClientCustom && denyCustom)
         p minfo = isNothing (minfo >>= infoNegotiatedGroup) == (null commonGroups && isCustom)
     if shouldFail
         then runTLSInitFailure (clientParam',serverParam')


### PR DESCRIPTION
This PR restricts received groups to make sure the peer selected from what was advertised in the "supported_groups" extension.

For FFDHE one consequence is that the client may accept as custom group a FF group which is not supported.

Related to #194.