### PR TITLE
Post-handshake authentication

### DIFF
--- a/core/Network/TLS.hs
+++ b/core/Network/TLS.hs
@@ -98,9 +98,10 @@ module Network.TLS
     -- ** Negotiated
     , getNegotiatedProtocol
     , getClientSNI
-    -- ** Updating keys
+    -- ** Post-handshake actions
     , updateKey
     , KeyUpdateRequest(..)
+    , requestCertificate
 
     -- * Raw types
     , ProtocolType(..)

--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -67,6 +67,7 @@ module Network.TLS.Context
 import Network.TLS.Backend
 import Network.TLS.Context.Internal
 import Network.TLS.Struct
+import Network.TLS.Struct13
 import Network.TLS.State
 import Network.TLS.Hooks
 import Network.TLS.Record.State
@@ -74,6 +75,7 @@ import Network.TLS.Parameters
 import Network.TLS.Measurement
 import Network.TLS.Types (Role(..))
 import Network.TLS.Handshake (handshakeClient, handshakeClientWith, handshakeServer, handshakeServerWith)
+import Network.TLS.PostHandshake (postHandshakeAuthClientWith, postHandshakeAuthServerWith)
 import Network.TLS.X509
 import Network.TLS.RNG
 
@@ -92,6 +94,7 @@ class TLSParams a where
     getTLSRole         :: a -> Role
     doHandshake        :: a -> Context -> IO ()
     doHandshakeWith    :: a -> Context -> Handshake -> IO ()
+    doPostHandshakeAuthWith :: a -> Context -> Handshake13 -> IO ()
 
 instance TLSParams ClientParams where
     getTLSCommonParams cparams = ( clientSupported cparams
@@ -101,6 +104,7 @@ instance TLSParams ClientParams where
     getTLSRole _ = ClientRole
     doHandshake = handshakeClient
     doHandshakeWith = handshakeClientWith
+    doPostHandshakeAuthWith = postHandshakeAuthClientWith
 
 instance TLSParams ServerParams where
     getTLSCommonParams sparams = ( serverSupported sparams
@@ -110,6 +114,7 @@ instance TLSParams ServerParams where
     getTLSRole _ = ServerRole
     doHandshake = handshakeServer
     doHandshakeWith = handshakeServerWith
+    doPostHandshakeAuthWith = postHandshakeAuthServerWith
 
 -- | create a new context using the backend and parameters specified.
 contextNew :: (MonadIO m, HasBackend backend, TLSParams params)
@@ -158,6 +163,7 @@ contextNew backend params = liftIO $ do
             , ctxHandshake    = hs
             , ctxDoHandshake  = doHandshake params
             , ctxDoHandshakeWith  = doHandshakeWith params
+            , ctxDoPostHandshakeAuthWith = doPostHandshakeAuthWith params
             , ctxMeasurement  = stats
             , ctxEOF_         = eof
             , ctxEstablished_ = established

--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -149,6 +149,7 @@ contextNew backend params = liftIO $ do
     rx    <- newMVar newRecordState
     hs    <- newMVar Nothing
     as    <- newIORef []
+    crs   <- newIORef []
     lockWrite <- newMVar ()
     lockRead  <- newMVar ()
     lockState <- newMVar ()
@@ -174,6 +175,7 @@ contextNew backend params = liftIO $ do
             , ctxLockRead         = lockRead
             , ctxLockState        = lockState
             , ctxPendingActions   = as
+            , ctxCertRequests     = crs
             , ctxKeyLogger        = debugKeyLogger debug
             }
 

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -114,6 +114,7 @@ data Context = Context
     , ctxHandshake        :: MVar (Maybe HandshakeState) -- ^ optional handshake state
     , ctxDoHandshake      :: Context -> IO ()
     , ctxDoHandshakeWith  :: Context -> Handshake -> IO ()
+    , ctxDoPostHandshakeAuthWith :: Context -> Handshake13 -> IO ()
     , ctxHooks            :: IORef Hooks   -- ^ hooks for this context
     , ctxLockWrite        :: MVar ()       -- ^ lock to use for writing data (including updating the state)
     , ctxLockRead         :: MVar ()       -- ^ lock to use for reading data (including updating the state)

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -54,6 +54,8 @@ module Network.TLS.Context.Internal
     , runRxState
     , usingHState
     , getHState
+    , saveHState
+    , restoreHState
     , getStateRNG
     , tls13orLater
     ) where
