### PR TITLE
Avoid handshake failure with small RSA keys

### DIFF
--- a/core/Network/TLS/Crypto.hs
+++ b/core/Network/TLS/Crypto.hs
@@ -25,7 +25,6 @@ module Network.TLS.Crypto
     , PublicKey
     , PrivateKey
     , SignatureParams(..)
-    , findDigitalSignatureAlg
     , findKeyExchangeSignatureAlg
     , findFiniteFieldGroup
     , kxEncrypt
@@ -71,16 +70,6 @@ data KxError =
       RSAError RSA.Error
     | KxUnsupported
     deriving (Show)
-
-findDigitalSignatureAlg :: (PubKey, PrivKey) -> Maybe DigitalSignatureAlg
-findDigitalSignatureAlg keyPair =
-    case keyPair of
-        (PubKeyRSA     _, PrivKeyRSA      _)  -> Just DS_RSA
-        (PubKeyDSA     _, PrivKeyDSA      _)  -> Just DS_DSS
-        --(PubKeyECDSA   _, PrivKeyECDSA    _)  -> Just DS_ECDSA
-        (PubKeyEd25519 _, PrivKeyEd25519  _)  -> Just DS_Ed25519
-        (PubKeyEd448   _, PrivKeyEd448    _)  -> Just DS_Ed448
-        _                                     -> Nothing
 
 findKeyExchangeSignatureAlg :: (PubKey, PrivKey) -> Maybe KeyExchangeSignatureAlg
 findKeyExchangeSignatureAlg keyPair =

--- a/core/Network/TLS/Crypto.hs
+++ b/core/Network/TLS/Crypto.hs
@@ -25,6 +25,7 @@ module Network.TLS.Crypto
     , PublicKey
     , PrivateKey
     , SignatureParams(..)
+    , isKeyExchangeSignatureKey
     , findKeyExchangeSignatureAlg
     , findFiniteFieldGroup
     , kxEncrypt
@@ -70,6 +71,16 @@ data KxError =
       RSAError RSA.Error
     | KxUnsupported
     deriving (Show)
+
+isKeyExchangeSignatureKey :: KeyExchangeSignatureAlg -> PubKey -> Bool
+isKeyExchangeSignatureKey = f
+  where
+    f KX_RSA   (PubKeyRSA     _)   = True
+    f KX_DSS   (PubKeyDSA     _)   = True
+    f KX_ECDSA (PubKeyEC      _)   = True
+    f KX_ECDSA (PubKeyEd25519 _)   = True
+    f KX_ECDSA (PubKeyEd448   _)   = True
+    f _        _                   = False
 
 findKeyExchangeSignatureAlg :: (PubKey, PrivKey) -> Maybe KeyExchangeSignatureAlg
 findKeyExchangeSignatureAlg keyPair =

--- a/core/Network/TLS/Crypto/Types.hs
+++ b/core/Network/TLS/Crypto/Types.hs
@@ -17,10 +17,6 @@ availableFFGroups = [FFDHE2048,FFDHE3072,FFDHE4096,FFDHE6144,FFDHE8192]
 availableECGroups :: [Group]
 availableECGroups = [P256,P384,P521,X25519,X448]
 
--- Digital signature algorithm, in close relation to public/private key types.
-data DigitalSignatureAlg = DS_RSA | DS_DSS | DS_ECDSA | DS_Ed25519 | DS_Ed448
-                           deriving (Show, Eq)
-
 -- Key-exchange signature algorithm, in close relation to ciphers
 -- (before TLS 1.3).
 data KeyExchangeSignatureAlg = KX_RSA | KX_DSS | KX_ECDSA

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -766,13 +766,9 @@ processServerKeyExchange ctx (ServerKeyXchg origSkx) = do
 
         getSignaturePublicKey kxsAlg = do
             publicKey <- usingHState ctx getRemotePublicKey
