### PR TITLE
Verification of PSK modes

### DIFF
--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -864,6 +864,8 @@ handshakeClient13' cparams ctx usedCipher usedHash = do
                 Nothing                          ->
                     return (hkdfExtract usedHash zero zero, False)
                 Just (PreSharedKeyServerHello 0) -> do
+                    unless (B.length sec == hashSize) $
+                        throwCore $ Error_Protocol ("selected cipher is incompatible with selected PSK", True, IllegalParameter)
                     usingHState ctx $ setTLS13HandshakeMode PreSharedKey
                     return (sec, True)
                 Just _                           -> throwCore $ Error_Protocol ("selected identity out of range", True, IllegalParameter)

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -914,7 +914,7 @@ doHandshake13 sparams ctx allCreds chosenVersion usedCipher exts usedHash client
         let nst = createNewSessionTicket life add nonce label rtt0max
         sendPacket13 ctx $ Handshake13 [nst]
       where
-        sendNST = (PSK_KE `elem` dhModes) || (PSK_DHE_KE `elem` dhModes)
+        sendNST = PSK_DHE_KE `elem` dhModes
         generateSession life psk maxSize rtt = do
             Session (Just sessionId) <- newSession ctx
             tinfo <- createTLS13TicketInfo life (Left ctx) (Just rtt)


### PR DESCRIPTION
Makes client extension "psk_key_exchange_modes" mandatory for PSK handshake, and verifies adequacy of server-selected cipher.

Sending NST when PSK_DHE_KE is not supported is not useful, the implementation is not able to resume with PSK_KE.