@@ -71,6 +73,7 @@ import Network.TLS.Record.State
 import Network.TLS.Parameters
 import Network.TLS.Measurement
 import Network.TLS.Imports
+import Network.TLS.Util
 import qualified Data.ByteString as B
 
 import Control.Concurrent.MVar
@@ -224,6 +227,14 @@ usingHState ctx f = liftIO $ modifyMVar (ctxHandshake ctx) $ \mst ->
 
 getHState :: MonadIO m => Context -> m (Maybe HandshakeState)
 getHState ctx = liftIO $ readMVar (ctxHandshake ctx)
+
+saveHState :: Context -> IO (Saved (Maybe HandshakeState))
+saveHState ctx = saveMVar (ctxHandshake ctx)
+
+restoreHState :: Context
+              -> Saved (Maybe HandshakeState)
+              -> IO (Saved (Maybe HandshakeState))
+restoreHState ctx = restoreMVar (ctxHandshake ctx)
 
 runTxState :: Context -> RecordM a -> IO (Either TLSError a)
 runTxState ctx f = do

--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -29,6 +29,7 @@ module Network.TLS.Core
     , recvData'
     , updateKey
     , KeyUpdateRequest(..)
+    , requestCertificate
     ) where
 
 import Network.TLS.Cipher

--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -46,6 +46,7 @@ import Network.TLS.Handshake.Common13
 import Network.TLS.Handshake.Process
 import Network.TLS.Handshake.State
 import Network.TLS.Handshake.State13
+import Network.TLS.PostHandshake
 import Network.TLS.KeySchedule
 import Network.TLS.Types (Role(..), HostName)
 import Network.TLS.Util (catchException, mapChunks_)
@@ -221,6 +222,10 @@ recvData13 ctx = do
               else do
                 let reason = "received key update before established"
                 terminate (Error_Misc reason) AlertLevel_Fatal UnexpectedMessage reason
+        loopHandshake13 (h@CertRequest13{}:hs) =
+            postHandshakeAuthWith ctx h >> loopHandshake13 hs
+        loopHandshake13 (h@Certificate13{}:hs) =
+            postHandshakeAuthWith ctx h >> loopHandshake13 hs
         loopHandshake13 (h:hs) = do
             mPendingAction <- popPendingAction ctx
             case mPendingAction of

--- a/core/Network/TLS/Extension.hs
+++ b/core/Network/TLS/Extension.hs
@@ -51,6 +51,7 @@ module Network.TLS.Extension
     , KeyShare(..)
     , KeyShareEntry(..)
     , MessageType(..)
+    , PostHandshakeAuth(..)
     , PskKexMode(..)
     , PskKeyExchangeModes(..)
     , PskIdentity(..)
@@ -463,6 +464,16 @@ decodeSignatureAlgorithms :: ByteString -> Maybe SignatureAlgorithms
 decodeSignatureAlgorithms = runGetMaybe $ do
     len <- getWord16
     SignatureAlgorithms <$> getList (fromIntegral len) (getSignatureHashAlgorithm >>= \sh -> return (2, sh))
+
+------------------------------------------------------------
+
+data PostHandshakeAuth = PostHandshakeAuth deriving (Show,Eq)
+
+instance Extension PostHandshakeAuth where
+    extensionID _ = extensionID_PostHandshakeAuth
+    extensionEncode _               = B.empty
+    extensionDecode MsgTClientHello = runGetMaybe (pure PostHandshakeAuth)
+    extensionDecode _               = error "extensionDecode: PostHandshakeAuth"
 
 ------------------------------------------------------------
 

--- a/core/Network/TLS/Handshake.hs
+++ b/core/Network/TLS/Handshake.hs
@@ -16,17 +16,12 @@ module Network.TLS.Handshake
 
 import Network.TLS.Context.Internal
 import Network.TLS.Struct
-import Network.TLS.Struct13
-import Network.TLS.IO
-import Network.TLS.Util (catchException)
-import Network.TLS.Imports
 
 import Network.TLS.Handshake.Common
 import Network.TLS.Handshake.Client
 import Network.TLS.Handshake.Server
 
 import Control.Monad.State.Strict
-import Control.Exception (IOException, handle, fromException)
 
 -- | Handshake for a new TLS connection
 -- This is to be called at the beginning of a connection, and during renegotiation