-            case (kxsAlg, publicKey) of
-                (KX_RSA,   PubKeyRSA     _) -> return publicKey
-                (KX_DSS,   PubKeyDSA     _) -> return publicKey
-                (KX_ECDSA, PubKeyEC      _) -> return publicKey
-                (KX_ECDSA, PubKeyEd25519 _) -> return publicKey
-                (KX_ECDSA, PubKeyEd448   _) -> return publicKey
-                _                           -> throwCore $ Error_Protocol ("server public key algorithm is incompatible with " ++ show kxsAlg, True, HandshakeFailure)
+            unless (isKeyExchangeSignatureKey kxsAlg publicKey) $
+                throwCore $ Error_Protocol ("server public key algorithm is incompatible with " ++ show kxsAlg, True, HandshakeFailure)
+            return publicKey
 
 processServerKeyExchange ctx p = processCertificateRequest ctx p
 

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -576,7 +576,7 @@ sendClientData cparams ctx = sendCertificate >> sendClientKeyXchg >> sendCertifi
             --
             certSent <- usingHState ctx getClientCertSent
             when certSent $ do
-                pubKey      <- getLocalDigitalSignatureKey ctx
+                pubKey      <- getLocalPublicKey ctx
                 mhashSig    <- case ver of
                     TLS12 ->
                         let cHashSigs = supportedHashSignatures $ ctxSupported ctx
@@ -1017,7 +1017,7 @@ sendClientFlight13 cparams ctx usedHash baseKey = do
             [] -> return ()
             _  -> do
                   hChSc      <- transcriptHash ctx
-                  pubKey     <- getLocalDigitalSignatureKey ctx
+                  pubKey     <- getLocalPublicKey ctx
                   sigAlg     <- liftIO $ getLocalHashSigAlg ctx cHashSigs pubKey
                   vfy        <- makeCertVerify ctx pubKey sigAlg hChSc
                   loadPacket13 ctx $ Handshake13 [vfy]

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -323,10 +323,10 @@ storePrivInfoClient :: Context
                     -> Credential
                     -> IO ()
 storePrivInfoClient ctx cTypes (cc, privkey) = do
-    privalg <- storePrivInfo ctx cc privkey
-    unless (certificateCompatible privalg cTypes) $
+    pubkey <- storePrivInfo ctx cc privkey
+    unless (certificateCompatible pubkey cTypes) $
         throwCore $ Error_Protocol
