### PR TITLE
Fixing memory leak

### DIFF
--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_HADDOCK hide #-}
-{-# LANGUAGE OverloadedStrings, ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings, ScopedTypeVariables, BangPatterns #-}
 -- |
 -- Module      : Network.TLS.Core
 -- License     : BSD-style
@@ -202,7 +202,8 @@ recvData13 ctx = do
                         _                                    -> 0
                 tinfo <- createTLS13TicketInfo life (Right add) Nothing
                 sdata <- getSessionData13 ctx usedCipher tinfo maxSize psk
-                sessionEstablish (sharedSessionManager $ ctxShared ctx) label sdata
+                let !label' = B.copy label
+                sessionEstablish (sharedSessionManager $ ctxShared ctx) label' sdata
                 -- putStrLn $ "NewSessionTicket received: lifetime = " ++ show life ++ " sec"
             loopHandshake13 hs
         loopHandshake13 (KeyUpdate13 mode:hs) = do

--- a/core/Network/TLS/Handshake/Common.hs
+++ b/core/Network/TLS/Handshake/Common.hs
@@ -21,6 +21,7 @@ module Network.TLS.Handshake.Common
     , checkSupportedGroup
     ) where
 
+import qualified Data.ByteString as B
 import Control.Concurrent.MVar
 
 import Network.TLS.Parameters
@@ -83,7 +84,8 @@ handshakeTerminate ctx = do
     case session of
         Session (Just sessionId) -> do
             sessionData <- getSessionData ctx
-            liftIO $ sessionEstablish (sharedSessionManager $ ctxShared ctx) sessionId (fromJust "session-data" sessionData)
+            let !sessionId' = B.copy sessionId
+            liftIO $ sessionEstablish (sharedSessionManager $ ctxShared ctx) sessionId' (fromJust "session-data" sessionData)
         _ -> return ()
     -- forget most handshake data and reset bytes counters.
     liftIO $ modifyMVar_ (ctxHandshake ctx) $ \ mhshake ->

--- a/session/ChangeLog.md
+++ b/session/ChangeLog.md
@@ -1,2 +1,11 @@
+# 0.1.0.0
+
+- Using ShortByteString internally to avoid ByteString's fragmentation.
+- The default value of dbMaxSize is now 1,000.
+
+# 0.0.1.0
+
+- Supporting sessionResumeOnlyOnce.
+
 # 0.0.0.0
 - A first release.

--- a/session/Network/TLS/SessionManager.hs
+++ b/session/Network/TLS/SessionManager.hs
@@ -36,12 +36,12 @@ data Config = Config {
     , dbMaxSize      :: !Int
     }
 
--- | Lifetime: 1 day , delay: 10 minutes, limit: 10,000 entries.
+-- | Lifetime: 1 day , delay: 10 minutes, max size: 1000 entries.
 defaultConfig :: Config
 defaultConfig = Config {
       ticketLifetime = 86400
     , pruningDelay   = 6000
-    , dbMaxSize      = 10000
+    , dbMaxSize      = 1000
     }
 
 ----------------------------------------------------------------

--- a/session/Network/TLS/SessionManager.hs
+++ b/session/Network/TLS/SessionManager.hs
@@ -14,11 +14,11 @@ module Network.TLS.SessionManager (
   , newSessionManager
   ) where
 
-import Data.ByteString (ByteString)
-import Data.ByteString.Short (ShortByteString)
-import qualified Data.ByteString.Short as Short
+import Basement.Block (Block)
+import Data.ByteArray (convert)
 import Control.Exception (assert)
 import Control.Reaper
+import Data.ByteString (ByteString)
 import Data.IORef
 import Data.OrdPSQ (OrdPSQ)
 import qualified Data.OrdPSQ as Q
@@ -49,35 +49,35 @@ defaultConfig = Config {
 
 ----------------------------------------------------------------
 
-toKey :: ByteString -> ShortByteString
-toKey = Short.toShort
+toKey :: ByteString -> Block Word8
+toKey = convert
 
 toValue :: SessionData -> SessionDataCopy
 toValue (SessionData v cid comp msni sec mg mti malpn siz) =
     SessionDataCopy v cid comp msni sec' mg mti malpn' siz
   where
-    !sec' = Short.toShort sec
-    !malpn' = Short.toShort <$> malpn
+    !sec' = convert sec
+    !malpn' = convert <$> malpn
 
 fromValue :: SessionDataCopy -> SessionData
 fromValue (SessionDataCopy v cid comp msni sec' mg mti malpn' siz) =
     (SessionData v cid comp msni sec mg mti malpn siz)
   where
-    !sec = Short.fromShort sec'
-    !malpn = Short.fromShort <$> malpn'
+    !sec = convert sec'
+    !malpn = convert <$> malpn'
 
 ----------------------------------------------------------------
 
-type SessionIDCopy = ShortByteString
+type SessionIDCopy = Block Word8
 data SessionDataCopy = SessionDataCopy {
       ssVersion     :: !Version
     , ssCipher      :: !CipherID
     , ssCompression :: !CompressionID
     , ssClientSNI   :: !(Maybe HostName)
-    , ssSecret      :: !ShortByteString
+    , ssSecret      :: Block Word8
     , ssGroup       :: !(Maybe Group)
     , ssTicketInfo  :: !(Maybe TLS13TicketInfo)
-    , ssALPN        :: !(Maybe ShortByteString)
+    , ssALPN        :: !(Maybe (Block Word8))
     , ssMaxEarlyDataSize :: Int
     } deriving (Show,Eq)
 

--- a/session/tls-session-manager.cabal
+++ b/session/tls-session-manager.cabal
@@ -18,8 +18,10 @@ library
   -- other-extensions:
   build-depends:       base >= 4.7 && < 5
                      , auto-update
+                     , basement
                      , bytestring
                      , clock
+                     , memory
                      , psqueues >= 0.2.3
                      , tls
   -- hs-source-dirs:

--- a/session/tls-session-manager.cabal
+++ b/session/tls-session-manager.cabal
@@ -18,6 +18,7 @@ library
   -- other-extensions:
   build-depends:       base >= 4.7 && < 5
                      , auto-update
+                     , bytestring
                      , clock
                      , psqueues >= 0.2.3
                      , tls


### PR DESCRIPTION
@ocheron found that session values of `ByteString` lead memory leak. I also found that session keys (IDs) of `ByteString` leak memory. 1afb213 fixes it. In my server, this reduced memory usage from 30% to 11%.

b0ba6a9 changes the internal data structure from `ByteString` to `ShortByteString` to avoid fragmentation. This improves memory footprint from 11% to 5%. I did both experiments with `dbMaxSize` = 1,000.