### PR TITLE
docment ordering

### DIFF
--- a/core/Network/TLS.hs
+++ b/core/Network/TLS.hs
@@ -99,7 +99,7 @@ module Network.TLS
     , updateKey
     , KeyUpdateRequest(..)
     , requestCertificate
-    -- ** Modifying context
+    -- ** Modifying hooks in context
     , Hooks(..)
     , contextModifyHooks
     , Handshake
@@ -108,6 +108,8 @@ module Network.TLS
     , contextHookSetHandshake13Recv
     , contextHookSetCertificateRecv
     , Logging(..)
+    , Header(..)
+    , ProtocolType(..)
     , contextHookSetLogging
 
     -- * Errors and exceptions
@@ -119,8 +121,6 @@ module Network.TLS
     , TLSException(..)
 
     -- * Raw types
-    , Header(..)
-    , ProtocolType(..)
     -- ** Compressions class
     , CompressionC(..)
     , CompressionID

--- a/core/Network/TLS.hs
+++ b/core/Network/TLS.hs
@@ -20,48 +20,24 @@ module Network.TLS
     , HasBackend(..)
     , Backend(..)
 
-    -- * Context configuration
-    -- ** Parameters
+    -- * Parameters
     -- intentionally hide the internal methods even haddock warns.
     , TLSParams
     , ClientParams(..)
     , defaultParamsClient
     , ServerParams(..)
-    -- ** Supported
-    , Supported(..)
     -- ** Shared
     , Shared(..)
-    -- ** Debug parameters
-    , DebugParams(..)
-    -- ** Client Server Hooks
+    -- ** Hooks
     , ClientHooks(..)
     , OnCertificateRequest
     , OnServerCertificate
     , ServerHooks(..)
-    -- ** Credentials
-    , Credentials(..)
-    , Credential
-    , credentialLoadX509
-    , credentialLoadX509FromMemory
-    , credentialLoadX509Chain
-    , credentialLoadX509ChainFromMemory
-    -- ** Session
-    , SessionID
-    , SessionData(..)
-    , SessionManager(..)
-    , noSessionManager
-    , TLS13TicketInfo
-    -- ** Hooks
-    , Hooks(..)
-    , Handshake
-    , Handshake13
-    , Logging(..)
-    , contextHookSetHandshakeRecv
-    , contextHookSetHandshake13Recv
-    , contextHookSetCertificateRecv
-    , contextHookSetLogging
-    , contextModifyHooks
-    -- ** Misc
+    -- ** Supported
+    , Supported(..)
+    -- ** Debug parameters
+    , DebugParams(..)
+    -- ** Types
     , HostName
     , DHParams
     , DHPublic
@@ -75,17 +51,28 @@ module Network.TLS
     , SignatureAlgorithm(..)
     , CertificateType(..)
 
-    -- * X509
-    -- ** X509 Validation
-    , ValidationChecks(..)
-    , ValidationHooks(..)
-
-    -- ** X509 Validation Cache
+    -- * Shared parameters
+    -- ** Credentials
+    , Credentials(..)
+    , Credential
+    , credentialLoadX509
+    , credentialLoadX509FromMemory
+    , credentialLoadX509Chain
+    , credentialLoadX509ChainFromMemory
+    -- ** Session manager
+    , SessionManager(..)
+    , noSessionManager
+    , SessionID
+    , SessionData(..)
+    , TLS13TicketInfo
+    -- ** Validation Cache
     , ValidationCache(..)
+    , ValidationCacheQueryCallback
+    , ValidationCacheAddCallback
     , ValidationCacheResult(..)
     , exceptionValidationCache
 
-    -- * APIs
+    -- * Advanced APIs
     -- ** Backend
     , ctxConnection
     , contextFlush
@@ -104,6 +91,16 @@ module Network.TLS
     , updateKey
     , KeyUpdateRequest(..)
     , requestCertificate
+    -- ** Modifying context
+    , Hooks(..)
+    , contextModifyHooks
+    , Handshake
+    , contextHookSetHandshakeRecv
+    , Handshake13
+    , contextHookSetHandshake13Recv
+    , contextHookSetCertificateRecv
+    , Logging(..)
+    , contextHookSetLogging
 
     -- * Raw types
     , ProtocolType(..)
@@ -137,6 +134,8 @@ module Network.TLS
     , contextNewOnSocket
 #endif
     , Bytes