-            ( show privalg ++ " credential does not match allowed certificate types"
+            ( pubkeyType pubkey ++ " credential does not match allowed certificate types"
             , True
             , InternalError )
 
@@ -408,7 +408,7 @@ clientChain cparams ctx =
                        return $ Just cc
 
 -- | Return a most preferred 'HandAndSignatureAlgorithm' that is
--- compatible with the private key and server's signature
+-- compatible with the local key and server's signature
 -- algorithms (both already saved).  Must only be called for TLS
 -- versions 1.2 and up.
 --
@@ -418,22 +418,22 @@ clientChain cparams ctx =
 --
 getLocalHashSigAlg :: Context
                    -> [HashAndSignatureAlgorithm]
-                   -> DigitalSignatureAlg
+                   -> PubKey
                    -> IO HashAndSignatureAlgorithm
-getLocalHashSigAlg ctx cHashSigs keyAlg = do
+getLocalHashSigAlg ctx cHashSigs pubKey = do
     -- Must be present with TLS 1.2 and up.
     (Just (_, Just hashSigs, _)) <- usingHState ctx getCertReqCBdata
-    let want = (&&) <$> signatureCompatible keyAlg
+    let want = (&&) <$> signatureCompatible pubKey
                     <*> flip elem hashSigs
     case find want cHashSigs of
         Just best -> return best
         Nothing   -> throwCore $ Error_Protocol
-                         ( keyerr keyAlg
+                         ( keyerr pubKey
                          , True
                          , HandshakeFailure
                          )
   where
-    keyerr alg = "no " ++ show alg ++ " hash algorithm in common with the server"
+    keyerr k = "no " ++ pubkeyType k ++ " hash algorithm in common with the server"
 
 -- | Return the supported 'CertificateType' values that are
 -- compatible with at least one supported signature algorithm.
@@ -576,16 +576,16 @@ sendClientData cparams ctx = sendCertificate >> sendClientKeyXchg >> sendCertifi
             --
             certSent <- usingHState ctx getClientCertSent
             when certSent $ do
-                keyAlg      <- getLocalDigitalSignatureAlg ctx
+                pubKey      <- getLocalDigitalSignatureKey ctx
                 mhashSig    <- case ver of
                     TLS12 ->
                         let cHashSigs = supportedHashSignatures $ ctxSupported ctx
-                         in Just <$> getLocalHashSigAlg ctx cHashSigs keyAlg
+                         in Just <$> getLocalHashSigAlg ctx cHashSigs pubKey
                     _     -> return Nothing
 
                 -- Fetch all handshake messages up to now.
                 msgs   <- usingHState ctx $ B.concat <$> getHandshakeMessages
-                sigDig <- createCertificateVerify ctx ver keyAlg mhashSig msgs
+                sigDig <- createCertificateVerify ctx ver pubKey mhashSig msgs
                 sendPacket ctx $ Handshake [CertVerify sigDig]
 
 processServerExtension :: ExtensionRaw -> TLSSt ()
@@ -752,26 +752,26 @@ processServerKeyExchange ctx (ServerKeyXchg origSkx) = do
                 (c,_)           -> throwCore $ Error_Protocol ("unknown server key exchange received, expecting: " ++ show c, True, HandshakeFailure)
         doDHESignature dhparams signature kxsAlg = do
             -- FF group selected by the server is verified when generating CKX
-            signatureType <- getSignatureType kxsAlg
-            verified <- digitallySignDHParamsVerify ctx dhparams signatureType signature
-            unless verified $ decryptError ("bad " ++ show signatureType ++ " signature for dhparams " ++ show dhparams)
+            publicKey <- getSignaturePublicKey kxsAlg
+            verified <- digitallySignDHParamsVerify ctx dhparams publicKey signature
+            unless verified $ decryptError ("bad " ++ pubkeyType publicKey ++ " signature for dhparams " ++ show dhparams)
             usingHState ctx $ setServerDHParams dhparams
 
         doECDHESignature ecdhparams signature kxsAlg = do
             -- EC group selected by the server is verified when generating CKX
-            signatureType <- getSignatureType kxsAlg
-            verified <- digitallySignECDHParamsVerify ctx ecdhparams signatureType signature
-            unless verified $ decryptError ("bad " ++ show signatureType ++ " signature for ecdhparams")
+            publicKey <- getSignaturePublicKey kxsAlg
+            verified <- digitallySignECDHParamsVerify ctx ecdhparams publicKey signature
+            unless verified $ decryptError ("bad " ++ pubkeyType publicKey ++ " signature for ecdhparams")
             usingHState ctx $ setServerECDHParams ecdhparams
 
-        getSignatureType kxsAlg = do
+        getSignaturePublicKey kxsAlg = do
             publicKey <- usingHState ctx getRemotePublicKey
             case (kxsAlg, publicKey) of
-                (KX_RSA,   PubKeyRSA     _) -> return DS_RSA
-                (KX_DSS,   PubKeyDSA     _) -> return DS_DSS
-                (KX_ECDSA, PubKeyEC      _) -> return DS_ECDSA
-                (KX_ECDSA, PubKeyEd25519 _) -> return DS_Ed25519
-                (KX_ECDSA, PubKeyEd448   _) -> return DS_Ed448
+                (KX_RSA,   PubKeyRSA     _) -> return publicKey
+                (KX_DSS,   PubKeyDSA     _) -> return publicKey
+                (KX_ECDSA, PubKeyEC      _) -> return publicKey
+                (KX_ECDSA, PubKeyEd25519 _) -> return publicKey
+                (KX_ECDSA, PubKeyEd448   _) -> return publicKey
                 _                           -> throwCore $ Error_Protocol ("server public key algorithm is incompatible with " ++ show kxsAlg, True, HandshakeFailure)
 
 processServerKeyExchange ctx p = processCertificateRequest ctx p
@@ -930,13 +930,13 @@ handshakeClient13' cparams ctx groupSent usedCipher usedHash = do
     expectCertAndVerify (Certificate13 _ cc _) = do
         _ <- liftIO $ processCertificate cparams ctx (Certificates cc)
         let pubkey = certPubKey $ getCertificate $ getCertificateChainLeaf cc
+        checkDigitalSignatureKey pubkey
         usingHState ctx $ setPublicKey pubkey
         recvHandshake13hash ctx $ expectCertVerify pubkey
     expectCertAndVerify p = unexpected (show p) (Just "server certificate")
 
     expectCertVerify pubkey hChSc (CertVerify13 sigAlg sig) = do
-        let keyAlg = fromJust "fromPubKey" (fromPubKey pubkey)
-        ok <- checkCertVerify ctx keyAlg sigAlg sig hChSc
+        ok <- checkCertVerify ctx pubkey sigAlg sig hChSc
         unless ok $ decryptError "cannot verify CertificateVerify"
     expectCertVerify _ _ p = unexpected (show p) (Just "certificate verify")
 
@@ -1017,9 +1017,9 @@ sendClientFlight13 cparams ctx usedHash baseKey = do
             [] -> return ()
             _  -> do
                   hChSc      <- transcriptHash ctx
-                  keyAlg     <- getLocalDigitalSignatureAlg ctx
-                  sigAlg     <- liftIO $ getLocalHashSigAlg ctx cHashSigs keyAlg
-                  vfy        <- makeCertVerify ctx keyAlg sigAlg hChSc
+                  pubKey     <- getLocalDigitalSignatureKey ctx
+                  sigAlg     <- liftIO $ getLocalHashSigAlg ctx cHashSigs pubKey
+                  vfy        <- makeCertVerify ctx pubKey sigAlg hChSc
                   loadPacket13 ctx $ Handshake13 [vfy]
     --
     sendClientData13 _ _ =

--- a/core/Network/TLS/Handshake/Common13.hs
+++ b/core/Network/TLS/Handshake/Common13.hs
@@ -125,22 +125,22 @@ serverContextString = "TLS 1.3, server CertificateVerify"
 clientContextString :: ByteString
 clientContextString = "TLS 1.3, client CertificateVerify"
 
-makeCertVerify :: MonadIO m => Context -> DigitalSignatureAlg -> HashAndSignatureAlgorithm -> ByteString -> m Handshake13
-makeCertVerify ctx sig hs hashValue = do
+makeCertVerify :: MonadIO m => Context -> PubKey -> HashAndSignatureAlgorithm -> ByteString -> m Handshake13
+makeCertVerify ctx pub hs hashValue = do
     cc <- liftIO $ usingState_ ctx isClientContext
     let ctxStr | cc == ClientRole = clientContextString
                | otherwise        = serverContextString
         target = makeTarget ctxStr hashValue
-    CertVerify13 hs <$> sign ctx sig hs target
+    CertVerify13 hs <$> sign ctx pub hs target
 
-checkCertVerify :: MonadIO m => Context -> DigitalSignatureAlg -> HashAndSignatureAlgorithm -> Signature -> ByteString -> m Bool
-checkCertVerify ctx sig hs signature hashValue
-    | sig `signatureCompatible` hs = liftIO $ do
+checkCertVerify :: MonadIO m => Context -> PubKey -> HashAndSignatureAlgorithm -> Signature -> ByteString -> m Bool
+checkCertVerify ctx pub hs signature hashValue
+    | pub `signatureCompatible` hs = liftIO $ do
         cc <- usingState_ ctx isClientContext
         let ctxStr | cc == ClientRole = serverContextString -- opposite context
-                   | otherwise        = clientContextString
+                | otherwise        = clientContextString
             target = makeTarget ctxStr hashValue
-            sigParams = signatureParams sig (Just hs)
+            sigParams = signatureParams pub (Just hs)
         checkHashSignatureValid13 hs
         checkSupportedHashSignature ctx (Just hs)
         verifyPublic ctx sigParams target signature
@@ -153,10 +153,10 @@ makeTarget contextString hashValue = runPut $ do
     putWord8 0
     putBytes hashValue
 
-sign :: MonadIO m => Context -> DigitalSignatureAlg -> HashAndSignatureAlgorithm -> ByteString -> m Signature
-sign ctx sig hs target = liftIO $ do
+sign :: MonadIO m => Context -> PubKey -> HashAndSignatureAlgorithm -> ByteString -> m Signature
+sign ctx pub hs target = liftIO $ do
     cc <- usingState_ ctx isClientContext
-    let sigParams = signatureParams sig (Just hs)
+    let sigParams = signatureParams pub (Just hs)
     signPrivate ctx cc sigParams target
 
 ----------------------------------------------------------------

--- a/core/Network/TLS/Handshake/Key.hs
+++ b/core/Network/TLS/Handshake/Key.hs
@@ -17,7 +17,9 @@ module Network.TLS.Handshake.Key
     , generateECDHEShared
     , generateFFDHE
     , generateFFDHEShared
-    , getLocalDigitalSignatureAlg
+    , isDigitalSignaturePair
+    , checkDigitalSignatureKey
+    , getLocalDigitalSignatureKey
     , logKey
     , LogKey(..)
     ) where
@@ -83,12 +85,41 @@ generateFFDHE ctx grp = usingState_ ctx $ withRNG $ dhGroupGenerateKeyPair grp
 generateFFDHEShared :: Context -> Group -> DHPublic -> IO (Maybe (DHPublic, DHKey))
 generateFFDHEShared ctx grp pub = usingState_ ctx $ withRNG $ dhGroupGetPubShared grp pub
 
-getLocalDigitalSignatureAlg :: (MonadFail m, MonadIO m) => Context -> m DigitalSignatureAlg
-getLocalDigitalSignatureAlg ctx = do
-    keys <- usingHState ctx getLocalPublicPrivateKeys
-    case findDigitalSignatureAlg keys of
-        Just sigAlg -> return sigAlg
-        Nothing     -> fail "selected credential does not support signing"
+isDigitalSignatureKey :: PubKey -> Bool
+isDigitalSignatureKey (PubKeyRSA _)      = True
+isDigitalSignatureKey (PubKeyDSA _)      = True
+isDigitalSignatureKey (PubKeyEC  _)      = True
+isDigitalSignatureKey (PubKeyEd25519 _)  = True
+isDigitalSignatureKey (PubKeyEd448   _)  = True
+isDigitalSignatureKey _                  = False
+
+-- | Test whether the argument is a public key supported for signature.  This
+-- also accepts a key for RSA encryption.  This test is performed by clients or
+-- servers before verifying a remote Certificate Verify.
+checkDigitalSignatureKey :: MonadIO m => PubKey -> m ()
+checkDigitalSignatureKey key =
+    unless (isDigitalSignatureKey key) $
+        throwCore $ Error_Protocol ("unsupported remote public key type", True, HandshakeFailure)
+
+-- | Test whether the argument is matching key pair supported for signature.
+-- This also accepts material for RSA encryption.  This test is performed by
+-- servers or clients before using a credential from the local configuration.
+isDigitalSignaturePair :: (PubKey, PrivKey) -> Bool
+isDigitalSignaturePair keyPair =
+    case keyPair of
+        (PubKeyRSA      _, PrivKeyRSA      _)  -> True
+        (PubKeyDSA      _, PrivKeyDSA      _)  -> True
+        --(PubKeyECDSA    _, PrivKeyECDSA    _)  -> True
+        (PubKeyEd25519  _, PrivKeyEd25519  _)  -> True
+        (PubKeyEd448    _, PrivKeyEd448    _)  -> True
+        _                                      -> False
+
+getLocalDigitalSignatureKey :: (MonadFail m, MonadIO m) => Context -> m PubKey
+getLocalDigitalSignatureKey ctx = do
+    keys@(pubKey, _) <- usingHState ctx getLocalPublicPrivateKeys
+    if isDigitalSignaturePair keys
+        then return pubKey
+        else fail "selected credential does not support signing"
 
 ----------------------------------------------------------------
 

--- a/core/Network/TLS/Handshake/Key.hs
+++ b/core/Network/TLS/Handshake/Key.hs
@@ -19,7 +19,7 @@ module Network.TLS.Handshake.Key
     , generateFFDHEShared
     , isDigitalSignaturePair
     , checkDigitalSignatureKey
-    , getLocalDigitalSignatureKey
+    , getLocalPublicKey
     , logKey
     , LogKey(..)
     ) where
