### PR TITLE
Check SSLv3 padding length

### DIFF
--- a/core/Network/TLS/Struct.hs
+++ b/core/Network/TLS/Struct.hs
@@ -78,7 +78,7 @@ data CipherType = CipherStream | CipherBlock | CipherAEAD
 data CipherData = CipherData
     { cipherDataContent :: ByteString
     , cipherDataMAC     :: Maybe ByteString
-    , cipherDataPadding :: Maybe ByteString
+    , cipherDataPadding :: Maybe (ByteString, Int)
     } deriving (Show,Eq)
 
 -- | Some of the IANA registered code points for 'CertificateType' are not


### PR DESCRIPTION
Contrary to TLS, SSL requires the CBC padding to be minimal, i.e. the minimum number of bytes to get a multiple of the block size.  This PR adds the verification and makes tlsfuzzer script
`test-SSLv3-padding.py` all successful.