### PR TITLE
refactoring for sending and receiving

### DIFF
--- a/core/Network/TLS/Handshake/Process.hs
+++ b/core/Network/TLS/Handshake/Process.hs
@@ -83,7 +83,7 @@ processHandshake ctx hs = do
         isHRR _                                 = False
 
 processHandshake13 :: Context -> Handshake13 -> IO ()
-processHandshake13 = updateHandshake13
+processHandshake13 ctx = void . updateHandshake13 ctx
 
 -- process the client key exchange message. the protocol expects the initial
 -- client version received in ClientHello, not the negotiated version.

--- a/core/Network/TLS/IO.hs
+++ b/core/Network/TLS/IO.hs
@@ -12,9 +12,10 @@ module Network.TLS.IO
     , sendPacket13
     , recvPacket
     , recvPacket13
-    -- * Grouping multiple packets in the same flight
+    --
     , isRecvComplete
     , checkValid
+    -- * Grouping multiple packets in the same flight
     , PacketFlightM
     , runPacketFlight
     , loadPacket13

--- a/core/Network/TLS/IO.hs
+++ b/core/Network/TLS/IO.hs
@@ -62,7 +62,7 @@ writePacketBytes :: MonadIO m => Context -> Packet -> m ByteString
 writePacketBytes ctx pkt = do
     edataToSend <- liftIO $ do
                         withLog ctx $ \logging -> loggingPacketSent logging (show pkt)
-                        writePacket ctx pkt
+                        encodePacket ctx pkt
     either throwCore return edataToSend
 
 ----------------------------------------------------------------
@@ -74,7 +74,7 @@ writePacketBytes13 :: MonadIO m => Context -> Packet13 -> m ByteString
 writePacketBytes13 ctx pkt = do
     edataToSend <- liftIO $ do
                         withLog ctx $ \logging -> loggingPacketSent logging (show pkt)
-                        writePacket13 ctx pkt
+                        encodePacket13 ctx pkt
     either throwCore return edataToSend
 
 sendBytes :: MonadIO m => Context -> ByteString -> m ()

--- a/core/Network/TLS/Packet.hs
+++ b/core/Network/TLS/Packet.hs
@@ -30,7 +30,6 @@ module Network.TLS.Packet
     , decodeHandshake
     , decodeDeprecatedHandshake
     , encodeHandshake
-    , encodeHandshakes
     , encodeHandshakeHeader
     , encodeHandshakeContent
 
@@ -358,9 +357,6 @@ encodeHandshake o =
                     ClientHello _ _ _ _ _ _ (Just _) -> "" -- SSLv2 ClientHello message
                     _ -> runPut $ encodeHandshakeHeader (typeOfHandshake o) len in
     B.concat [ header, content ]
-
-encodeHandshakes :: [Handshake] -> ByteString
-encodeHandshakes hss = B.concat $ map encodeHandshake hss
 
 encodeHandshakeHeader :: HandshakeType -> Int -> Put
 encodeHandshakeHeader ty len = putWord8 (valOfType ty) >> putWord24 len

--- a/core/Network/TLS/Receiving.hs
+++ b/core/Network/TLS/Receiving.hs
@@ -15,10 +15,6 @@ module Network.TLS.Receiving
     , getRecord
     ) where
 
-import Control.Monad.State.Strict
-import Control.Concurrent.MVar
-import qualified Data.ByteString as B
-
 import Network.TLS.Cipher
 import Network.TLS.Context.Internal
 import Network.TLS.ErrT
@@ -31,6 +27,10 @@ import Network.TLS.State
 import Network.TLS.Struct
 import Network.TLS.Util
 import Network.TLS.Wire
+
+import Control.Concurrent.MVar
+import Control.Monad.State.Strict
+import qualified Data.ByteString as B
 
 processPacket :: Context -> Record Plaintext -> IO (Either TLSError Packet)
 