@@ -114,12 +114,9 @@ isDigitalSignaturePair keyPair =
         (PubKeyEd448    _, PrivKeyEd448    _)  -> True
         _                                      -> False
 
-getLocalDigitalSignatureKey :: (MonadFail m, MonadIO m) => Context -> m PubKey
-getLocalDigitalSignatureKey ctx = do
-    keys@(pubKey, _) <- usingHState ctx getLocalPublicPrivateKeys
-    if isDigitalSignaturePair keys
-        then return pubKey
-        else fail "selected credential does not support signing"
+getLocalPublicKey :: MonadIO m => Context -> m PubKey
+getLocalPublicKey ctx =
+    usingHState ctx (fst <$> getLocalPublicPrivateKeys)
 
 ----------------------------------------------------------------
 

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -450,7 +450,7 @@ doHandshake sparams mcred ctx chosenVersion usedCipher usedCompression clientSes
 
         generateSKX_DHE kxsAlg = do
             serverParams  <- setup_DHE
-            pubKey <- getLocalDigitalSignatureKey ctx
+            pubKey <- getLocalPublicKey ctx
             mhashSig <- decideHashSig pubKey
             signed <- digitallySignDHParams ctx serverParams pubKey mhashSig
             case kxsAlg of
@@ -474,7 +474,7 @@ doHandshake sparams mcred ctx chosenVersion usedCipher usedCompression clientSes
                      []  -> throwCore $ Error_Protocol ("no common group", True, HandshakeFailure)
                      g:_ -> return g
             serverParams <- setup_ECDHE grp
