### PR TITLE
Send "certificate_authorities" extension

### DIFF
--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -75,7 +75,7 @@ import Network.TLS.Parameters
 import Network.TLS.Measurement
 import Network.TLS.Types (Role(..))
 import Network.TLS.Handshake (handshakeClient, handshakeClientWith, handshakeServer, handshakeServerWith)
-import Network.TLS.PostHandshake (postHandshakeAuthClientWith, postHandshakeAuthServerWith)
+import Network.TLS.PostHandshake (requestCertificateServer, postHandshakeAuthClientWith, postHandshakeAuthServerWith)
 import Network.TLS.X509
 import Network.TLS.RNG
 
@@ -94,6 +94,7 @@ class TLSParams a where
     getTLSRole         :: a -> Role
     doHandshake        :: a -> Context -> IO ()
     doHandshakeWith    :: a -> Context -> Handshake -> IO ()
+    doRequestCertificate :: a -> Context -> IO Bool
     doPostHandshakeAuthWith :: a -> Context -> Handshake13 -> IO ()
 
 instance TLSParams ClientParams where
@@ -104,6 +105,7 @@ instance TLSParams ClientParams where
     getTLSRole _ = ClientRole
     doHandshake = handshakeClient
     doHandshakeWith = handshakeClientWith
+    doRequestCertificate _ _ = return False
     doPostHandshakeAuthWith = postHandshakeAuthClientWith
 
 instance TLSParams ServerParams where
@@ -114,6 +116,7 @@ instance TLSParams ServerParams where
     getTLSRole _ = ServerRole
     doHandshake = handshakeServer
     doHandshakeWith = handshakeServerWith
+    doRequestCertificate = requestCertificateServer
     doPostHandshakeAuthWith = postHandshakeAuthServerWith
 
 -- | create a new context using the backend and parameters specified.
@@ -164,6 +167,7 @@ contextNew backend params = liftIO $ do
             , ctxHandshake    = hs
             , ctxDoHandshake  = doHandshake params
             , ctxDoHandshakeWith  = doHandshakeWith params
+            , ctxDoRequestCertificate = doRequestCertificate params
             , ctxDoPostHandshakeAuthWith = doPostHandshakeAuthWith params
             , ctxMeasurement  = stats
             , ctxEOF_         = eof

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -117,6 +117,7 @@ data Context = Context
     , ctxHandshake        :: MVar (Maybe HandshakeState) -- ^ optional handshake state
     , ctxDoHandshake      :: Context -> IO ()
     , ctxDoHandshakeWith  :: Context -> Handshake -> IO ()
+    , ctxDoRequestCertificate :: Context -> IO Bool
     , ctxDoPostHandshakeAuthWith :: Context -> Handshake13 -> IO ()
     , ctxHooks            :: IORef Hooks   -- ^ hooks for this context
     , ctxLockWrite        :: MVar ()       -- ^ lock to use for writing data (including updating the state)

--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -236,7 +236,7 @@ recvData13 ctx = do
                 Just (pa, postAction) -> do
                     -- Pending actions are executed with read+write locks, just
                     -- like regular handshake code.
-                    withWriteLock ctx $ do
+                    withWriteLock ctx $ handleException ctx $ do
                         pa h
                         processHandshake13 ctx h
                         postAction

--- a/core/Network/TLS/Credentials.hs
+++ b/core/Network/TLS/Credentials.hs
@@ -116,7 +116,7 @@ credentialCanDecrypt (chain, priv) =
                     | KeyUsage_keyEncipherment `elem` flags -> Just ()
                     | otherwise                             -> Nothing
         _                           -> Nothing
-    where cert   = signedObject $ getSigned signed
+    where cert   = getCertificate signed
           pub    = certPubKey cert
           signed = getCertificateChainLeaf chain
 
@@ -127,13 +127,13 @@ credentialCanSign (chain, priv) =
         Just (ExtKeyUsage flags)
             | KeyUsage_digitalSignature `elem` flags -> findKeyExchangeSignatureAlg (pub, priv)
             | otherwise                              -> Nothing