--- a/core/Network/TLS/Receiving.hs
+++ b/core/Network/TLS/Receiving.hs
@@ -81,15 +81,15 @@ getRecord :: Context -> Int -> Header -> ByteString -> IO (Either TLSError (Reco
 getRecord ctx appDataOverhead header@(Header pt _ _) content = do
     withLog ctx $ \logging -> loggingIORecv logging header content
     runRxState ctx $ do
-        r <- decodeRecord header content
+        r <- decodeRecordM header content
         let Record _ _ fragment = r
         when (B.length (fragmentGetBytes fragment) > 16384 + overhead) $
             throwError contentSizeExceeded
         return r
   where overhead = if pt == ProtocolType_AppData then appDataOverhead else 0
 
-decodeRecord :: Header -> ByteString -> RecordM (Record Plaintext)
-decodeRecord header content = disengageRecord erecord
+decodeRecordM :: Header -> ByteString -> RecordM (Record Plaintext)
+decodeRecordM header content = disengageRecord erecord
    where
      erecord = rawToRecord header (fragmentCiphertext content)
 

--- a/core/Network/TLS/Receiving13.hs
+++ b/core/Network/TLS/Receiving13.hs
@@ -14,19 +14,19 @@ module Network.TLS.Receiving13
        ( processPacket13
        ) where
 
-import Control.Monad.State
-
 import Network.TLS.Context.Internal
-import Network.TLS.Struct
-import Network.TLS.Struct13
 import Network.TLS.ErrT
-import Network.TLS.Record.Types
+import Network.TLS.Imports
 import Network.TLS.Packet
 import Network.TLS.Packet13
-import Network.TLS.Wire
+import Network.TLS.Record.Types
 import Network.TLS.State
+import Network.TLS.Struct
+import Network.TLS.Struct13
 import Network.TLS.Util
-import Network.TLS.Imports
+import Network.TLS.Wire
+
+import Control.Monad.State
 
 processPacket13 :: Context -> Record Plaintext -> IO (Either TLSError Packet13)
 processPacket13 _ (Record ProtocolType_ChangeCipherSpec _ _) = return $ Right ChangeCipherSpec13

--- a/core/Network/TLS/Sending.hs
+++ b/core/Network/TLS/Sending.hs
@@ -36,7 +36,7 @@ import Data.IORef
 -- and updating state on the go
 encodePacket :: Context -> Packet -> IO (Either TLSError ByteString)
 encodePacket ctx pkt = do
-    Right ver <- runTxState ctx getRecordVersion
+    (ver, _) <- decideRecordVersion ctx
     let pt = packetType pkt
         mkRecord bs = Record pt ver (fragmentPlaintext bs)
     records <- map mkRecord <$> packetToFragments ctx 16384 pkt

--- a/core/Network/TLS/Sending.hs
+++ b/core/Network/TLS/Sending.hs
@@ -56,19 +56,22 @@ packetToFragments _   _   (AppData x)      = return [x]
 
 -- before TLS 1.1, the block cipher IV is made of the residual of the previous block,
 -- so we use cstIV as is, however in other case we generate an explicit IV
-encodeRecord :: Context -> Record Plaintext -> IO (Either TLSError ByteString)
-encodeRecord ctx record = do
+prepareRecord :: Context -> RecordM a -> IO (Either TLSError a)
+prepareRecord ctx f = do
     ver     <- usingState_ ctx (getVersionWithDefault $ maximum $ supportedVersions $ ctxSupported ctx)
     txState <- readMVar $ ctxTxState ctx
     let sz = case stCipher txState of
                   Nothing     -> 0
-                  Just cipher
-                    | hasRecordIV $ bulkF $ cipherBulk cipher -> bulkIVSize $ cipherBulk cipher
-                    | otherwise -> 0 -- to not generate IV
+                  Just cipher -> if hasRecordIV $ bulkF $ cipherBulk cipher
+                                    then bulkIVSize $ cipherBulk cipher
+                                    else 0 -- to not generate IV
     if hasExplicitBlockIV ver && sz > 0
         then do newIV <- getStateRNG ctx sz
-                runTxState ctx (modify (setRecordIV newIV) >> encodeRecordM record)
-        else runTxState ctx $ encodeRecordM record
+                runTxState ctx (modify (setRecordIV newIV) >> f)
+        else runTxState ctx f
+
+encodeRecord :: Context -> Record Plaintext -> IO (Either TLSError ByteString)
+encodeRecord ctx = prepareRecord ctx . encodeRecordM
 
 encodeRecordM :: Record Plaintext -> RecordM ByteString
 encodeRecordM record = do

--- a/core/Network/TLS/Sending.hs
+++ b/core/Network/TLS/Sending.hs
@@ -48,13 +48,11 @@ encodePacket ctx pkt = do
 -- packets are not fragmented here but by callers of sendPacket, so that the
 -- empty-packet countermeasure may be applied to each fragment independently.
 packetToFragments :: Context -> Int -> Packet -> IO [ByteString]
-packetToFragments ctx len pkt  = encodePacketContent pkt
-  where
-    encodePacketContent (Handshake hss)    =
-        getChunks len . B.concat <$> mapM (updateHandshake ctx ClientRole) hss
-    encodePacketContent (Alert a)          = return [encodeAlerts a]
-    encodePacketContent  ChangeCipherSpec  = return [encodeChangeCipherSpec]
-    encodePacketContent (AppData x)        = return [x]
+packetToFragments ctx len (Handshake hss)  =
+    getChunks len . B.concat <$> mapM (updateHandshake ctx ClientRole) hss
+packetToFragments _   _   (Alert a)        = return [encodeAlerts a]
+packetToFragments _   _   ChangeCipherSpec = return [encodeChangeCipherSpec]
+packetToFragments _   _   (AppData x)      = return [x]
 
 -- before TLS 1.1, the block cipher IV is made of the residual of the previous block,
 -- so we use cstIV as is, however in other case we generate an explicit IV

--- a/core/Network/TLS/Sending.hs
+++ b/core/Network/TLS/Sending.hs
@@ -63,9 +63,9 @@ runEncodeRecord ctx record = do
     txState <- readMVar $ ctxTxState ctx
     let sz = case stCipher txState of
                   Nothing     -> 0
-                  Just cipher -> if hasRecordIV $ bulkF $ cipherBulk cipher
-                                    then bulkIVSize $ cipherBulk cipher
-                                    else 0 -- to not generate IV
+                  Just cipher
+                    | hasRecordIV $ bulkF $ cipherBulk cipher -> bulkIVSize $ cipherBulk cipher
+                    | otherwise -> 0 -- to not generate IV
     if hasExplicitBlockIV ver && sz > 0
         then do newIV <- getStateRNG ctx sz
                 runTxState ctx (modify (setRecordIV newIV) >> encodeRecord record)

--- a/core/Network/TLS/Sending13.hs
+++ b/core/Network/TLS/Sending13.hs
@@ -33,7 +33,10 @@ encodePacket13 ctx pkt = do
     let pt = contentType pkt
         mkRecord bs = Record pt TLS12 (fragmentPlaintext bs)
     records <- map mkRecord <$> packetToFragments ctx 16384 pkt
-    fmap B.concat <$> forEitherM records (runTxState ctx . encodeRecord)
+    fmap B.concat <$> forEitherM records (encodeRecord ctx)
+
+encodeRecord :: Context -> Record Plaintext -> IO (Either TLSError ByteString)
+encodeRecord ctx = runTxState ctx . encodeRecordM
 
 packetToFragments :: Context -> Int -> Packet13 -> IO [ByteString]
 packetToFragments ctx len pkt = encodePacketContent pkt

--- a/core/Network/TLS/Sending13.hs
+++ b/core/Network/TLS/Sending13.hs
@@ -20,7 +20,7 @@ import Network.TLS.Handshake.State13
 import Network.TLS.Imports
 import Network.TLS.Packet
 import Network.TLS.Packet13
-import Network.TLS.Record.Types
+import Network.TLS.Record
 import Network.TLS.Sending
 import Network.TLS.Struct
 import Network.TLS.Struct13
@@ -35,8 +35,11 @@ encodePacket13 ctx pkt = do
     records <- map mkRecord <$> packetToFragments ctx 16384 pkt
     fmap B.concat <$> forEitherM records (encodeRecord ctx)
 
+prepareRecord :: Context -> RecordM a -> IO (Either TLSError a)
+prepareRecord = runTxState
+
 encodeRecord :: Context -> Record Plaintext -> IO (Either TLSError ByteString)
-encodeRecord ctx = runTxState ctx . encodeRecordM
+encodeRecord ctx = prepareRecord ctx . encodeRecordM
 
 packetToFragments :: Context -> Int -> Packet13 -> IO [ByteString]
 packetToFragments ctx len (Handshake13 hss)  =

--- a/core/Network/TLS/Sending13.hs
+++ b/core/Network/TLS/Sending13.hs
@@ -39,13 +39,11 @@ encodeRecord :: Context -> Record Plaintext -> IO (Either TLSError ByteString)
 encodeRecord ctx = runTxState ctx . encodeRecordM
 
 packetToFragments :: Context -> Int -> Packet13 -> IO [ByteString]
-packetToFragments ctx len pkt = encodePacketContent pkt
-  where
-    encodePacketContent (Handshake13 hss)  =
-        getChunks len . B.concat <$> mapM (updateHandshake13 ctx) hss
-    encodePacketContent (Alert13 a)        = return [encodeAlerts a]
-    encodePacketContent (AppData13 x)      = return [x]
-    encodePacketContent ChangeCipherSpec13 = return [encodeChangeCipherSpec]
+packetToFragments ctx len (Handshake13 hss)  =
+    getChunks len . B.concat <$> mapM (updateHandshake13 ctx) hss
+packetToFragments _   _   (Alert13 a)        = return [encodeAlerts a]
+packetToFragments _   _   (AppData13 x)      = return [x]
+packetToFragments _   _   ChangeCipherSpec13 = return [encodeChangeCipherSpec]
 
 updateHandshake13 :: Context -> Handshake13 -> IO ByteString
 updateHandshake13 ctx hs


### PR DESCRIPTION
This patches make `Sending` and `Receiving` symmetric as described in #392.
Also, these reduce unnecessary encodings to calculate transcript hash.