### PR TITLE
Make sendPacket non-recursive

### DIFF
--- a/core/Network/TLS/IO.hs
+++ b/core/Network/TLS/IO.hs
@@ -162,17 +162,21 @@ sendPacket ctx pkt = do
     -- in ver <= TLS1.0, block ciphers using CBC are using CBC residue as IV, which can be guessed
     -- by an attacker. Hence, an empty packet is sent before a normal data packet, to
     -- prevent guessability.
-    withEmptyPacket <- liftIO $ readIORef $ ctxNeedEmptyPacket ctx
-    when (isNonNullAppData pkt && withEmptyPacket) $ sendPacket ctx $ AppData B.empty
+    when (isNonNullAppData pkt) $ do
+        withEmptyPacket <- liftIO $ readIORef $ ctxNeedEmptyPacket ctx
+        when withEmptyPacket $
+            writePacketBytes ctx (AppData B.empty) >>= sendBytes ctx
 
+    writePacketBytes ctx pkt >>= sendBytes ctx
+  where isNonNullAppData (AppData b) = not $ B.null b
+        isNonNullAppData _           = False
+
+writePacketBytes :: MonadIO m => Context -> Packet -> m ByteString
+writePacketBytes ctx pkt = do
     edataToSend <- liftIO $ do
                         withLog ctx $ \logging -> loggingPacketSent logging (show pkt)
                         writePacket ctx pkt
-    case edataToSend of
-        Left err         -> throwCore err
-        Right dataToSend -> sendBytes ctx dataToSend
-  where isNonNullAppData (AppData b) = not $ B.null b
-        isNonNullAppData _           = False
+    either throwCore return edataToSend
 
 sendPacket13 :: MonadIO m => Context -> Packet13 -> m ()
 sendPacket13 ctx pkt = writePacketBytes13 ctx pkt >>= sendBytes ctx


### PR DESCRIPTION
`sendPacket13` is split into 2 separate steps with `writePacketBytes13` and `sendBytes`.

For `sendPacket` we can use the same structure for similarity. And this makes it easy to remove the recursion and inline the function into itself, keeping just what is relevant in the code flow.