### PR TITLE
Send "supported_groups" in encrypted extensions

### DIFF
--- a/core/Network/TLS.hs
+++ b/core/Network/TLS.hs
@@ -56,6 +56,7 @@ module Network.TLS
     , Handshake
     , Logging(..)
     , contextHookSetHandshakeRecv
+    , contextHookSetHandshake13Recv
     , contextHookSetCertificateRecv
     , contextHookSetLogging
     , contextModifyHooks

--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -49,6 +49,7 @@ module Network.TLS.Context
 
     -- * Context hooks
     , contextHookSetHandshakeRecv
+    , contextHookSetHandshake13Recv
     , contextHookSetCertificateRecv
     , contextHookSetLogging
 
@@ -200,6 +201,10 @@ contextNewOnSocket sock params = contextNew sock params
 contextHookSetHandshakeRecv :: Context -> (Handshake -> IO Handshake) -> IO ()
 contextHookSetHandshakeRecv context f =
     contextModifyHooks context (\hooks -> hooks { hookRecvHandshake = f })
+
+contextHookSetHandshake13Recv :: Context -> (Handshake13 -> IO Handshake13) -> IO ()
+contextHookSetHandshake13Recv context f =
+    contextModifyHooks context (\hooks -> hooks { hookRecvHandshake13 = f })
 
 contextHookSetCertificateRecv :: Context -> (CertificateChain -> IO ()) -> IO ()
 contextHookSetCertificateRecv context f =

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -99,7 +99,7 @@ handshakeClient' cparams ctx groups mcrand = do
                   Just _  -> error "handshakeClient': invalid KeyShare value"
                   Nothing -> throwCore $ Error_Protocol ("key exchange not implemented in HRR, expected key_share extension", True, HandshakeFailure)
           else do
-            handshakeClient13 cparams ctx
+            handshakeClient13 cparams ctx groupToSend
       else do
         sessionResuming <- usingState_ ctx isSessionResuming
         if sessionResuming
@@ -112,6 +112,7 @@ handshakeClient' cparams ctx groups mcrand = do
         compressions = supportedCompressions $ ctxSupported ctx
         highestVer = maximum $ supportedVersions $ ctxSupported ctx
         tls13 = highestVer >= TLS13
+        groupToSend = listToMaybe groups
         getExtensions pskInfo rtt0 = sequence
             [ sniExtension
             , secureReneg
@@ -166,9 +167,9 @@ handshakeClient' cparams ctx groups mcrand = do
 
         -- FIXME
         keyshareExtension
-          | tls13 = case groups of
-                  []    -> return Nothing
-                  grp:_ -> do
+          | tls13 = case groupToSend of
+                  Nothing  -> return Nothing
+                  Just grp -> do
                       (cpri, ent) <- makeClientKeyShare ctx grp
                       usingHState ctx $ setGroupPrivate cpri
                       return $ Just $ toExtensionRaw $ KeyShareClientHello [ent]
@@ -792,14 +793,14 @@ requiredCertKeyUsage cipher =
                            , KeyUsage_keyAgreement
                            ]
 
-handshakeClient13 :: ClientParams -> Context -> IO ()
-handshakeClient13 _cparams ctx = do
+handshakeClient13 :: ClientParams -> Context -> Maybe Group -> IO ()
+handshakeClient13 cparams ctx groupSent = do
     usedCipher <- usingHState ctx getPendingCipher
     let usedHash = cipherHash usedCipher
-    handshakeClient13' _cparams ctx usedCipher usedHash
+    handshakeClient13' cparams ctx groupSent usedCipher usedHash
 
-handshakeClient13' :: ClientParams -> Context -> Cipher -> Hash -> IO ()
-handshakeClient13' cparams ctx usedCipher usedHash = do
+handshakeClient13' :: ClientParams -> Context -> Maybe Group -> Cipher -> Hash -> IO ()
+handshakeClient13' cparams ctx groupSent usedCipher usedHash = do
     (resuming, handshakeSecret, clientHandshakeTrafficSecret, serverHandshakeTrafficSecret) <- switchToHandshakeSecret
     rtt0accepted <- runRecvHandshake13 $ do
         accepted <- recvHandshake13preUpdate ctx expectEncryptedExtensions
