### PR TITLE
Extended Master Secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Features
 * key exchange supported: RSA, DHE-RSA, DHE-DSS, ECDHE-RSA, ECDHE-ECDSA
 * diffie-hellman groups: finite fields, elliptic curves P-256, P-384, P-521, X25519, X448
 * bulk algorithm supported: any stream or block ciphers
-* supported extensions: secure renegotiation, next protocol negotiation (draft 2), server name indication
+* supported extensions: secure renegotiation, application-layer protocol
+  negotiation, extended master secret, server name indication
 
 Common Issues
 =============

--- a/core/Network/TLS.hs
+++ b/core/Network/TLS.hs
@@ -67,6 +67,7 @@ module Network.TLS
     , noSessionManager
     , SessionID
     , SessionData(..)
+    , SessionFlag(..)
     , TLS13TicketInfo
     -- ** Validation Cache
     , ValidationCache(..)

--- a/core/Network/TLS.hs
+++ b/core/Network/TLS.hs
@@ -85,6 +85,7 @@ module Network.TLS
     , HashAlgorithm(..)
     , SignatureAlgorithm(..)
     , Group(..)
+    , EMSMode(..)
     -- ** For parameters and hooks
     , DHParams
     , DHPublic

--- a/core/Network/TLS/Extension.hs
+++ b/core/Network/TLS/Extension.hs
@@ -17,6 +17,7 @@ module Network.TLS.Extension
     , extensionID_MaxFragmentLength
     , extensionID_SecureRenegotiation
     , extensionID_ApplicationLayerProtocolNegotiation
+    , extensionID_ExtendedMasterSecret
     , extensionID_NegotiatedGroups
     , extensionID_EcPointFormats
     , extensionID_Heartbeat
@@ -38,6 +39,7 @@ module Network.TLS.Extension
     , MaxFragmentEnum(..)
     , SecureRenegotiation(..)
     , ApplicationLayerProtocolNegotiation(..)
+    , ExtendedMasterSecret(..)
     , NegotiatedGroups(..)
     , Group(..)
     , EcPointFormatsSupported(..)
@@ -144,7 +146,7 @@ extensionID_ClientCertificateType               = 0x13 -- RFC7250
 extensionID_ServerCertificateType               = 0x14 -- RFC7250
 extensionID_Padding                             = 0x15 -- draft-agl-tls-padding. expires 2015-03-12
 extensionID_EncryptThenMAC                      = 0x16 -- RFC7366
-extensionID_ExtendedMasterSecret                = 0x17 -- draft-ietf-tls-session-hash. expires 2015-09-26
+extensionID_ExtendedMasterSecret                = 0x17 -- REF7627
 extensionID_SessionTicket                       = 0x23 -- RFC4507
 -- Reserved                                       0x28 -- TLS 1.3
 extensionID_PreSharedKey                        = 0x29 -- TLS 1.3
