### PR TITLE
Handshake packet fragmentation

### DIFF
--- a/core/Network/TLS/Handshake/Common13.hs
+++ b/core/Network/TLS/Handshake/Common13.hs
@@ -302,7 +302,7 @@ getHandshake13 ctx = RecvHandshake13M $ do
     recvLoop = do
         epkt <- recvPacket13 ctx
         case epkt of
-            Right (Handshake13 [])     -> recvLoop
+            Right (Handshake13 [])     -> error "invalid recvPacket13 result"
             Right (Handshake13 (h:hs)) -> found h hs
             Right ChangeCipherSpec13   -> recvLoop
             Right x                    -> unexpected (show x) (Just "handshake 13")

--- a/core/Network/TLS/IO.hs
+++ b/core/Network/TLS/IO.hs
@@ -169,7 +169,7 @@ recvRecord13 :: Context
 recvRecord13 ctx = readExact ctx 5 >>= either (return . Left) (recvLengthE . decodeHeader)
   where recvLengthE = either (return . Left) recvLength
         recvLength header@(Header _ _ readlen)
-          | readlen > 16384 + 2048 = return $ Left maximumSizeExceeded
+          | readlen > 16384 + 256  = return $ Left maximumSizeExceeded
           | otherwise              =
               readExact ctx (fromIntegral readlen) >>=
                  either (return . Left) (getRecord header)


### PR DESCRIPTION
The project has most of what is necessary to handle fragmented packets except 2 things that are missing:
- the recvPacket functions may return an empty result instead of continuing receiving, which causes failures in the handshake state machine
- packets are not fragmented when sending