-    where cert   = signedObject $ getSigned signed
+    where cert   = getCertificate signed
           pub    = certPubKey cert
           signed = getCertificateChainLeaf chain
 
 credentialPublicPrivateKeys :: Credential -> (PubKey, PrivKey)
 credentialPublicPrivateKeys (chain, priv) = pub `seq` (pub, priv)
-    where cert   = signedObject $ getSigned signed
+    where cert   = getCertificate signed
           pub    = certPubKey cert
           signed = getCertificateChainLeaf chain
 
@@ -176,5 +176,5 @@ credentialMatchesHashSignatures hashSigs (chain, _) =
                               Just hs -> hs `elem` hashSigs
 
     isSelfSigned signed =
-        let cert = signedObject $ getSigned signed
+        let cert = getCertificate signed
          in certSubjectDN cert == certIssuerDN cert

--- a/core/Network/TLS/Handshake/Certificate.hs
+++ b/core/Network/TLS/Handshake/Certificate.hs
@@ -10,6 +10,7 @@ module Network.TLS.Handshake.Certificate
     , badCertificate
     , rejectOnException
     , verifyLeafKeyUsage
+    , extractCAname
     ) where
 
 import Network.TLS.Context.Internal
@@ -47,3 +48,6 @@ verifyLeafKeyUsage validFlags (CertificateChain (signed:_)) =
         case extensionGet (certExtensions cert) of
             Nothing                          -> True -- unrestricted cert
             Just (ExtKeyUsage flags)         -> any (`elem` validFlags) flags
+
+extractCAname :: SignedCertificate -> DistinguishedName
+extractCAname cert = certSubjectDN $ getCertificate cert

--- a/core/Network/TLS/Handshake/Certificate.hs
+++ b/core/Network/TLS/Handshake/Certificate.hs
@@ -18,7 +18,7 @@ import Network.TLS.Struct
 import Network.TLS.X509
 import Control.Monad.State.Strict
 import Control.Exception (SomeException)
-import Data.X509 (ExtKeyUsage(..), ExtKeyUsageFlag, extensionGet, getSigned, signedObject)
+import Data.X509 (ExtKeyUsage(..), ExtKeyUsageFlag, extensionGet)
 
 -- on certificate reject, throw an exception with the proper protocol alert error.
 certificateRejected :: MonadIO m => CertificateRejectReason -> m a
@@ -43,7 +43,7 @@ verifyLeafKeyUsage validFlags (CertificateChain (signed:_)) =
     unless verified $ badCertificate $
         "certificate is not allowed for any of " ++ show validFlags
   where
-    cert     = signedObject $ getSigned signed
+    cert     = getCertificate signed
     verified =
         case extensionGet (certExtensions cert) of
             Nothing                          -> True -- unrestricted cert

--- a/core/Network/TLS/Handshake/Certificate.hs
+++ b/core/Network/TLS/Handshake/Certificate.hs
@@ -28,6 +28,8 @@ certificateRejected CertificateRejectExpired =
     throwCore $ Error_Protocol ("certificate has expired", True, CertificateExpired)
 certificateRejected CertificateRejectUnknownCA =
     throwCore $ Error_Protocol ("certificate has unknown CA", True, UnknownCa)
+certificateRejected CertificateRejectAbsent =
+    throwCore $ Error_Protocol ("certificate is missing", True, CertificateRequired)
 certificateRejected (CertificateRejectOther s) =
     throwCore $ Error_Protocol ("certificate rejected: " ++ s, True, CertificateUnknown)
 

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -1016,9 +1016,9 @@ setALPN ctx exts = case extensionLookup extensionID_ApplicationLayerProtocolNego
             _ -> return ()
     _ -> return ()
 
-postHandshakeAuthClientWith :: MonadIO m => ClientParams -> Context -> Handshake13 -> m ()
+postHandshakeAuthClientWith :: ClientParams -> Context -> Handshake13 -> IO ()
 postHandshakeAuthClientWith cparams ctx h@(CertRequest13 certReqCtx exts) =