@@ -41,18 +36,3 @@ handshake ctx =
 handshakeWith :: MonadIO m => Context -> Handshake -> m ()
 handshakeWith ctx hs =
     liftIO $ withWriteLock ctx $ handleException ctx $ ctxDoHandshakeWith ctx ctx hs
-
-handleException :: Context -> IO () -> IO ()
-handleException ctx f = catchException f $ \exception -> do
-    let tlserror = fromMaybe (Error_Misc $ show exception) $ fromException exception
-    setEstablished ctx NotEstablished
-    handle ignoreIOErr $ do
-        tls13 <- tls13orLater ctx
-        if tls13 then
-            sendPacket13 ctx $ Alert13 $ errorToAlert tlserror
-          else
-            sendPacket ctx $ Alert $ errorToAlert tlserror
-    handshakeFailed tlserror
-  where
-    ignoreIOErr :: IOException -> IO ()
-    ignoreIOErr _ = return ()

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -10,6 +10,7 @@
 module Network.TLS.Handshake.Client
     ( handshakeClient
     , handshakeClientWith
+    , postHandshakeAuthClientWith
     ) where
 
 import Network.TLS.Crypto
@@ -994,3 +995,7 @@ setALPN ctx exts = case extensionLookup extensionID_ApplicationLayerProtocolNego
                 setNegotiatedProtocol proto
             _ -> return ()
     _ -> return ()
+
+postHandshakeAuthClientWith :: MonadIO m => ClientParams -> Context -> Handshake13 -> m ()
+postHandshakeAuthClientWith _ _ _ =
+    throwCore $ Error_Protocol ("postHandshakeAuthClientWith not implemented", True, HandshakeFailure)

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -685,7 +685,9 @@ doHandshake13 :: ServerParams -> Context -> Credentials -> Version
               -> Session -> Bool
               -> IO ()
 doHandshake13 sparams ctx allCreds chosenVersion usedCipher exts usedHash clientKeyShare clientSession rtt0 = do
-    newSession ctx >>= \ss -> usingState_ ctx (setSession ss False)
+    newSession ctx >>= \ss -> usingState_ ctx $ do
+        setSession ss False
+        setClientSupportsPHA supportsPHA
     usingHState ctx $ setNegotiatedGroup $ keyShareEntryGroup clientKeyShare
     srand <- setServerParameter
     (psk, binderInfo, is0RTTvalid) <- choosePSK
@@ -785,6 +787,10 @@ doHandshake13 sparams ctx allCreds chosenVersion usedCipher exts usedHash client
         usingState_ ctx $ setVersion chosenVersion
         usingHState ctx $ setHelloParameters13 usedCipher
         return srand
+
+    supportsPHA = case extensionLookup extensionID_PostHandshakeAuth exts >>= extensionDecode MsgTClientHello of
+        Just PostHandshakeAuth -> True
+        Nothing                -> False
 
     choosePSK = case extensionLookup extensionID_PreSharedKey exts >>= extensionDecode MsgTClientHello of
       Just (PreSharedKeyClientHello (PskIdentity sessionId obfAge:_) bnds@(bnd:_)) -> do
@@ -1086,5 +1092,37 @@ clientCertVerify sparams ctx certs verif = do
                 else decryptError "verification failed"
 
 postHandshakeAuthServerWith :: ServerParams -> Context -> Handshake13 -> IO ()
