### PR TITLE
Additional verification regarding EC signatures

### DIFF
--- a/core/Network/TLS/Crypto.hs
+++ b/core/Network/TLS/Crypto.hs
@@ -28,6 +28,7 @@ module Network.TLS.Crypto
     , isKeyExchangeSignatureKey
     , findKeyExchangeSignatureAlg
     , findFiniteFieldGroup
+    , findEllipticCurveGroup
     , kxEncrypt
     , kxDecrypt
     , kxSign
@@ -103,6 +104,14 @@ findFiniteFieldGroup params = lookup (pg params) table
     table = [ (pg prms, grp) | grp <- availableFFGroups
                              , let Just prms = dhParamsForGroup grp
             ]
+
+findEllipticCurveGroup :: PubKeyEC -> Maybe Group
+findEllipticCurveGroup ecPub =
+    case ecPubKeyCurveName ecPub of
+        Just ECC.SEC_p256r1 -> Just P256
+        Just ECC.SEC_p384r1 -> Just P384
+        Just ECC.SEC_p521r1 -> Just P521
+        _                   -> Nothing
 
 -- functions to use the hidden class.
 hashInit :: Hash -> HashContext

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -785,6 +785,9 @@ processServerKeyExchange ctx (ServerKeyXchg origSkx) = do
             ver <- usingState_ ctx getVersion
             unless (publicKey `versionCompatible` ver) $
                 throwCore $ Error_Protocol (show ver ++ " has no support for " ++ pubkeyType publicKey, True, IllegalParameter)
+            let groups = supportedGroups (ctxSupported ctx)
+            unless (satisfiesEcPredicate (`elem` groups) publicKey) $
+                throwCore $ Error_Protocol ("server public key has unsupported elliptic curve", True, IllegalParameter)
             return publicKey
 
 processServerKeyExchange ctx p = processCertificateRequest ctx p

--- a/core/Network/TLS/Handshake/Common13.hs
+++ b/core/Network/TLS/Handshake/Common13.hs
@@ -143,7 +143,7 @@ makeCertVerify ctx pub hs hashValue = do
 
 checkCertVerify :: MonadIO m => Context -> PubKey -> HashAndSignatureAlgorithm -> Signature -> ByteString -> m Bool
 checkCertVerify ctx pub hs signature hashValue
-    | pub `signatureCompatible` hs = liftIO $ do
+    | pub `signatureCompatible13` hs = liftIO $ do
         cc <- usingState_ ctx isClientContext
         let ctxStr | cc == ClientRole = serverContextString -- opposite context
                 | otherwise        = clientContextString

--- a/core/Network/TLS/Handshake/Key.hs
+++ b/core/Network/TLS/Handshake/Key.hs
@@ -22,6 +22,7 @@ module Network.TLS.Handshake.Key
     , isDigitalSignaturePair
     , checkDigitalSignatureKey
     , getLocalPublicKey
+    , satisfiesEcPredicate
     , logKey
     ) where
 
@@ -130,6 +131,14 @@ isDigitalSignaturePair keyPair =
 getLocalPublicKey :: MonadIO m => Context -> m PubKey
 getLocalPublicKey ctx =
     usingHState ctx (fst <$> getLocalPublicPrivateKeys)
+
+-- | Test whether the public key satisfies a predicate about the elliptic curve.
+-- When the public key is not suitable for ECDSA, like RSA for instance, the
+-- predicate is not used and the result is 'True'.
+satisfiesEcPredicate :: (Group -> Bool) -> PubKey -> Bool
+satisfiesEcPredicate p (PubKeyEC ecPub) =
+    maybe False p $ findEllipticCurveGroup ecPub
+satisfiesEcPredicate _ _                = True
 
 ----------------------------------------------------------------
 

--- a/core/Network/TLS/Handshake/Key.hs
+++ b/core/Network/TLS/Handshake/Key.hs
@@ -18,6 +18,7 @@ module Network.TLS.Handshake.Key
     , generateECDHEShared
     , generateFFDHE
     , generateFFDHEShared
+    , versionCompatible
     , isDigitalSignaturePair
     , checkDigitalSignatureKey
     , getLocalPublicKey
@@ -35,6 +36,7 @@ import Network.TLS.Types
 import Network.TLS.Context.Internal
 import Network.TLS.Imports
 import Network.TLS.Struct