+    , ValidationChecks(..)
+    , ValidationHooks(..)
     ) where
 
 import Network.TLS.Backend (Backend(..), HasBackend(..))

--- a/core/Network/TLS.hs
+++ b/core/Network/TLS.hs
@@ -6,6 +6,21 @@
 -- Stability   : experimental
 -- Portability : unknown
 --
+-- Native Haskell TLS and SSL protocol implementation for server and
+-- client.
+--
+-- This provides a high-level implementation of a sensitive security
+-- protocol, eliminating a common set of security issues through the
+-- use of the advanced type system, high level constructions and
+-- common Haskell features.
+--
+-- Currently implement the SSL3.0, TLS1.0, TLS1.1, TLS1.2 and TLS 1.3
+-- protocol, and support RSA and Ephemeral (Elliptic curve and
+-- regular) Diffie Hellman key exchanges, and many extensions.
+--
+-- Some debug tools linked with tls, are available through the
+-- http://hackage.haskell.org/package/tls-debug/.
+
 module Network.TLS
     (
     -- * Basic APIs

--- a/core/Network/TLS.hs
+++ b/core/Network/TLS.hs
@@ -33,23 +33,11 @@ module Network.TLS
     , OnCertificateRequest
     , OnServerCertificate
     , ServerHooks(..)
+    , Measurement(..)
     -- ** Supported
     , Supported(..)
     -- ** Debug parameters
     , DebugParams(..)
-    -- ** Types
-    , HostName
-    , DHParams
-    , DHPublic
-    , Measurement(..)
-    , GroupUsage(..)
-    , CertificateUsage(..)
-    , CertificateRejectReason(..)
-    , MaxFragmentEnum(..)
-    , HashAndSignatureAlgorithm
-    , HashAlgorithm(..)
-    , SignatureAlgorithm(..)
-    , CertificateType(..)
 
     -- * Shared parameters
     -- ** Credentials
@@ -72,6 +60,25 @@ module Network.TLS
     , ValidationCacheResult(..)
     , exceptionValidationCache
 
+    -- * Types
+    -- ** For 'Supported'
+    , Version(..)
+    , Compression(..)
+    , nullCompression
+    , HashAndSignatureAlgorithm
+    , HashAlgorithm(..)
+    , SignatureAlgorithm(..)
+    , Group(..)
+    -- ** For parameters and hooks
+    , DHParams
+    , DHPublic
+    , GroupUsage(..)
+    , CertificateUsage(..)
+    , CertificateRejectReason(..)
+    , CertificateType(..)
+    , HostName
+    , MaxFragmentEnum(..)
+
     -- * Advanced APIs
     -- ** Backend
     , ctxConnection
@@ -84,6 +91,7 @@ module Network.TLS
     , ServerRandom
     , unClientRandom
     , unServerRandom
+    , HandshakeMode13(..)
     -- ** Negotiated
     , getNegotiatedProtocol
     , getClientSNI
@@ -102,30 +110,25 @@ module Network.TLS
     , Logging(..)
     , contextHookSetLogging
 
-    -- * Raw types
-    , ProtocolType(..)
-    , Header(..)
-    , Version(..)
-    -- ** Compressions & Predefined compressions
-    , module Network.TLS.Compression
-    , CompressionID
-    -- ** Ciphers & Predefined ciphers
-    , module Network.TLS.Cipher
-    -- ** Crypto Key
-    , PubKey(..)
-    , PrivKey(..)
-    -- ** TLS 1.3
-    , Group(..)
-    , HandshakeMode13(..)
-
     -- * Errors and exceptions
     -- ** Errors
     , TLSError(..)
     , KxError(..)
     , AlertDescription(..)
-
     -- ** Exceptions
     , TLSException(..)
+
+    -- * Raw types
+    , Header(..)
+    , ProtocolType(..)
+    -- ** Compressions class
+    , CompressionC(..)
+    , CompressionID
+    -- ** Crypto Key
+    , PubKey(..)
+    , PrivKey(..)
+    -- ** Ciphers & Predefined ciphers
+    , module Network.TLS.Cipher
 
     -- * Deprecated
     , recvData'


### PR DESCRIPTION
To make the document more readable, sections and subsections are re-ordred.

Q1) Many things in "Raw types" are not used. Is it necessary to export them from the top module? Should be create the `Internal` module to export them?
Q2) Why are `ValidationChecks` and `ValidationHooks` exported?
Q3) Why aren't necessary things such as `ciphersuite_strong` exported?
