### PR TITLE
Fixing ALPN

### DIFF
--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -698,7 +698,7 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
     usingHState ctx $ setNegotiatedGroup $ keyShareEntryGroup clientKeyShare
     srand <- setServerParameter
     -- ALPN is used in choosePSK
-    protoExt <- liftIO $ applicationProtocol ctx exts sparams
+    protoExt <- applicationProtocol ctx exts sparams
     (psk, binderInfo, is0RTTvalid) <- choosePSK
     earlyKey <- calculateEarlySecret ctx choice (Left psk) True
     let earlySecret = pairBase earlyKey

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -697,6 +697,8 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
         setClientSupportsPHA supportsPHA
     usingHState ctx $ setNegotiatedGroup $ keyShareEntryGroup clientKeyShare
     srand <- setServerParameter
+    -- ALPN is used in choosePSK
+    protoExt <- liftIO $ applicationProtocol ctx exts sparams
     (psk, binderInfo, is0RTTvalid) <- choosePSK
     earlyKey <- calculateEarlySecret ctx choice (Left psk) True
     let earlySecret = pairBase earlyKey
@@ -736,7 +738,7 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
             setRxState ctx usedHash usedCipher $ if rtt0OK then clientEarlySecret else clientHandshakeSecret
             setTxState ctx usedHash usedCipher serverHandshakeSecret
     ----------------------------------------------------------------
-        sendExtensions rtt0OK
+        sendExtensions rtt0OK protoExt
         case mCredInfo of
             Nothing              -> return ()
             Just (cred, hashSig) -> sendCertAndVerify cred hashSig
@@ -887,8 +889,7 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
         vrfy <- makeCertVerify ctx pubkey hashSig hChSc
         loadPacket13 ctx $ Handshake13 [vrfy]
 
-    sendExtensions rtt0OK = do
-        protoExt <- liftIO $ applicationProtocol ctx exts sparams
+    sendExtensions rtt0OK protoExt = do
         msni <- liftIO $ usingState_ ctx getClientSNI
         let sniExtension = case msni of
               -- RFC6066: In this event, the server SHALL include

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -324,8 +324,17 @@ prop_handshake13_rtt0 = do
           { supportedCiphers = [cipher_TLS13_AES128GCM_SHA256]
           , supportedGroups = [X25519]
           }
-        params0 = (cli { clientSupported = cliSupported }
+        cliHooks = def {
+            onSuggestALPN = return $ Just ["h2"]
+          }
+        svrHooks = def {
+            onALPNClientSuggest = Just (\protos -> return $ head protos)
+          }
+        params0 = (cli { clientSupported = cliSupported
+                       , clientHooks = cliHooks
+                       }
                   ,srv { serverSupported = svrSupported
+                       , serverHooks = svrHooks
                        , serverEarlyDataSize = 2048 }
                   )
 


### PR DESCRIPTION
ALPN should be decided before the decision of 0-RTT.

The first commit discloses the bug and the second one should fix it.

@ocheron BTW, do you know which specification requires the rule implemented in `checkSessionEquality`? I would like to add comments there.