+import Network.TLS.X509
 
 {- if the RSA encryption fails we just return an empty bytestring, and let the protocol
  - fail by itself; however it would be probably better to just report it since it's an internal problem.
@@ -93,13 +95,24 @@ isDigitalSignatureKey (PubKeyEd25519 _)  = True
 isDigitalSignatureKey (PubKeyEd448   _)  = True
 isDigitalSignatureKey _                  = False
 
--- | Test whether the argument is a public key supported for signature.  This
--- also accepts a key for RSA encryption.  This test is performed by clients or
--- servers before verifying a remote Certificate Verify.
-checkDigitalSignatureKey :: MonadIO m => PubKey -> m ()
-checkDigitalSignatureKey key =
+versionCompatible :: PubKey -> Version -> Bool
+versionCompatible (PubKeyRSA _)       _ = True
+versionCompatible (PubKeyDSA _)       v = v <= TLS12
+versionCompatible (PubKeyEC _)        v = v >= TLS10
+versionCompatible (PubKeyEd25519 _)   v = v >= TLS12
+versionCompatible (PubKeyEd448 _)     v = v >= TLS12
+versionCompatible _                   _ = False
+
+-- | Test whether the argument is a public key supported for signature at the
+-- specified TLS version.  This also accepts a key for RSA encryption.  This
+-- test is performed by clients or servers before verifying a remote
+-- Certificate Verify.
+checkDigitalSignatureKey :: MonadIO m => Version -> PubKey -> m ()
+checkDigitalSignatureKey usedVersion key = do
     unless (isDigitalSignatureKey key) $
         throwCore $ Error_Protocol ("unsupported remote public key type", True, HandshakeFailure)
+    unless (key `versionCompatible` usedVersion) $
+        throwCore $ Error_Protocol (show usedVersion ++ " has no support for " ++ pubkeyType key, True, IllegalParameter)
 
 -- | Test whether the argument is matching key pair supported for signature.
 -- This also accepts material for RSA encryption.  This test is performed by

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -247,7 +247,10 @@ handshakeServerWithTLS12 sparams ctx chosenVersion exts ciphers serverName clien
                                                  then (allCreds, sigAllCreds, allCiphers)
                                                  else (cltCreds, sigCltCreds, cltCiphers)
                             in resultTuple
-                  _     -> (allCreds, allCreds, selectCipher allCreds allCreds)
+                  _     ->
+                    let sigAllCreds = filterCredentials (isJust . credentialDigitalSignatureKey) allCreds
+                        allCiphers  = selectCipher allCreds sigAllCreds
+                     in (allCreds, sigAllCreds, allCiphers)
 
     -- The shared cipherlist can become empty after filtering for compatible
     -- creds, check now before calling onCipherChoosing, which does not handle

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -530,7 +530,7 @@ recvClientData sparams ctx = runRecvState ctx (RecvStateHandshake processClientC
             msgs  <- usingHState ctx $ B.concat <$> getHandshakeMessages
 
             pubKey <- usingHState ctx getRemotePublicKey
-            checkDigitalSignatureKey pubKey
+            checkDigitalSignatureKey usedVersion pubKey
 
             verif <- checkCertificateVerify ctx usedVersion pubKey msgs dsig
             clientCertVerify sparams ctx certs verif
@@ -959,7 +959,8 @@ expectCertVerify sparams ctx hChCc (CertVerify13 sigAlg sig) = liftIO $ do
     pubkey <- case cc of
                 [] -> throwCore $ Error_Protocol ("client certificate missing", True, HandshakeFailure)
                 c:_ -> return $ certPubKey $ getCertificate c
-    checkDigitalSignatureKey pubkey
+    ver <- usingState_ ctx getVersion
+    checkDigitalSignatureKey ver pubkey
     usingHState ctx $ setPublicKey pubkey
     verif <- checkCertVerify ctx pubkey sigAlg sig hChCc
     clientCertVerify sparams ctx certs verif

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -1076,7 +1076,7 @@ credentialsFindForSigning13' sigAlg (Credentials l) = find forSigning l
   where
     forSigning cred = case credentialDigitalSignatureKey cred of
         Nothing  -> False
-        Just pub -> pub `signatureCompatible` sigAlg
+        Just pub -> pub `signatureCompatible13` sigAlg
 
 clientCertificate :: ServerParams -> Context -> CertificateChain -> IO ()
 clientCertificate sparams ctx certs = do

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -312,7 +312,9 @@ data Supported = Supported
       --
       --   The list is sent to the server as part of the "supported_groups"
       --   extension.  It is used in both clients and servers to restrict
-      --   accepted groups in DH key exchange.
+      --   accepted groups in DH key exchange.  Up until TLS v1.2, it is also
+      --   used by a client to restrict accepted elliptic curves in ECDSA
+      --   signatures.
       --
       --   The default value includes all groups with security strength of 128
       --   bits or more.


### PR DESCRIPTION
* Prevents to use EdDSA with TLS10 and TLS11. EdDSA support is signaled through "signature_algorithms" only, so needs TLS12 or later for proper negotiation between client and server.
* For TLS13, verifies that the received elliptic curve matches the hash algorithm chosen by peer (i.e. SHA-256 is for P-256, SHA-384 is for P-384, etc.)
* For TLS12 or before, verifies that the elliptic curve used to generate an ECDSA signature matches sent extension "Supported Elliptic Curves"
* For uniform behavior, make sure we call isDigitalSignaturePair before TLS12 too