+postHandshakeAuthServerWith sparams ctx h@(Certificate13 certCtx certs _ext) = do
+    mCertReq <- getCertRequest13 ctx certCtx
+    when (isNothing mCertReq) $ throwCore $ Error_Protocol ("unknown certificate request context", True, DecodeError)
+    let certReq = fromJust "certReq" mCertReq
+
+    -- fixme checking _ext
+    clientCertificate sparams ctx certs
+
+    baseHState <- saveHState ctx
+    processHandshake13 ctx certReq
+    processHandshake13 ctx h
+
+    (usedHash, _, applicationTrafficSecretN) <- getRxState ctx
+
+    let expectFinished (Finished13 verifyData') = do
+            hChBeforeCf <- transcriptHash ctx
+            let verifyData = makeVerifyData usedHash applicationTrafficSecretN hChBeforeCf
+            unless (verifyData == verifyData') $
+                decryptError "cannot verify finished"
+        expectFinished hs = unexpected (show hs) (Just "finished 13")
+
+        postAction = void $ restoreHState ctx baseHState
+
+    -- Note: here the server could send updated NST too, however the library
+    -- currently has no API to handle resumption and client authentication
+    -- together, see discussion in #133
+    if isNullCertificateChain certs
+        then setPendingActions ctx [ (expectFinished, postAction) ]
+        else setPendingActions ctx [ (expectCertVerify sparams ctx, mempty)
+                                   , (expectFinished, postAction)
+                                   ]
+
 postHandshakeAuthServerWith _ _ _ =
-    throwCore $ Error_Protocol ("postHandshakeAuthServerWith not implemented", True, HandshakeFailure)
+    throwCore $ Error_Protocol ("unexpected handshake message received in postHandshakeAuthServerWith", True, UnexpectedMessage)

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -9,6 +9,7 @@
 module Network.TLS.Handshake.Server
     ( handshakeServer
     , handshakeServerWith
+    , postHandshakeAuthServerWith
     ) where
 
 import Network.TLS.Parameters
@@ -1083,3 +1084,7 @@ clientCertVerify sparams ctx certs verif = do
                 -- chain to the context.
                 usingState_ ctx $ setClientCertificateChain certs
                 else decryptError "verification failed"
+
+postHandshakeAuthServerWith :: ServerParams -> Context -> Handshake13 -> IO ()
+postHandshakeAuthServerWith _ _ _ =
+    throwCore $ Error_Protocol ("postHandshakeAuthServerWith not implemented", True, HandshakeFailure)

--- a/core/Network/TLS/Handshake/State.hs
+++ b/core/Network/TLS/Handshake/State.hs
@@ -119,7 +119,8 @@ data HandshakeState = HandshakeState
     , hstClientCertSent      :: !Bool
         -- ^ Set to true when a client certificate chain was sent
     , hstCertReqSent         :: !Bool
-        -- ^ Set to true when a certificate request was sent
+        -- ^ Set to true when a certificate request was sent.  This applies
+        -- only to requests sent during handshake (not post-handshake).
     , hstClientCertChain     :: !(Maybe CertificateChain)
     , hstPendingTxState      :: Maybe RecordState
     , hstPendingRxState      :: Maybe RecordState

--- a/core/Network/TLS/PostHandshake.hs
+++ b/core/Network/TLS/PostHandshake.hs
@@ -6,19 +6,52 @@
 -- Portability : unknown
 --
 module Network.TLS.PostHandshake
-    ( postHandshakeAuthWith
+    ( requestCertificate
+    , postHandshakeAuthWith
     , postHandshakeAuthClientWith
     , postHandshakeAuthServerWith
     ) where
 
 import Network.TLS.Context.Internal
+import Network.TLS.Extension
+import Network.TLS.IO
+import Network.TLS.Parameters
+import Network.TLS.State
+import Network.TLS.Struct
 import Network.TLS.Struct13
+import Network.TLS.Types
 
 import Network.TLS.Handshake.Common
 import Network.TLS.Handshake.Client
 import Network.TLS.Handshake.Server
 
+import Control.Exception (bracket)
 import Control.Monad.State.Strict
+
+newCertReqContext :: Context -> IO CertReqContext
+newCertReqContext ctx = getStateRNG ctx 32
+
+-- | Post-handshake certificate request with TLS 1.3.  Returns 'True' if the
+-- request was possible, i.e. if TLS 1.3 is used and the remote client supports
+-- post-handshake authentication.
+requestCertificate :: MonadIO m => Context -> m Bool
+requestCertificate ctx = liftIO $ do
+    tls13 <- tls13orLater ctx
+    ok <- usingState_ ctx $ do
+        supportsPHA <- getClientSupportsPHA
+        cc <- isClientContext
+        return (cc == ServerRole && tls13 && supportsPHA)
+    when ok $ do
+        certReqCtx <- newCertReqContext ctx
+        let sigAlgs = extensionEncode $ SignatureAlgorithms $ supportedHashSignatures $ ctxSupported ctx
+            crexts = [ExtensionRaw extensionID_SignatureAlgorithms sigAlgs]
+            certReq = CertRequest13 certReqCtx crexts
+        withWriteLock ctx $ do
+            checkValid ctx
+            bracket (saveHState ctx) (restoreHState ctx) $ \_ -> do
+                addCertRequest13 ctx certReq
+                sendPacket13 ctx $ Handshake13 [certReq]
+    return ok
 
 -- Handle a post-handshake authentication flight with TLS 1.3.  This is called
 -- automatically by 'recvData', in a context where the read lock is already

--- a/core/Network/TLS/PostHandshake.hs
+++ b/core/Network/TLS/PostHandshake.hs
@@ -1,0 +1,28 @@
+-- |
+-- Module      : Network.TLS.PostHandshake
+-- License     : BSD-style
+-- Maintainer  : Vincent Hanquez <vincent@snarc.org>
+-- Stability   : experimental
+-- Portability : unknown
+--
+module Network.TLS.PostHandshake
+    ( postHandshakeAuthWith
+    , postHandshakeAuthClientWith
+    , postHandshakeAuthServerWith
+    ) where
+
+import Network.TLS.Context.Internal
+import Network.TLS.Struct13
+
+import Network.TLS.Handshake.Common
+import Network.TLS.Handshake.Client
+import Network.TLS.Handshake.Server
+
+import Control.Monad.State.Strict
+
+-- Handle a post-handshake authentication flight with TLS 1.3.  This is called
+-- automatically by 'recvData', in a context where the read lock is already
+-- taken.
+postHandshakeAuthWith :: MonadIO m => Context -> Handshake13 -> m ()
+postHandshakeAuthWith ctx hs =
+    liftIO $ withWriteLock ctx $ handleException ctx $ ctxDoPostHandshakeAuthWith ctx ctx hs

--- a/core/Network/TLS/State.hs
+++ b/core/Network/TLS/State.hs
@@ -56,6 +56,8 @@ module Network.TLS.State
     , getTLS13HRR
     , setTLS13Cookie
     , getTLS13Cookie
+    , setClientSupportsPHA
+    , getClientSupportsPHA
     -- * random
     , genRandom
     , withRNG
@@ -97,6 +99,7 @@ data TLSState = TLSState
     , stTLS13HRR            :: !Bool
     , stTLS13Cookie         :: Maybe Cookie
     , stExporterMasterSecret :: Maybe ByteString -- TLS 1.3
+    , stClientSupportsPHA   :: !Bool -- Post-Handshake Authentication (TLS 1.3)
     }
 
 newtype TLSSt a = TLSSt { runTLSSt :: ErrT TLSError (State TLSState) a }
@@ -136,6 +139,7 @@ newTLSState rng clientContext = TLSState
     , stTLS13HRR            = False
     , stTLS13Cookie         = Nothing
     , stExporterMasterSecret = Nothing
+    , stClientSupportsPHA   = False
     }
 
 updateVerifiedData :: Role -> ByteString -> TLSSt ()
@@ -287,3 +291,9 @@ setTLS13Cookie mcookie = modify (\st -> st { stTLS13Cookie = mcookie })
 
 getTLS13Cookie :: TLSSt (Maybe Cookie)
 getTLS13Cookie = gets stTLS13Cookie
+
+setClientSupportsPHA :: Bool -> TLSSt ()
+setClientSupportsPHA b = modify (\st -> st { stClientSupportsPHA = b })
+
+getClientSupportsPHA :: TLSSt Bool
+getClientSupportsPHA = gets stClientSupportsPHA

--- a/core/Network/TLS/Struct13.hs
+++ b/core/Network/TLS/Struct13.hs
@@ -33,7 +33,6 @@ data KeyUpdate = UpdateNotRequested
                deriving (Show,Eq)
 
 type TicketNonce = ByteString
-type CertReqContext = ByteString
 
 -- fixme: convert Word32 to proper data type
 data Handshake13 =

--- a/core/Network/TLS/Types.hs
+++ b/core/Network/TLS/Types.hs
@@ -9,6 +9,7 @@ module Network.TLS.Types
     ( Version(..)
     , SessionID
     , SessionData(..)
+    , CertReqContext
     , TLS13TicketInfo(..)
     , CipherID
     , CompressionID
@@ -47,6 +48,9 @@ data SessionData = SessionData
     , sessionALPN        :: Maybe ByteString
     , sessionMaxEarlyDataSize :: Int
     } deriving (Show,Eq)
+
+-- | Certificate request context for TLS 1.3.
+type CertReqContext = ByteString
 
 data TLS13TicketInfo = TLS13TicketInfo
     { lifetime :: Second      -- NewSessionTicket.ticket_lifetime in seconds

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -637,6 +637,48 @@ prop_handshake_client_auth = do
             | chain == fst cred = return CertificateUsageAccept
             | otherwise         = return (CertificateUsageReject CertificateRejectUnknownCA)
 
+prop_post_handshake_auth :: PropertyM IO ()
+prop_post_handshake_auth = do
+    (clientParam,serverParam) <- pick arbitraryPairParams13
+    cred <- pick (arbitraryClientCredential TLS13)
+    let clientParam' = clientParam { clientHooks = (clientHooks clientParam)
+                                       { onCertificateRequest = \_ -> return $ Just cred }
+                                   }
+        serverParam' = serverParam { serverHooks = (serverHooks serverParam)
+                                        { onClientCertificate = validateChain cred }
+                                   }
+    if isCredentialDSA cred
+        then runTLSInitFailureGen (clientParam',serverParam') hsServer hsClient
+        else runTLSPipe (clientParam',serverParam') tlsServer tlsClient
+  where validateChain cred chain
+            | chain == fst cred = return CertificateUsageAccept
+            | otherwise         = return (CertificateUsageReject CertificateRejectUnknownCA)
+        tlsServer ctx queue = do
+            hsServer ctx
+            d <- recvData ctx
+            writeChan queue [d]
+            bye ctx
+        tlsClient queue ctx = do
+            hsClient ctx
+            d <- readChan queue
+            sendData ctx (L.fromChunks [d])
+            byeBye ctx
+        hsServer ctx = do
+            handshake ctx
+            recvDataAssert ctx "request 1"
+            _ <- requestCertificate ctx  -- single request
+            sendData ctx "response 1"
+            recvDataAssert ctx "request 2"
+            _ <- requestCertificate ctx
+            _ <- requestCertificate ctx  -- two simultaneously
+            sendData ctx "response 2"
+        hsClient ctx = do
+            handshake ctx
+            sendData ctx "request 1"
+            recvDataAssert ctx "response 1"
+            sendData ctx "request 2"
+            recvDataAssert ctx "response 2"
+
 prop_handshake_clt_key_usage :: PropertyM IO ()
 prop_handshake_clt_key_usage = do
     (clientParam,serverParam) <- pick arbitraryPairParams