@@ -205,6 +207,7 @@ supportedExtensions :: [ExtensionID]
 supportedExtensions = [ extensionID_ServerName
                       , extensionID_MaxFragmentLength
                       , extensionID_ApplicationLayerProtocolNegotiation
+                      , extensionID_ExtendedMasterSecret
                       , extensionID_SecureRenegotiation
                       , extensionID_NegotiatedGroups
                       , extensionID_EcPointFormats
@@ -354,6 +357,18 @@ decodeApplicationLayerProtocolNegotiation = runGetMaybe $ do
         alpnParsed <- getOpaque8
         let !alpn = B.copy alpnParsed
         return (B.length alpn + 1, alpn)
+
+------------------------------------------------------------
+
+-- | Extended Master Secret
+data ExtendedMasterSecret = ExtendedMasterSecret deriving (Show,Eq)
+
+instance Extension ExtendedMasterSecret where
+    extensionID _ = extensionID_ExtendedMasterSecret
+    extensionEncode ExtendedMasterSecret = B.empty
+    extensionDecode MsgTClientHello _ = Just ExtendedMasterSecret
+    extensionDecode MsgTServerHello _ = Just ExtendedMasterSecret
+    extensionDecode _               _ = error "extensionDecode: ExtendedMasterSecret"
 
 ------------------------------------------------------------
 

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -258,9 +258,9 @@ handshakeClient' cparams ctx groups mparams = do
                     let paramSession = case clientWantSessionResume cparams of
                             Nothing -> Session Nothing
                             Just (sid, sdata)
-                                | sessionVersion sdata >= TLS13 -> Session Nothing
-                                | ems /= NoEMS && noSessionEMS  -> Session Nothing
-                                | otherwise                     -> Session (Just sid)
+                                | sessionVersion sdata >= TLS13     -> Session Nothing
+                                | ems == RequireEMS && noSessionEMS -> Session Nothing
+                                | otherwise                         -> Session (Just sid)
                               where noSessionEMS = SessionEMS `notElem` sessionFlags sdata
                     -- In compatibility mode a client not offering a pre-TLS 1.3
                     -- session MUST generate a new 32-byte value

--- a/core/Network/TLS/Handshake/Common.hs
+++ b/core/Network/TLS/Handshake/Common.hs
@@ -187,7 +187,7 @@ getSessionData ctx = do
     ver <- usingState_ ctx getVersion
     sni <- usingState_ ctx getClientSNI
     mms <- usingHState ctx (gets hstMasterSecret)
-    ems <- usingHState ctx getExtendedMasterSec
+    !ems <- usingHState ctx getExtendedMasterSec
     tx  <- liftIO $ readMVar (ctxTxState ctx)
     alpn <- usingState_ ctx getNegotiatedProtocol
     let !cipher      = cipherID $ fromJust "cipher" $ stCipher tx

--- a/core/Network/TLS/Handshake/Common.hs
+++ b/core/Network/TLS/Handshake/Common.hs
@@ -99,6 +99,7 @@ handshakeTerminate ctx = do
                 return $ Just (newEmptyHandshake (hstClientVersion hshake) (hstClientRandom hshake))
                     { hstServerRandom = hstServerRandom hshake
                     , hstMasterSecret = hstMasterSecret hshake
+                    , hstExtendedMasterSec = hstExtendedMasterSec hshake
                     , hstNegotiatedGroup = hstNegotiatedGroup hshake
                     }
     updateMeasure ctx resetBytesCounters

--- a/core/Network/TLS/Handshake/Common.hs
+++ b/core/Network/TLS/Handshake/Common.hs
@@ -172,10 +172,12 @@ getSessionData ctx = do
     ver <- usingState_ ctx getVersion
     sni <- usingState_ ctx getClientSNI
     mms <- usingHState ctx (gets hstMasterSecret)
+    ems <- usingHState ctx getExtendedMasterSec
     tx  <- liftIO $ readMVar (ctxTxState ctx)
     alpn <- usingState_ ctx getNegotiatedProtocol
     let !cipher      = cipherID $ fromJust "cipher" $ stCipher tx
         !compression = compressionID $ stCompression tx
+        flags = [SessionEMS | ems]
     case mms of
         Nothing -> return Nothing
         Just ms -> return $ Just SessionData
@@ -188,6 +190,7 @@ getSessionData ctx = do
                         , sessionTicketInfo  = Nothing
                         , sessionALPN        = alpn
                         , sessionMaxEarlyDataSize = 0
+                        , sessionFlags       = flags
                         }
 
 extensionLookup :: ExtensionID -> [ExtensionRaw] -> Maybe ByteString

--- a/core/Network/TLS/Handshake/Common13.hs
+++ b/core/Network/TLS/Handshake/Common13.hs
@@ -323,6 +323,7 @@ getSessionData13 ctx usedCipher tinfo maxSize psk = do
       , sessionTicketInfo  = Just tinfo
       , sessionALPN        = malpn
       , sessionMaxEarlyDataSize = maxSize
+      , sessionFlags       = []
       }
 
 ----------------------------------------------------------------

--- a/core/Network/TLS/Handshake/Process.hs
+++ b/core/Network/TLS/Handshake/Process.hs
@@ -11,7 +11,6 @@ module Network.TLS.Handshake.Process
     ( processHandshake
     , processHandshake13
     , startHandshake
-    , getHandshakeDigest
     ) where
 
 import Network.TLS.Context.Internal

--- a/core/Network/TLS/Handshake/Process.hs
+++ b/core/Network/TLS/Handshake/Process.hs
@@ -52,12 +52,14 @@ processHandshake ctx hs = do
             hrr <- usingState_ ctx getTLS13HRR
             unless hrr $ startHandshake ctx cver ran
         Certificates certs            -> processCertificates role certs
