### PR TITLE
Decrease memory footprint of SessionData values

### DIFF
--- a/core/Network/TLS/Extension.hs
+++ b/core/Network/TLS/Extension.hs
@@ -262,8 +262,9 @@ decodeServerName = runGetMaybe $ do
   where
     getServerName = do
         ty    <- getWord8
-        sname <- getOpaque16
-        let name = case ty of
+        snameParsed <- getOpaque16
+        let !sname = B.copy snameParsed
+            name = case ty of
               0 -> ServerNameHostName $ BC.unpack sname -- FIXME: should be puny code conversion
               _ -> ServerNameOther (ty, sname)
         return (1+2+B.length sname, name)
@@ -349,7 +350,8 @@ decodeApplicationLayerProtocolNegotiation = runGetMaybe $ do
     ApplicationLayerProtocolNegotiation <$> getList (fromIntegral len) getALPN
   where
     getALPN = do
-        alpn <- getOpaque8
+        alpnParsed <- getOpaque8
+        let !alpn = B.copy alpnParsed
         return (B.length alpn + 1, alpn)
 
 ------------------------------------------------------------

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -611,9 +611,7 @@ onServerHello ctx cparams sentExts (ServerHello rver serverRan serverSession cip
         isHRR = isHelloRetryRequest serverRan
     usingState_ ctx $ do
         setTLS13HRR isHRR
-        case extensionLookup extensionID_Cookie exts >>= extensionDecode MsgTServerHello of
-          Just cookie -> setTLS13Cookie cookie
-          _           -> return ()
+        setTLS13Cookie (guard isHRR >> extensionLookup extensionID_Cookie exts >>= extensionDecode MsgTServerHello)
         setSession serverSession (isJust resumingSession)
         setVersion rver -- must be before processing supportedVersions ext
         mapM_ processServerExtension exts

--- a/core/Network/TLS/Handshake/Common.hs
+++ b/core/Network/TLS/Handshake/Common.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Network.TLS.Handshake.Common
     ( handshakeFailed
@@ -143,12 +144,14 @@ getSessionData ctx = do
     mms <- usingHState ctx (gets hstMasterSecret)
     tx  <- liftIO $ readMVar (ctxTxState ctx)
     alpn <- usingState_ ctx getNegotiatedProtocol
+    let !cipher      = cipherID $ fromJust "cipher" $ stCipher tx
+        !compression = compressionID $ stCompression tx
     case mms of
         Nothing -> return Nothing
         Just ms -> return $ Just SessionData
                         { sessionVersion     = ver
-                        , sessionCipher      = cipherID $ fromJust "cipher" $ stCipher tx
-                        , sessionCompression = compressionID $ stCompression tx
+                        , sessionCipher      = cipher
+                        , sessionCompression = compression
                         , sessionClientSNI   = sni
                         , sessionSecret      = ms
                         , sessionGroup       = Nothing

--- a/core/Network/TLS/State.hs
+++ b/core/Network/TLS/State.hs
@@ -282,8 +282,8 @@ setTLS13HRR b = modify (\st -> st { stTLS13HRR = b })
 getTLS13HRR :: TLSSt Bool
 getTLS13HRR = gets stTLS13HRR
 
-setTLS13Cookie :: Cookie -> TLSSt ()
-setTLS13Cookie cookie = modify (\st -> st { stTLS13Cookie = Just cookie })
+setTLS13Cookie :: Maybe Cookie -> TLSSt ()
+setTLS13Cookie mcookie = modify (\st -> st { stTLS13Cookie = mcookie })
 
 getTLS13Cookie :: TLSSt (Maybe Cookie)
 getTLS13Cookie = gets stTLS13Cookie


### PR DESCRIPTION
The report in yesodweb/wai#728 shows a space leak in the session manager but also that retained memory is high overall.

Here are simple mitigations, mainly to decrease what is retained by SessionData values. This kind of modification can probably be carried out further to decrease footprint of live Context values.

With this PR I measure process memory on the server memleak test going down to 24 KB per session instead of 54 KB.

As for design, copying ByteStrings ideally should be moved out of extension decoding but this is a very convenient location (before additional transformations take place, like unpacking to String).