### PR TITLE
Fix recvClientData with single Handshake packet

### DIFF
--- a/core/Network/TLS/Handshake/Common.hs
+++ b/core/Network/TLS/Handshake/Common.hs
@@ -125,6 +125,7 @@ recvPacketHandshake ctx = do
 -- | process a list of handshakes message in the recv state machine.
 onRecvStateHandshake :: Context -> RecvState IO -> [Handshake] -> IO (RecvState IO)
 onRecvStateHandshake _   recvState [] = return recvState
+onRecvStateHandshake _   (RecvStateNext f) hms = f (Handshake hms)
 onRecvStateHandshake ctx (RecvStateHandshake f) (x:xs) = do
     nstate <- f x
     processHandshake ctx x


### PR DESCRIPTION
Function recvClientData did not accept a client flight with messages
ClientKeyXchg and CertVerify received from the same Handshake packet.
This patch extends the state machine to transform remaining handshake
messages as input to RecvStateNext.

Resolves #350.