@@ -849,7 +850,8 @@ handshakeClient13' cparams ctx usedCipher usedHash = do
               Just _                        -> error "calcSharedKey: invalid KeyShare value"
               Nothing                       -> throwCore $ Error_Protocol ("key exchange not implemented, expected key_share extension", True, HandshakeFailure)
         let grp = keyShareEntryGroup serverKeyShare
-        checkSupportedGroup ctx grp
+        unless (groupSent == Just grp) $
+            throwCore $ Error_Protocol ("received incompatible group for (EC)DHE", True, IllegalParameter)
         usingHState ctx $ setNegotiatedGroup grp
         usingHState ctx getGroupPrivate >>= fromServerKeyShare serverKeyShare
 

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -886,7 +886,7 @@ doHandshake13 sparams ctx allCreds chosenVersion usedCipher exts usedHash client
         loadPacket13 ctx $ Handshake13 [vrfy]
 
     sendExtensions rtt0OK = do
-        extensions' <- liftIO $ applicationProtocol ctx exts sparams
+        protoExt <- liftIO $ applicationProtocol ctx exts sparams
         msni <- liftIO $ usingState_ ctx getClientSNI
         let sniExtension = case msni of
               -- RFC6066: In this event, the server SHALL include
@@ -895,7 +895,7 @@ doHandshake13 sparams ctx allCreds chosenVersion usedCipher exts usedHash client
               -- field of this extension SHALL be empty.
               Just _  -> Just $ ExtensionRaw extensionID_ServerName ""
               Nothing -> Nothing
-        mgroup <- usingHState ctx getNegotiatedGroup 
+        mgroup <- usingHState ctx getNegotiatedGroup
         let serverGroups = supportedGroups (ctxSupported ctx)
             groupExtension
               | null serverGroups = Nothing
@@ -904,7 +904,7 @@ doHandshake13 sparams ctx allCreds chosenVersion usedCipher exts usedHash client
         let earlyDataExtension
               | rtt0OK = Just $ ExtensionRaw extensionID_EarlyData $ extensionEncode (EarlyDataIndication Nothing)
               | otherwise = Nothing
-        let extensions = catMaybes [earlyDataExtension, groupExtension, sniExtension] ++ extensions'
+        let extensions = catMaybes [earlyDataExtension, groupExtension, sniExtension] ++ protoExt
         loadPacket13 ctx $ Handshake13 [EncryptedExtensions13 extensions]
 
     sendNewSessionTicket masterSecret sfSentTime = when sendNST $ do

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -888,16 +888,17 @@ doHandshake13 sparams ctx allCreds chosenVersion usedCipher exts usedHash client
     sendExtensions rtt0OK = do
         extensions' <- liftIO $ applicationProtocol ctx exts sparams
         msni <- liftIO $ usingState_ ctx getClientSNI
-        let extensions'' = case msni of
+        let sniExtension = case msni of
               -- RFC6066: In this event, the server SHALL include
               -- an extension of type "server_name" in the
               -- (extended) server hello. The "extension_data"
               -- field of this extension SHALL be empty.
-              Just _  -> ExtensionRaw extensionID_ServerName "" : extensions'
-              Nothing -> extensions'
-        let extensions
-              | rtt0OK = ExtensionRaw extensionID_EarlyData (extensionEncode (EarlyDataIndication Nothing)) : extensions''
-              | otherwise = extensions''
+              Just _  -> Just $ ExtensionRaw extensionID_ServerName ""
+              Nothing -> Nothing
+        let earlyDataExtension
+              | rtt0OK = Just $ ExtensionRaw extensionID_EarlyData $ extensionEncode (EarlyDataIndication Nothing)
+              | otherwise = Nothing
+        let extensions = catMaybes [earlyDataExtension, sniExtension] ++ extensions'
         loadPacket13 ctx $ Handshake13 [EncryptedExtensions13 extensions]
 
     sendNewSessionTicket masterSecret sfSentTime = when sendNST $ do

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -895,10 +895,16 @@ doHandshake13 sparams ctx allCreds chosenVersion usedCipher exts usedHash client
               -- field of this extension SHALL be empty.
               Just _  -> Just $ ExtensionRaw extensionID_ServerName ""
               Nothing -> Nothing