-    liftIO $ bracket (saveHState ctx) (restoreHState ctx) $ \_ -> do
+    bracket (saveHState ctx) (restoreHState ctx) $ \_ -> do
         processHandshake13 ctx h
         processCertRequest13 ctx certReqCtx exts
         (usedHash, _, applicationTrafficSecretN) <- getTxState ctx

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -666,6 +666,8 @@ onServerHello _ _ _ p = unexpected (show p) (Just "server hello")
 
 processCertificate :: ClientParams -> Context -> Handshake -> IO (RecvState IO)
 processCertificate cparams ctx (Certificates certs) = do
+    when (isNullCertificateChain certs) $
+        throwCore $ Error_Protocol ("server certificate missing", True, DecodeError)
     -- run certificate recv hook
     ctxWithHooks ctx (`hookRecvCertificates` certs)
     -- then run certificate validation
@@ -895,11 +897,9 @@ handshakeClient13' cparams ctx usedCipher usedHash = do
             -- setCertReqSigAlgsCert Nothing
         expectCertAndVerify other
 
-    expectCertAndVerify (Certificate13 _ cc@(CertificateChain certChain) _) = do
+    expectCertAndVerify (Certificate13 _ cc _) = do
         _ <- liftIO $ processCertificate cparams ctx (Certificates cc)
-        pubkey <- case certChain of
-                    [] -> throwCore $ Error_Protocol ("server certificate missing", True, HandshakeFailure)
-                    c:_ -> return $ certPubKey $ getCertificate c
+        let pubkey = certPubKey $ getCertificate $ getCertificateChainLeaf cc
         usingHState ctx $ setPublicKey pubkey
         hChSc <- transcriptHash ctx
         recvHandshake13preUpdate ctx $ expectCertVerify pubkey hChSc

--- a/core/Network/TLS/Handshake/Common13.hs
+++ b/core/Network/TLS/Handshake/Common13.hs
@@ -17,6 +17,7 @@ module Network.TLS.Handshake.Common13
        , checkCertVerify
        , makePSKBinder
        , replacePSKBinder
+       , makeCertRequest
        , createTLS13TicketInfo
        , ageToObfuscatedAge
        , isAgeValid
@@ -51,6 +52,7 @@ import Network.TLS.Handshake.Signature
 import Network.TLS.Imports
 import Network.TLS.KeySchedule
 import Network.TLS.MAC
+import Network.TLS.Parameters
 import Network.TLS.IO
 import Network.TLS.State
 import Network.TLS.Struct
@@ -169,6 +171,14 @@ replacePSKBinder pskz binder = identities `B.append` binders
     bindersSize = B.length binder + 3
     identities  = B.take (B.length pskz - bindersSize) pskz
     binders     = runPut $ putOpaque16 $ runPut $ putOpaque8 binder
+
+----------------------------------------------------------------
+
+makeCertRequest :: Context -> CertReqContext -> Handshake13
+makeCertRequest ctx certReqCtx =
+    let sigAlgs = extensionEncode $ SignatureAlgorithms $ supportedHashSignatures $ ctxSupported ctx
+        crexts = [ExtensionRaw extensionID_SignatureAlgorithms sigAlgs]
+     in CertRequest13 certReqCtx crexts
 
 ----------------------------------------------------------------
 

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -51,7 +51,7 @@ import Network.TLS.Handshake.Common13
 --
 -- This is just a helper to pop the next message from the recv layer,
 -- and call handshakeServerWith.
-handshakeServer :: MonadIO m => ServerParams -> Context -> m ()
+handshakeServer :: ServerParams -> Context -> IO ()
 handshakeServer sparams ctx = liftIO $ do
     hss <- recvPacketHandshake ctx
     case hss of

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -874,9 +874,8 @@ doHandshake13 sparams ctx allCreds chosenVersion usedCipher exts usedHash client
         storePrivInfoServer ctx cred
         when (serverWantClientCert sparams) $ do
             let certReqCtx = "" -- this must be zero length here.