-            pubKey <- getLocalDigitalSignatureKey ctx
+            pubKey <- getLocalPublicKey ctx
             mhashSig <- decideHashSig pubKey
             signed <- digitallySignECDHParams ctx serverParams pubKey mhashSig
             case kxsAlg of
@@ -881,7 +881,7 @@ doHandshake13 sparams ctx allCreds chosenVersion usedCipher exts usedHash client
             ess = replicate (length cs) []
         loadPacket13 ctx $ Handshake13 [Certificate13 "" certChain ess]
         hChSc <- transcriptHash ctx
-        pubkey <- getLocalDigitalSignatureKey ctx
+        pubkey <- getLocalPublicKey ctx
         vrfy <- makeCertVerify ctx pubkey hashSig hChSc
         loadPacket13 ctx $ Handshake13 [vrfy]
 

--- a/core/Network/TLS/Handshake/Signature.hs
+++ b/core/Network/TLS/Handshake/Signature.hs
@@ -52,10 +52,13 @@ certificateCompatible (PubKeyEd448 _)    _      = True
 certificateCompatible _                  _      = False
 
 signatureCompatible :: PubKey -> HashAndSignatureAlgorithm -> Bool
-signatureCompatible (PubKeyRSA _)       (_, SignatureRSA)              = True
-signatureCompatible (PubKeyRSA _)       (_, SignatureRSApssRSAeSHA256) = True
-signatureCompatible (PubKeyRSA _)       (_, SignatureRSApssRSAeSHA384) = True
-signatureCompatible (PubKeyRSA _)       (_, SignatureRSApssRSAeSHA512) = True
+signatureCompatible (PubKeyRSA pk)      (HashSHA1,   SignatureRSA)     = kxCanUseRSApkcs1 pk SHA1
+signatureCompatible (PubKeyRSA pk)      (HashSHA256, SignatureRSA)     = kxCanUseRSApkcs1 pk SHA256
+signatureCompatible (PubKeyRSA pk)      (HashSHA384, SignatureRSA)     = kxCanUseRSApkcs1 pk SHA384
+signatureCompatible (PubKeyRSA pk)      (HashSHA512, SignatureRSA)     = kxCanUseRSApkcs1 pk SHA512
+signatureCompatible (PubKeyRSA pk)      (_, SignatureRSApssRSAeSHA256) = kxCanUseRSApss pk SHA256
+signatureCompatible (PubKeyRSA pk)      (_, SignatureRSApssRSAeSHA384) = kxCanUseRSApss pk SHA384
+signatureCompatible (PubKeyRSA pk)      (_, SignatureRSApssRSAeSHA512) = kxCanUseRSApss pk SHA512
 signatureCompatible (PubKeyDSA _)       (_, SignatureDSS)              = True
 signatureCompatible (PubKeyEC _)        (_, SignatureECDSA)            = True
 signatureCompatible (PubKeyEd25519 _)   (_, SignatureEd25519)          = True