-        ClientKeyXchg content         -> when (role == ServerRole) $ do
-            processClientKeyXchg ctx content
         Finished fdata                -> processClientFinished ctx fdata
         _                             -> return ()
     when (isHRR hs) $ usingHState ctx wrapAsMessageHash13
     void $ updateHandshake ctx ServerRole hs
+    case hs of
+        ClientKeyXchg content  -> when (role == ServerRole) $
+            processClientKeyXchg ctx content
+        _                      -> return ()
   where secureRenegotiation = supportedSecureRenegotiation $ ctxSupported ctx
         -- RFC5746: secure renegotiation
         -- the renegotiation_info extension: 0xff01

--- a/core/Network/TLS/Packet.hs
+++ b/core/Network/TLS/Packet.hs
@@ -46,6 +46,7 @@ module Network.TLS.Packet
 
     -- * generate things for packet content
     , generateMasterSecret
+    , generateExtendedMasterSec
     , generateKeyBlock
     , generateClientFinished
     , generateServerFinished
@@ -586,6 +587,16 @@ generateMasterSecret :: ByteArrayAccess preMaster
 generateMasterSecret SSL2 _ = generateMasterSecret_SSL
 generateMasterSecret SSL3 _ = generateMasterSecret_SSL
 generateMasterSecret v    c = generateMasterSecret_TLS $ getPRF v c
+
+generateExtendedMasterSec :: ByteArrayAccess preMaster
+                          => Version
+                          -> Cipher
+                          -> preMaster
+                          -> ByteString
+                          -> ByteString
+generateExtendedMasterSec v c premasterSecret sessionHash =
+    getPRF v c (B.convert premasterSecret) seed 48
+  where seed = B.append "extended master secret" sessionHash
 
 generateKeyBlock_TLS :: PRF -> ClientRandom -> ServerRandom -> ByteString -> Int -> ByteString
 generateKeyBlock_TLS prf (ClientRandom c) (ServerRandom s) mastersecret kbsize =

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -21,6 +21,7 @@ module Network.TLS.Parameters
     , defaultParamsClient
     -- * Parameters
     , MaxFragmentEnum(..)
+    , EMSMode(..)
     , GroupUsage(..)
     , CertificateUsage(..)
     , CertificateRejectReason(..)
@@ -210,6 +211,15 @@ data Supported = Supported
       --   If 'False', renegotiation is allowed only from the server side
       --   via HelloRequest.
     , supportedClientInitiatedRenegotiation :: Bool
+      -- | The mode regarding extended master secret.  Enabling this extension
+      -- provides better security for TLS versions 1.0 to 1.2.  TLS 1.3 provides
+      -- the security properties natively and does not need the extension.
+      --
+      -- By default the extension is enabled but not required.  If mode is set
+      -- to 'RequireEMS', the handshake will fail when the peer does not support
+      -- the extension.  It is also advised to disable SSLv3 which does not have
+      -- this mechanism.
+    , supportedExtendedMasterSec   :: EMSMode
       -- | Set if we support session.
     , supportedSession             :: Bool
       -- | Support for fallback SCSV defined in RFC7507.
@@ -235,6 +245,13 @@ data Supported = Supported
     , supportedGroups              :: [Group]
     } deriving (Show,Eq)
 
+-- | Client or server policy regarding Extended Master Secret
+data EMSMode
+    = NoEMS       -- ^ Extended Master Secret is not used
+    | AllowEMS    -- ^ Extended Master Secret is allowed
+    | RequireEMS  -- ^ Extended Master Secret is required
+    deriving (Show,Eq)
+
 defaultSupported :: Supported
 defaultSupported = Supported
     { supportedVersions       = [TLS13,TLS12,TLS11,TLS10]
@@ -256,6 +273,7 @@ defaultSupported = Supported
                                 ]
     , supportedSecureRenegotiation = True
     , supportedClientInitiatedRenegotiation = False
+    , supportedExtendedMasterSec   = AllowEMS
     , supportedSession             = True
     , supportedFallbackScsv        = True
     , supportedEmptyPacket         = True

--- a/core/Network/TLS/Types.hs
+++ b/core/Network/TLS/Types.hs
@@ -10,6 +10,7 @@ module Network.TLS.Types
     ( Version(..)
     , SessionID
     , SessionData(..)
+    , SessionFlag(..)
     , CertReqContext
     , TLS13TicketInfo(..)
     , CipherID
@@ -58,7 +59,13 @@ data SessionData = SessionData
     , sessionTicketInfo  :: Maybe TLS13TicketInfo
     , sessionALPN        :: Maybe ByteString
     , sessionMaxEarlyDataSize :: Int
+    , sessionFlags       :: [SessionFlag]
     } deriving (Show,Eq)