+        mgroup <- usingHState ctx getNegotiatedGroup 
+        let serverGroups = supportedGroups (ctxSupported ctx)
+            groupExtension
+              | null serverGroups = Nothing
+              | maybe True (== head serverGroups) mgroup = Nothing
+              | otherwise = Just $ ExtensionRaw extensionID_NegotiatedGroups $ extensionEncode (NegotiatedGroups serverGroups)
         let earlyDataExtension
               | rtt0OK = Just $ ExtensionRaw extensionID_EarlyData $ extensionEncode (EarlyDataIndication Nothing)
               | otherwise = Nothing
-        let extensions = catMaybes [earlyDataExtension, sniExtension] ++ extensions'
+        let extensions = catMaybes [earlyDataExtension, groupExtension, sniExtension] ++ extensions'
         loadPacket13 ctx $ Handshake13 [EncryptedExtensions13 extensions]
 
     sendNewSessionTicket masterSecret sfSentTime = when sendNST $ do

--- a/core/Network/TLS/Hooks.hs
+++ b/core/Network/TLS/Hooks.hs
@@ -12,7 +12,8 @@ module Network.TLS.Hooks
     ) where
 
 import qualified Data.ByteString as B
-import Network.TLS.Struct (Header, Handshake(..))
+import Network.TLS.Struct (Header, Handshake)
+import Network.TLS.Struct13 (Handshake13)
 import Network.TLS.X509 (CertificateChain)
 import Data.Default.Class
 
@@ -41,6 +42,8 @@ instance Default Logging where
 data Hooks = Hooks
     { -- | called at each handshake message received
       hookRecvHandshake    :: Handshake -> IO Handshake
+      -- | called at each handshake message received for TLS 1.3
+    , hookRecvHandshake13  :: Handshake13 -> IO Handshake13
       -- | called at each certificate chain message received
     , hookRecvCertificates :: CertificateChain -> IO ()
       -- | hooks on IO and packets, receiving and sending.
@@ -50,6 +53,7 @@ data Hooks = Hooks
 defaultHooks :: Hooks
 defaultHooks = Hooks
     { hookRecvHandshake    = return
+    , hookRecvHandshake13  = return
     , hookRecvCertificates = return . const ()
     , hookLogging          = def
     }

--- a/core/Network/TLS/Internal.hs
+++ b/core/Network/TLS/Internal.hs
@@ -8,7 +8,9 @@
 --
 module Network.TLS.Internal
     ( module Network.TLS.Struct
+    , module Network.TLS.Struct13
     , module Network.TLS.Packet
+    , module Network.TLS.Packet13
     , module Network.TLS.Receiving
     , module Network.TLS.Sending
     , module Network.TLS.Wire
@@ -17,7 +19,9 @@ module Network.TLS.Internal
     ) where
 
 import Network.TLS.Struct
+import Network.TLS.Struct13
 import Network.TLS.Packet
+import Network.TLS.Packet13
 import Network.TLS.Receiving
 import Network.TLS.Sending
 import Network.TLS.Wire

--- a/core/Tests/Certificate.hs
+++ b/core/Tests/Certificate.hs
@@ -5,6 +5,7 @@ module Certificate
     ( arbitraryX509
     , arbitraryX509WithKey
     , arbitraryX509WithKeyAndUsage
+    , arbitraryDN
     , arbitraryKeyUsage
     , simpleCertificate
     , simpleX509

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -872,6 +872,7 @@ main = defaultMain $ testGroup "tls"
         tests_marshalling = testGroup "Marshalling"
             [ testProperty "Header" prop_header_marshalling_id
             , testProperty "Handshake" prop_handshake_marshalling_id
+            , testProperty "Handshake13" prop_handshake13_marshalling_id
             ]
         tests_ciphers = testGroup "Ciphers"
             [ testProperty "Bulk" propertyBulkFunctional ]


### PR DESCRIPTION
When the group selected is not the one prefered by the server it is possible to send this extension.

On client side, we can also control not only that the group received is supported by the client, but that this is the same group for which the key share was sent.