### PR TITLE
Two simple checks for TLS13

### DIFF
--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -636,7 +636,8 @@ onServerHello ctx cparams sentExts (ServerHello rver serverRan serverSession cip
     case find (== ver) (supportedVersions $ ctxSupported ctx) of
         Nothing -> throwCore $ Error_Protocol ("server version " ++ show ver ++ " is not supported", True, ProtocolVersion)
         Just _  -> return ()
-    if ver == TLS13 then do
+    if ver > TLS12 then do
+        ensureNullCompression compression
         usingHState ctx $ setHelloParameters13 cipherAlg
         return RecvStateDone
       else do

--- a/core/Network/TLS/Handshake/Common13.hs
+++ b/core/Network/TLS/Handshake/Common13.hs
@@ -24,6 +24,7 @@ module Network.TLS.Handshake.Common13
        , checkFreshness
        , getCurrentTimeFromBase
        , getSessionData13
+       , ensureNullCompression
        , isHashSignatureValid13
        , safeNonNegative32
        , RecvHandshake13M
@@ -35,6 +36,7 @@ module Network.TLS.Handshake.Common13
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as B
 import Data.Hourglass
+import Network.TLS.Compression
 import Network.TLS.Context.Internal
 import Network.TLS.Cipher
 import Network.TLS.Crypto
@@ -250,6 +252,11 @@ getSessionData13 ctx usedCipher tinfo maxSize psk = do
       }
 
 ----------------------------------------------------------------
+
+ensureNullCompression :: MonadIO m => CompressionID -> m ()
+ensureNullCompression compression =
+    when (compression /= compressionID nullCompression) $
+        throwCore $ Error_Protocol ("compression is not allowed in TLS 1.3", True, IllegalParameter)
 
 -- Word32 is used in TLS 1.3 protocol.
 -- Int is used for API for Haskell TLS because it is natural.

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -147,7 +147,8 @@ handshakeServerWith sparams ctx clientHello@(ClientHello clientVersion _ clientS
     -- TLS version dependent
     if chosenVersion <= TLS12 then
         handshakeServerWithTLS12 sparams ctx chosenVersion allCreds exts ciphers serverName clientVersion compressions clientSession
-      else
+      else do
+        mapM_ ensureNullCompression compressions
         -- fixme: we should check if the client random is the same as
         -- that in the first client hello in the case of hello retry.
         handshakeServerWithTLS13 sparams ctx chosenVersion allCreds exts ciphers serverName clientSession

--- a/core/Network/TLS/Packet13.hs
+++ b/core/Network/TLS/Packet13.hs
@@ -46,7 +46,7 @@ encodeHandshake13' (ServerHello13 random session cipherId exts) = runPut $ do
     putServerRandom32 random
     putSession session
     putWord16 cipherId
-    putWord8 0
+    putWord8 0 -- compressionID nullCompression
     putExtensions exts
 encodeHandshake13' (EncryptedExtensions13 exts) = runPut $ putExtensions exts
 encodeHandshake13' (CertRequest13 reqctx exts) = runPut $ do

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -167,7 +167,10 @@ data Supported = Supported
       -- cipher list.  'Network.TLS.Extra.Cipher.ciphersuite_default' is often
       -- a good choice.
     , supportedCiphers        :: [Cipher]
-      -- | supported compressions methods
+      -- | Supported compressions methods.  By default only the "null"
+      -- compression is supported, which means no compression will be performed.
+      -- Allowing other compression method is not advised as it causes a
+      -- connection failure when TLS 1.3 is negotiated.
     , supportedCompressions   :: [Compression]
       -- | All supported hash/signature algorithms pair for client
       -- certificate verification and server signature in (EC)DHE,


### PR DESCRIPTION
- Prevent negotation of non-"null" compression
- Test that NewSessionTicket13 is received by a client, not a server