+
+-- | Some session flags
+data SessionFlag
+    = SessionEMS        -- ^ Session created with Extended Master Secret
+    deriving (Show,Eq,Enum)
 
 -- | Certificate request context for TLS 1.3.
 type CertReqContext = ByteString

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -759,7 +759,12 @@ prop_handshake_session_resumption_ems = do
 
     if emsVersion && use ems && not (use ems2)
         then runTLSInitFailure params2
-        else runTLSPipeSimple params2
+        else do
+            runTLSPipeSimple params2
+            sessionParams2 <- run $ readClientSessionRef sessionRefs
+            let sameSession = sessionParams == sessionParams2
+                sameUse     = use ems == use ems2
+            when emsVersion $ assert (sameSession == sameUse)
   where
     compatible (NoEMS, RequireEMS) = False
     compatible (RequireEMS, NoEMS) = False

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -721,6 +721,54 @@ prop_handshake_clt_key_usage = do
         then runTLSPipeSimple  (clientParam',serverParam')
         else runTLSInitFailure (clientParam',serverParam')
 
+prop_handshake_ems :: PropertyM IO ()
+prop_handshake_ems = do
+    (cems, sems) <- pick arbitraryEMSMode
+    params <- pick arbitraryPairParams
+    let params' = setEMSMode (cems, sems) params
+        version = getConnectVersion params'
+        emsVersion = version >= TLS10 && version <= TLS12
+        use = cems /= NoEMS && sems /= NoEMS
+        require = cems == RequireEMS || sems == RequireEMS
+        p info = infoExtendedMasterSec info == (emsVersion && use)
+    if emsVersion && require && not use
+        then runTLSInitFailure params'
+        else runTLSPipePredicate params' (maybe False p)
+
+prop_handshake_session_resumption_ems :: PropertyM IO ()
+prop_handshake_session_resumption_ems = do
+    sessionRefs <- run twoSessionRefs
+    let sessionManagers = twoSessionManagers sessionRefs
+
+    plainParams <- pick arbitraryPairParams
+    ems <- pick (arbitraryEMSMode `suchThat` compatible)
+    let params = setEMSMode ems $
+            setPairParamsSessionManagers sessionManagers plainParams
+
+    runTLSPipeSimple params
+
+    -- and resume
+    sessionParams <- run $ readClientSessionRef sessionRefs
+    assert (isJust sessionParams)
+    ems2 <- pick (arbitraryEMSMode `suchThat` compatible)
+    let params2 = setEMSMode ems2 $
+            setPairParamsSessionResuming (fromJust sessionParams) params
+
+    let version    = getConnectVersion params2
+        emsVersion = version >= TLS10 && version <= TLS12
+
+    if emsVersion && use ems && not (use ems2)
+        then runTLSInitFailure params2
+        else runTLSPipeSimple params2
+  where
+    compatible (NoEMS, RequireEMS) = False
+    compatible (RequireEMS, NoEMS) = False
+    compatible _                   = True
+
+    use (NoEMS, _) = False
+    use (_, NoEMS) = False
+    use _          = True
+
 prop_handshake_alpn :: PropertyM IO ()
 prop_handshake_alpn = do
     (clientParam,serverParam) <- pick arbitraryPairParams
@@ -891,6 +939,8 @@ main = defaultMain $ testGroup "tls"
             , testProperty "Server key usage" (monadicIO prop_handshake_srv_key_usage)
             , testProperty "Client authentication" (monadicIO prop_handshake_client_auth)
             , testProperty "Client key usage" (monadicIO prop_handshake_clt_key_usage)
+            , testProperty "Extended Master Secret" (monadicIO prop_handshake_ems)
+            , testProperty "Extended Master Secret (resumption)" (monadicIO prop_handshake_session_resumption_ems)
             , testProperty "ALPN" (monadicIO prop_handshake_alpn)
             , testProperty "SNI" (monadicIO prop_handshake_sni)
             , testProperty "Renegotiation" (monadicIO prop_handshake_renegotiation)

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -1,5 +1,5 @@
 Name:                tls
