### PR TITLE
Check record alignment when changing Rx key

### DIFF
--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -137,9 +137,9 @@ data Established = NotEstablished
                  deriving (Eq, Show)
 
 data PendingAction
-    = PendingAction (Handshake13 -> IO ())
+    = PendingAction Bool (Handshake13 -> IO ())
       -- ^ simple pending action
-    | PendingActionHash (ByteString -> Handshake13 -> IO ())
+    | PendingActionHash Bool (ByteString -> Handshake13 -> IO ())
       -- ^ pending action taking transcript hash up to preceding message
 
 updateMeasure :: Context -> (Measurement -> Measurement) -> IO ()

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -825,6 +825,7 @@ handshakeClient13' cparams ctx groupSent usedCipher usedHash = do
     zero = B.replicate hashSize 0
 
     switchToHandshakeSecret = do
+        ensureRecvComplete ctx
         ecdhe <- calcSharedKey
         (earlySecret, resuming) <- makeEarlySecret
         let handshakeSecret = hkdfExtract usedHash (deriveSecret usedHash earlySecret "derived" (hash usedHash "")) ecdhe
@@ -837,6 +838,7 @@ handshakeClient13' cparams ctx groupSent usedCipher usedHash = do
         return (resuming, handshakeSecret, clientHandshakeTrafficSecret, serverHandshakeTrafficSecret)
 
     switchToTrafficSecret handshakeSecret hChSf = do
+        ensureRecvComplete ctx
         let masterSecret = hkdfExtract usedHash (deriveSecret usedHash handshakeSecret "derived" (hash usedHash "")) zero
         let clientApplicationTrafficSecret0 = deriveSecret usedHash masterSecret "c ap traffic" hChSf
             serverApplicationTrafficSecret0 = deriveSecret usedHash masterSecret "s ap traffic" hChSf


### PR DESCRIPTION
Each time the Rx key is modified with `setRxState` we can verify that there is no message deprotected with the previous key still unconsumed. This includes verifying the tail of a received `[Handshake13]` packet as well as incomplete handshake fragments stored in the context.