-            let sigAlgs = extensionEncode $ SignatureAlgorithms $ supportedHashSignatures $ ctxSupported ctx
-                crexts = [ExtensionRaw extensionID_SignatureAlgorithms sigAlgs]
-            loadPacket13 ctx $ Handshake13 [CertRequest13 certReqCtx crexts]
+                certReq = makeCertRequest ctx certReqCtx
+            loadPacket13 ctx $ Handshake13 [certReq]
             usingHState ctx $ setCertReqSent True
 
         let CertificateChain cs = certChain
@@ -1106,9 +1105,7 @@ requestCertificateServer _ ctx = do
     let ok = tls13 && supportsPHA
     when ok $ do
         certReqCtx <- newCertReqContext ctx
-        let sigAlgs = extensionEncode $ SignatureAlgorithms $ supportedHashSignatures $ ctxSupported ctx
-            crexts = [ExtensionRaw extensionID_SignatureAlgorithms sigAlgs]
-            certReq = CertRequest13 certReqCtx crexts
+        let certReq = makeCertRequest ctx certReqCtx
         bracket (saveHState ctx) (restoreHState ctx) $ \_ -> do
             addCertRequest13 ctx certReq
             sendPacket13 ctx $ Handshake13 [certReq]

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -9,6 +9,7 @@
 module Network.TLS.Handshake.Server
     ( handshakeServer
     , handshakeServerWith
+    , requestCertificateServer
     , postHandshakeAuthServerWith
     ) where
 
@@ -36,6 +37,7 @@ import qualified Data.ByteString as B
 import Data.X509 (ExtKeyUsageFlag(..))
 
 import Control.Monad.State.Strict
+import Control.Exception (bracket)
 
 import Network.TLS.Handshake.Signature
 import Network.TLS.Handshake.Common
@@ -1093,6 +1095,24 @@ clientCertVerify sparams ctx certs verif = do
                 -- chain to the context.
                 usingState_ ctx $ setClientCertificateChain certs
                 else decryptError "verification failed"
+
+newCertReqContext :: Context -> IO CertReqContext
+newCertReqContext ctx = getStateRNG ctx 32
+
+requestCertificateServer :: ServerParams -> Context -> IO Bool
+requestCertificateServer _ ctx = do
+    tls13 <- tls13orLater ctx
+    supportsPHA <- usingState_ ctx getClientSupportsPHA
+    let ok = tls13 && supportsPHA
+    when ok $ do
+        certReqCtx <- newCertReqContext ctx
+        let sigAlgs = extensionEncode $ SignatureAlgorithms $ supportedHashSignatures $ ctxSupported ctx
+            crexts = [ExtensionRaw extensionID_SignatureAlgorithms sigAlgs]
+            certReq = CertRequest13 certReqCtx crexts
+        bracket (saveHState ctx) (restoreHState ctx) $ \_ -> do
+            addCertRequest13 ctx certReq
+            sendPacket13 ctx $ Handshake13 [certReq]
+    return ok
 
 postHandshakeAuthServerWith :: ServerParams -> Context -> Handshake13 -> IO ()
 postHandshakeAuthServerWith sparams ctx h@(Certificate13 certCtx certs _ext) = do

--- a/core/Network/TLS/PostHandshake.hs
+++ b/core/Network/TLS/PostHandshake.hs
@@ -7,51 +7,29 @@
 --
 module Network.TLS.PostHandshake
     ( requestCertificate
+    , requestCertificateServer
     , postHandshakeAuthWith
     , postHandshakeAuthClientWith
     , postHandshakeAuthServerWith
     ) where
 
 import Network.TLS.Context.Internal
-import Network.TLS.Extension
 import Network.TLS.IO
-import Network.TLS.Parameters
-import Network.TLS.State
-import Network.TLS.Struct
 import Network.TLS.Struct13
-import Network.TLS.Types
 
 import Network.TLS.Handshake.Common
 import Network.TLS.Handshake.Client
 import Network.TLS.Handshake.Server
 
-import Control.Exception (bracket)
 import Control.Monad.State.Strict
