### PR TITLE
Fix SSLv2 deprecated header

### DIFF
--- a/core/Network/TLS/IO.hs
+++ b/core/Network/TLS/IO.hs
@@ -109,7 +109,8 @@ recvRecord compatSSLv2 appDataOverhead ctx
                     case res of
                       Left e -> return $ Left e
                       Right content ->
-                        either (return . Left) (\h -> getRecord ctx appDataOverhead h content) $ decodeDeprecatedHeader readlen content
+                        let hdr = decodeDeprecatedHeader readlen (B.take 3 content)
+                         in either (return . Left) (\h -> getRecord ctx appDataOverhead h content) hdr
 #endif
 
 isCCS :: Record a -> Bool


### PR DESCRIPTION
Parsing the packet header was always failing because function
decodeDeprecatedHeader needs input no more than 3 bytes (or else
runGetErr returns a "remaining bytes" error).  Limiting input to 3
bytes restores the correct behavior.