### PR TITLE
refactoring for QUIC.

### DIFF
--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -191,10 +191,10 @@ recvData13 ctx = do
             -- read+write locks (which is also what we use for all calls to the
             -- session manager).
             withWriteLock ctx $ do
-                ResuptionSecret resumptionMasterSecret <- usingHState ctx getTLS13Secret
+                ResumptionSecret resumptionSecret <- usingHState ctx getTLS13Secret
                 (usedHash, usedCipher, _) <- getTxState ctx
                 let hashSize = hashDigestSize usedHash
-                    psk = hkdfExpandLabel usedHash resumptionMasterSecret "resumption" nonce hashSize
+                    psk = hkdfExpandLabel usedHash resumptionSecret "resumption" nonce hashSize
                     maxSize = case extensionLookup extensionID_EarlyData exts >>= extensionDecode MsgTNewSessionTicket of
                         Just (EarlyDataIndication (Just ms)) -> fromIntegral $ safeNonNegative32 ms
                         _                                    -> 0

--- a/core/Network/TLS/Handshake/Key.hs
+++ b/core/Network/TLS/Handshake/Key.hs
@@ -19,7 +19,6 @@ module Network.TLS.Handshake.Key
     , generateFFDHEShared
     , getLocalDigitalSignatureAlg
     , logKey
-    , LogKey(..)
     ) where
 
 import Control.Monad.State.Strict
@@ -92,30 +91,23 @@ getLocalDigitalSignatureAlg ctx = do
 
 ----------------------------------------------------------------
 
-data LogKey = MasterSecret ByteString
-            | ClientEarlyTrafficSecret ByteString
-            | ServerHandshakeTrafficSecret ByteString
-            | ClientHandshakeTrafficSecret ByteString
-            | ServerTrafficSecret0 ByteString
-            | ClientTrafficSecret0 ByteString
-
-labelAndKey :: LogKey -> (String, ByteString)
-labelAndKey (MasterSecret key) =
+labelAndKey :: TrafficSecret -> (String, ByteString)
+labelAndKey (MasterSecret12 key) =
     ("CLIENT_RANDOM", key)
-labelAndKey (ClientEarlyTrafficSecret key) =
+labelAndKey (ClientEarlySecret key) =
     ("CLIENT_EARLY_TRAFFIC_SECRET", key)
-labelAndKey (ServerHandshakeTrafficSecret key) =
+labelAndKey (ServerHandshakeSecret key) =
     ("SERVER_HANDSHAKE_TRAFFIC_SECRET", key)
-labelAndKey (ClientHandshakeTrafficSecret key) =
+labelAndKey (ClientHandshakeSecret key) =
     ("CLIENT_HANDSHAKE_TRAFFIC_SECRET", key)
-labelAndKey (ServerTrafficSecret0 key) =
+labelAndKey (ServerApplicationSecret0 key) =
     ("SERVER_TRAFFIC_SECRET_0", key)
-labelAndKey (ClientTrafficSecret0 key) =
+labelAndKey (ClientApplicationSecret0 key) =
     ("CLIENT_TRAFFIC_SECRET_0", key)
 
 -- NSS Key Log Format
 -- See https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format
-logKey :: Context -> LogKey -> IO ()
+logKey :: Context -> TrafficSecret -> IO ()
 logKey ctx logkey = do
     mhst <- getHState ctx
     case mhst of

--- a/core/Network/TLS/Handshake/Process.hs
+++ b/core/Network/TLS/Handshake/Process.hs
@@ -25,6 +25,7 @@ import Network.TLS.ErrT
 import Network.TLS.Struct
 import Network.TLS.Struct13
 import Network.TLS.State
+import Network.TLS.Types
 import Network.TLS.Context.Internal
 import Network.TLS.Crypto
 import Network.TLS.Imports
@@ -102,7 +103,7 @@ processClientKeyXchg ctx (CKX_RSA encryptedPremaster) = do
                 Right (ver, _)
                     | ver /= expectedVer -> setMasterSecretFromPre rver role random
                     | otherwise          -> setMasterSecretFromPre rver role premaster
-    liftIO $ logKey ctx (MasterSecret masterSecret)
+    liftIO $ logKey ctx (MasterSecret12 masterSecret)
 
 processClientKeyXchg ctx (CKX_DH clientDHValue) = do
     rver <- usingState_ ctx getVersion
