### PR TITLE
Enable X448 and FFDHE groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,12 @@ server name indication: 127.0.0.1
 
 ## TLS 1.3 HelloRetryRequest (HRR)
 
-The default value of `-g` is `x448,x25519,p256`. To trigger HRR, omit the `-g` option. The first value is only used for key-share.
+The first value of `-g` is used for key-share.  To trigger HRR, add in first
+position a value which will not be accepted by the server, for example use
+`ffdhe2048,x25519,p256`.
 
 ```
-% tls-simpleclient --tls13 -v --no-valid -O html-log.txt --http1.1 127.0.0.1 443
+% tls-simpleclient --tls13 -v --no-valid -O html-log.txt --http1.1 -g ffdhe2048,x25519,p256 127.0.0.1 443
 sending query:
 GET / HTTP/1.1
 Host: 127.0.0.1

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -230,10 +230,8 @@ data Supported = Supported
       --   extension.  It is used in both clients and servers to restrict
       --   accepted groups in DH key exchange.
       --
-      --   The default value is ['X25519','P256','P384','P521'].
-      --   'X25519' and 'P256' provide 128-bit security which is strong
-      --   enough until 2030.  Both curves are fast because their
-      --   backends are written in C.
+      --   The default value includes all groups with security strength of 128
+      --   bits or more.
     , supportedGroups              :: [Group]
     } deriving (Show,Eq)
 
@@ -261,7 +259,7 @@ defaultSupported = Supported
     , supportedSession             = True
     , supportedFallbackScsv        = True
     , supportedEmptyPacket         = True
-    , supportedGroups              = [X25519,P256,P384,P521]
+    , supportedGroups              = [X25519,X448,P256,FFDHE3072,FFDHE4096,P384,FFDHE6144,FFDHE8192,P521]
     }
 
 instance Default Supported where


### PR DESCRIPTION
Adds remaining groups to the default configuration, ordered by x86-64 performance measured in haskell-crypto/cryptonite#204.

Security strength with FFDHE2048 is only 103 bits so I excluded this group.
