### PR TITLE
Middlebox compatibility

### DIFF
--- a/core/Network/TLS/Handshake/Common13.hs
+++ b/core/Network/TLS/Handshake/Common13.hs
@@ -17,6 +17,7 @@ module Network.TLS.Handshake.Common13
        , checkCertVerify
        , makePSKBinder
        , replacePSKBinder
+       , sendChangeCipherSpec13
        , makeCertRequest
        , createTLS13TicketInfo
        , ageToObfuscatedAge
@@ -172,6 +173,16 @@ replacePSKBinder pskz binder = identities `B.append` binders
     bindersSize = B.length binder + 3
     identities  = B.take (B.length pskz - bindersSize) pskz
     binders     = runPut $ putOpaque16 $ runPut $ putOpaque8 binder
+
+----------------------------------------------------------------
+
+sendChangeCipherSpec13 :: Context -> PacketFlightM ()
+sendChangeCipherSpec13 ctx = do
+    sent <- usingHState ctx $ do
+                b <- getCCS13Sent
+                unless b $ setCCS13Sent True
+                return b
+    unless sent $ loadPacket13 ctx ChangeCipherSpec13
 
 ----------------------------------------------------------------
 

--- a/core/Network/TLS/Handshake/Random.hs
+++ b/core/Network/TLS/Handshake/Random.hs
@@ -59,11 +59,8 @@ suffix12 = B.pack [0x44, 0x4F, 0x57, 0x4E, 0x47, 0x52, 0x44, 0x01]
 suffix11 :: B.ByteString
 suffix11 = B.pack [0x44, 0x4F, 0x57, 0x4E, 0x47, 0x52, 0x44, 0x00]
 
--- ClientRandom in the second client hello for retry must be
--- the same as the first one.
-clientRandom :: Context -> Maybe ClientRandom -> IO ClientRandom
-clientRandom ctx Nothing   = ClientRandom <$> getStateRNG ctx 32
-clientRandom _   (Just cr) = return cr
+clientRandom :: Context -> IO ClientRandom
+clientRandom ctx = ClientRandom <$> getStateRNG ctx 32
 
 hrrRandom :: ServerRandom
 hrrRandom = ServerRandom $ B.pack [

--- a/core/Network/TLS/Handshake/State.hs
+++ b/core/Network/TLS/Handshake/State.hs
@@ -66,6 +66,8 @@ module Network.TLS.Handshake.State
     , getTLS13RTT0Status
     , setTLS13Secret
     , getTLS13Secret
+    , setCCS13Sent
+    , getCCS13Sent
     ) where
 
 import Network.TLS.Util
@@ -130,6 +132,7 @@ data HandshakeState = HandshakeState
     , hstTLS13HandshakeMode  :: HandshakeMode13
     , hstTLS13RTT0Status     :: !RTT0Status
     , hstTLS13Secret         :: Secret13
+    , hstCCS13Sent           :: !Bool
     } deriving (Show)
 
 {- | When we receive a CertificateRequest from a server, a just-in-time
@@ -218,6 +221,7 @@ newEmptyHandshake ver crand = HandshakeState
     , hstTLS13HandshakeMode  = FullHandshake
     , hstTLS13RTT0Status     = RTT0None
     , hstTLS13Secret         = NoSecret
+    , hstCCS13Sent           = False
     }
 
 runHandshake :: HandshakeState -> HandshakeM a -> (a, HandshakeState)
@@ -302,6 +306,12 @@ setTLS13Secret secret = modify (\hst -> hst { hstTLS13Secret = secret })
 
 getTLS13Secret :: HandshakeM Secret13
 getTLS13Secret = gets hstTLS13Secret
+
+setCCS13Sent :: Bool -> HandshakeM ()
+setCCS13Sent sent = modify (\hst -> hst { hstCCS13Sent = sent })
+
+getCCS13Sent :: HandshakeM Bool
+getCCS13Sent = gets hstCCS13Sent
 
 setCertReqSent :: Bool -> HandshakeM ()
 setCertReqSent b = modify (\hst -> hst { hstCertReqSent = b })


### PR DESCRIPTION
Currently the server code sends CCS13 at a fixed location, not very useful in case of HRR or early data. This PR adds remaining implementation of middlebox compatibility mode, hoping to maximize compatibility when transitioning to TLS 1.3.

I also include the client verification of legacy_session_id_echo.