--- a/core/Network/TLS/X509.hs
+++ b/core/Network/TLS/X509.hs
@@ -23,6 +23,7 @@ module Network.TLS.X509
     , FailedReason
     , ServiceID
     , wrapCertificateChecks
+    , pubkeyType
     ) where
 
 import Data.X509
@@ -60,3 +61,6 @@ wrapCertificateChecks l
     | SelfSigned `elem` l = CertificateUsageReject  CertificateRejectUnknownCA
     | EmptyChain `elem` l = CertificateUsageReject  CertificateRejectAbsent
     | otherwise          = CertificateUsageReject $ CertificateRejectOther (show l)
+
+pubkeyType :: PubKey -> String
+pubkeyType = show . pubkeyToAlg


### PR DESCRIPTION
1024-bit is a small RSA size but this is often the default value when generating with some tools.
As reported in #365, enabling RSA-PSS signatures has side effect and prevents to use keys which were accepted before.

This PR extends selection of hash algorithm to avoid the fatal failure with SHA-512, and pick SHA-384 (or lower) instead.

The data type `DigitalSignatureAlg` is removed, instead `signatureCompatible` and calling functions use `PubKey` instead. When deciding about signature schemes, the full content of the public key is available, so the size of the modulus can be checked.

`PubKey` allows more key types than `DigitalSignatureAlg`, so to prevent an invalid input to a function like `signatureParams`, the existing decoding to `DigitalSignatureAlg` that previously rejected bad inputs is not removed but adapted:
- findDigitalSignatureAlg becomes isDigitalSignaturePair
- fromPubKey becomes isDigitalSignatureKey/checkDigitalSignatureKey

Only exception to this rule is when transforming getLocalDigitalSignatureAlg to getLocalPublicKey. The code path ensures that the key pair stored in `hksLocalPublicPrivateKeys` is a combination already validated by isDigitalSignaturePair, so there is no need to verify again.

The consistency check between remote public-key type and selected signature scheme that was missing for TLS13 is added to `checkCertVerify`.