### PR TITLE
TLS13 handshake clean-up similar to handshakeTerminate

### DIFF
--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -837,7 +837,7 @@ handshakeClient13' cparams ctx groupSent usedCipher usedHash = do
     sendClientFlight13 cparams ctx usedHash clientHandshakeTrafficSecret
     masterSecret <- switchToTrafficSecret handshakeSecret hChSf
     setResumptionSecret masterSecret
-    setEstablished ctx Established
+    handshakeTerminate13 ctx
   where
     hashSize = hashDigestSize usedHash
     zero = B.replicate hashSize 0

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -938,9 +938,8 @@ handshakeClient13' cparams ctx groupSent usedCipher usedHash = do
         unless ok $ decryptError "cannot verify CertificateVerify"
     expectCertVerify _ _ p = unexpected (show p) (Just "certificate verify")
 
-    expectFinished baseKey hashValue (Finished13 verifyData) = do
-        let verifyData' = makeVerifyData usedHash baseKey hashValue
-        when (verifyData' /= verifyData) $ decryptError "cannot verify finished"
+    expectFinished baseKey hashValue (Finished13 verifyData) =
+        checkFinished usedHash baseKey hashValue verifyData
     expectFinished _ _ p = unexpected (show p) (Just "server finished")
 
     setResumptionSecret masterSecret = do

--- a/core/Network/TLS/Handshake/Common13.hs
+++ b/core/Network/TLS/Handshake/Common13.hs
@@ -193,6 +193,11 @@ sendChangeCipherSpec13 ctx = do
 
 ----------------------------------------------------------------
 
+-- | TLS13 handshake wrap up & clean up.  Contrary to @handshakeTerminate@, this
+-- does not handle session, which is managed separately for TLS 1.3.  This does
+-- not reset byte counters because renegotiation is not allowed.  And a few more
+-- state attributes are preserved, necessary for TLS13 handshake modes, session
+-- tickets and post-handshake authentication.
 handshakeTerminate13 :: Context -> IO ()
 handshakeTerminate13 ctx = do
     -- forget most handshake data

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -763,7 +763,7 @@ doHandshake13 sparams ctx allCreds chosenVersion usedCipher exts usedHash client
     let expectFinished hChBeforeCf (Finished13 verifyData') = do
             let verifyData = makeVerifyData usedHash clientHandshakeTrafficSecret hChBeforeCf
             if verifyData == verifyData' then liftIO $ do
-                setEstablished ctx Established
+                handshakeTerminate13 ctx
                 setRxState ctx usedHash usedCipher clientApplicationTrafficSecret0
                else
                 decryptError "cannot verify finished"


### PR DESCRIPTION
Adds a function `handshakeTerminate13` to remove unnecessary context values when TLS13 handshake is completed.

Code to verify `Finished13` message is also shared a little more.