@@ -116,7 +117,7 @@ processClientKeyXchg ctx (CKX_DH clientDHValue) = do
     dhpriv       <- usingHState ctx getDHPrivate
     let premaster = dhGetShared params dhpriv clientDHValue
     masterSecret <- usingHState ctx $ setMasterSecretFromPre rver role premaster
-    liftIO $ logKey ctx (MasterSecret masterSecret)
+    liftIO $ logKey ctx (MasterSecret12 masterSecret)
 
 processClientKeyXchg ctx (CKX_ECDH bytes) = do
     ServerECDHParams grp _ <- usingHState ctx getServerECDHParams
@@ -129,7 +130,7 @@ processClientKeyXchg ctx (CKX_ECDH bytes) = do
                   rver <- usingState_ ctx getVersion
                   role <- usingState_ ctx isClientContext
                   masterSecret <- usingHState ctx $ setMasterSecretFromPre rver role premaster
-                  liftIO $ logKey ctx (MasterSecret masterSecret)
+                  liftIO $ logKey ctx (MasterSecret12 masterSecret)
               Nothing -> throwCore $ Error_Protocol ("cannot generate a shared secret on ECDH", True, HandshakeFailure)
 
 processClientFinished :: Context -> FinishedData -> IO ()

--- a/core/Network/TLS/Handshake/State.hs
+++ b/core/Network/TLS/Handshake/State.hs
@@ -81,11 +81,6 @@ import Control.Monad.State.Strict
 import Data.X509 (CertificateChain)
 import Data.ByteArray (ByteArrayAccess)
 
-data Secret13 = NoSecret
-              | EarlySecret ByteString
-              | ResuptionSecret ByteString
-              deriving (Eq, Show)
-
 data HandshakeKeyState = HandshakeKeyState
     { hksRemotePublicKey :: !(Maybe PubKey)
     , hksLocalPublicPrivateKeys :: !(Maybe (PubKey, PrivKey))

--- a/core/Network/TLS/Packet.hs
+++ b/core/Network/TLS/Packet.hs
@@ -59,9 +59,13 @@ module Network.TLS.Packet
     , putSignatureHashAlgorithm
     , getBinaryVersion
     , putBinaryVersion
+    , getClientRandom32
+    , putClientRandom32
+    , getServerRandom32
     , putServerRandom32
-    , putExtension
     , getExtensions
+    , putExtension
+    , getSession
     , putSession
     , putDNames
     , getDNames

--- a/core/Network/TLS/Types.hs
+++ b/core/Network/TLS/Types.hs
@@ -18,6 +18,9 @@ module Network.TLS.Types
     , HostName
     , Second
     , Millisecond
+    , SecretTriple(..)
+    , Secret13(..)
+    , TrafficSecret(..)
     ) where
 
 import Network.TLS.Imports
@@ -72,3 +75,27 @@ data Direction = Tx | Rx
 invertRole :: Role -> Role
 invertRole ClientRole = ServerRole
 invertRole ServerRole = ClientRole
+
+data SecretTriple = SecretTriple {
+    triBase   :: Secret13
+  , triClient :: TrafficSecret
+  , triServer :: TrafficSecret
+  } deriving (Eq, Show)
+
+data Secret13 = NoSecret
+              | EarlySecret ByteString
+              | HandshakeSecret ByteString
+              | ApplicationSecret ByteString -- TLS 1.3 master secret
+              | ResumptionSecret ByteString
+              deriving (Eq, Show)
+
+data TrafficSecret =
+    -- TLS 1.2 or earlier
+    MasterSecret12 ByteString
+    -- TLS 1.3
+  | ClientEarlySecret        ByteString
+  | ServerHandshakeSecret    ByteString
+  | ClientHandshakeSecret    ByteString
+  | ServerApplicationSecret0 ByteString
+  | ClientApplicationSecret0 ByteString
+  deriving (Eq, Show)


### PR DESCRIPTION
- Defining new types: Choice and SecretTriple.
- Renaming LogKey to TrafficSecret.
  Each member now has a cleaner and shorter name.
  e.g. ServerTrafficSecret0 --> ServerApplicationSecret0
- Moving secret relating types to Network.TLS.Types.
- IO related code is separated in Network.TLS.{Client,Server}.
  Many local functions are now top-level functions.
  The original semantics remains.
- encodeHandshake13' and decodeHandshake13 are now total functions.
- Each member of recvHandshake13 is independent thanks to
  pushbackHandshake13. As a result, recvHandshake13preUpdate is
  gone. Only using recvHandshake13, the old recvHandshake13postUpdate.