@@ -822,6 +864,7 @@ main = defaultMain $ testGroup "tls"
             , testProperty "TLS 1.3 RTT0" (monadicIO prop_handshake13_rtt0)
             , testProperty "TLS 1.3 RTT0 -> PSK" (monadicIO prop_handshake13_rtt0_fallback)
             , testProperty "TLS 1.3 RTT0 length" (monadicIO prop_handshake13_rtt0_length)
+            , testProperty "TLS 1.3 Post-handshake auth" (monadicIO prop_post_handshake_auth)
             ]
 
         -- test concurrent reads and writes

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -105,6 +105,7 @@ Library
                      Network.TLS.Packet
                      Network.TLS.Packet13
                      Network.TLS.Parameters
+                     Network.TLS.PostHandshake
                      Network.TLS.Record
                      Network.TLS.Record.Types
                      Network.TLS.Record.Types13

--- a/debug/src/Common.hs
+++ b/debug/src/Common.hs
@@ -15,7 +15,6 @@ module Common
     ) where
 
 import Data.Char (isDigit)
-import Data.Maybe (fromJust)
 import Numeric (showHex)
 import Network.Socket
 


### PR DESCRIPTION
Adds basic client/server support for PHA.

Primary goal is to have client support for scenarios where this is needed by the server. The extension is sent unconditionnally since it is not any different than a renegotiation handshake before TLS13, which is always possible. Existing configuration and hooks about client authentication will apply, so this should minimize impact of enabling TLS13.

Ability for a server to request authentication is also added, with design similar to key update. i.e. the API does _nothing_ before TLS13, and does not try to trigger a renegotiation instead.

Internally the existing client-certificate code is reused, with handshake state being reverted at specific locations. The reasons for reverts are:
- successive post-handshake authentications don't cumulate in the transcript
- in case of several authentication requests in parallel, the client decides which one to honour first and the server can't anticipate any transcript update
- the server may request authentication before receiving client Finished13, so CertRequest13 is appended to the correct transcript only when receiving the matching Certificate13

As consequence, state modifications are not preserved after completion of the authentication sequence, but this is similar to what `handshakeTerminate` does before TLS13.