-
-newCertReqContext :: Context -> IO CertReqContext
-newCertReqContext ctx = getStateRNG ctx 32
 
 -- | Post-handshake certificate request with TLS 1.3.  Returns 'True' if the
 -- request was possible, i.e. if TLS 1.3 is used and the remote client supports
 -- post-handshake authentication.
 requestCertificate :: MonadIO m => Context -> m Bool
-requestCertificate ctx = liftIO $ do
-    tls13 <- tls13orLater ctx
-    ok <- usingState_ ctx $ do
-        supportsPHA <- getClientSupportsPHA
-        cc <- isClientContext
-        return (cc == ServerRole && tls13 && supportsPHA)
-    when ok $ do
-        certReqCtx <- newCertReqContext ctx
-        let sigAlgs = extensionEncode $ SignatureAlgorithms $ supportedHashSignatures $ ctxSupported ctx
-            crexts = [ExtensionRaw extensionID_SignatureAlgorithms sigAlgs]
-            certReq = CertRequest13 certReqCtx crexts
-        withWriteLock ctx $ do
-            checkValid ctx
-            bracket (saveHState ctx) (restoreHState ctx) $ \_ -> do
-                addCertRequest13 ctx certReq
-                sendPacket13 ctx $ Handshake13 [certReq]
-    return ok
+requestCertificate ctx =
+    liftIO $ withWriteLock ctx $
+        checkValid ctx >> ctxDoRequestCertificate ctx ctx
 
 -- Handle a post-handshake authentication flight with TLS 1.3.  This is called
 -- automatically by 'recvData', in a context where the read lock is already

--- a/core/Network/TLS/X509.hs
+++ b/core/Network/TLS/X509.hs
@@ -41,6 +41,7 @@ data CertificateRejectReason =
           CertificateRejectExpired
         | CertificateRejectRevoked
         | CertificateRejectUnknownCA
+        | CertificateRejectAbsent
         | CertificateRejectOther String
         deriving (Show,Eq)
 
@@ -56,4 +57,5 @@ wrapCertificateChecks l
     | Expired `elem` l   = CertificateUsageReject   CertificateRejectExpired
     | InFuture `elem` l  = CertificateUsageReject   CertificateRejectExpired
     | UnknownCA `elem` l = CertificateUsageReject   CertificateRejectUnknownCA
+    | EmptyChain `elem` l = CertificateUsageReject  CertificateRejectAbsent
     | otherwise          = CertificateUsageReject $ CertificateRejectOther (show l)

--- a/core/Network/TLS/X509.hs
+++ b/core/Network/TLS/X509.hs
@@ -57,5 +57,6 @@ wrapCertificateChecks l
     | Expired `elem` l   = CertificateUsageReject   CertificateRejectExpired
     | InFuture `elem` l  = CertificateUsageReject   CertificateRejectExpired
     | UnknownCA `elem` l = CertificateUsageReject   CertificateRejectUnknownCA
+    | SelfSigned `elem` l = CertificateUsageReject  CertificateRejectUnknownCA
     | EmptyChain `elem` l = CertificateUsageReject  CertificateRejectAbsent
     | otherwise          = CertificateUsageReject $ CertificateRejectOther (show l)

--- a/core/Tests/Connection.hs
+++ b/core/Tests/Connection.hs
@@ -148,7 +148,7 @@ isCustomDHParams params = params == dhParams512
 
 leafPublicKey :: CertificateChain -> Maybe PubKey
 leafPublicKey (CertificateChain [])       = Nothing
-leafPublicKey (CertificateChain (leaf:_)) = Just (certPubKey $ signedObject $ getSigned leaf)
+leafPublicKey (CertificateChain (leaf:_)) = Just (certPubKey $ getCertificate leaf)
 
 isLeafRSA :: Maybe CertificateChain -> Bool
 isLeafRSA chain = case chain >>= leafPublicKey of


### PR DESCRIPTION
Main point here is to add "certificate_authorities" extension currently missing in TLS13 certificate requests so that we keep same capabilities than with lower versions. Unfortunetly I did not see earlier that the extension was missing so I had to change to a bit more complex design to send post-handshake requests.

The PR also allows to send CertificateRequired alerts to the client and adds a few checks.