-Version:             1.5.2
+Version:             1.5.3
 Description:
    Native Haskell TLS and SSL protocol implementation for server and client.
    .

--- a/debug/src/Common.hs
+++ b/debug/src/Common.hs
@@ -114,6 +114,8 @@ printHandshakeInfo ctx = do
             putStrLn ("cipher: " ++ show (infoCipher i))
             putStrLn ("compression: " ++ show (infoCompression i))
             putStrLn ("group: " ++ maybe "(none)" show (infoNegotiatedGroup i))
+            when (infoVersion i < TLS13) $
+                putStrLn ("extended master secret: " ++ show (infoExtendedMasterSec i))
             when (infoVersion i == TLS13) $ do
                 putStrLn ("handshake emode: " ++ show (fromJust (infoTLS13HandshakeMode i)))
                 putStrLn ("early data accepted: " ++ show (infoIsEarlyDataAccepted i))

--- a/debug/tls-debug.cabal
+++ b/debug/tls-debug.cabal
@@ -28,7 +28,7 @@ Executable           tls-stunnel
                    , x509-validation >= 1.5
                    , data-default-class
                    , cryptonite >= 0.24
-                   , tls >= 1.5.0
+                   , tls >= 1.5.3
                    , tls-session-manager
   if os(windows)
     Buildable:       False
@@ -77,7 +77,7 @@ Executable           tls-simpleclient
                    , cryptonite >= 0.14
                    , x509-store
                    , x509-system >= 1.0
-                   , tls >= 1.5.0 && < 1.6
+                   , tls >= 1.5.3 && < 1.6
   Buildable:         True
   ghc-options:       -Wall -fno-warn-missing-signatures
 
@@ -94,7 +94,7 @@ Executable           tls-simpleserver
                    , cryptonite
                    , x509-store
                    , x509-system >= 1.0
-                   , tls >= 1.5.0 && < 1.6
+                   , tls >= 1.5.3 && < 1.6
                    , tls-session-manager
   Buildable:         True
   ghc-options:       -Wall -fno-warn-missing-signatures

--- a/session/Network/TLS/SessionManager.hs
+++ b/session/Network/TLS/SessionManager.hs
@@ -57,8 +57,13 @@ toKey = convert
 
 toValue :: SessionData -> SessionDataCopy
 #if MIN_VERSION_tls(1,5,0)
+#if MIN_VERSION_tls(1,5,3)
+toValue (SessionData v cid comp msni sec mg mti malpn siz flg) =
+    SessionDataCopy v cid comp msni sec' mg mti malpn' siz flg
+#else
 toValue (SessionData v cid comp msni sec mg mti malpn siz) =
     SessionDataCopy v cid comp msni sec' mg mti malpn' siz
+#endif
   where
     !sec' = convert sec
     !malpn' = convert <$> malpn
@@ -71,8 +76,13 @@ toValue (SessionData v cid comp msni sec) =
 
 fromValue :: SessionDataCopy -> SessionData
 #if MIN_VERSION_tls(1,5,0)
+#if MIN_VERSION_tls(1,5,3)
+fromValue (SessionDataCopy v cid comp msni sec' mg mti malpn' siz flg) =
+    SessionData v cid comp msni sec mg mti malpn siz flg
+#else
 fromValue (SessionDataCopy v cid comp msni sec' mg mti malpn' siz) =
     SessionData v cid comp msni sec mg mti malpn siz
+#endif
   where
     !sec = convert sec'
     !malpn = convert <$> malpn'
@@ -97,6 +107,9 @@ data SessionDataCopy = SessionDataCopy
     {- ssTicketInfo  -} !(Maybe TLS13TicketInfo)
     {- ssALPN        -} !(Maybe (Block Word8))
     {- ssMaxEarlyDataSize -} Int
+#endif
+#if MIN_VERSION_tls(1,5,3)
+    {- ssFlags       -} [SessionFlag]
 #endif
     deriving (Show,Eq)
 


### PR DESCRIPTION
Adds [RFC 7627](https://tools.ietf.org/html/rfc7627), which is a prerequisite for EKM and Token Binding before TLS 1.3.

For this I add an extensible list of flags to SessionData.  Encrypted SNI would benefit from this too.  It modifies the API but I think we should try this change in a minor version (not sure many people really depend on SessionData, but what is clear is that major versions tend to be blocked for months in stackage).