### PR TITLE
Handshake controller for QUIC

### DIFF
--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -183,6 +183,7 @@ contextNew backend params = liftIO $ do
             , ctxPendingActions   = as
             , ctxCertRequests     = crs
             , ctxKeyLogger        = debugKeyLogger debug
+            , ctxRecordLayer      = Nothing
             }
 
 -- | create a new context on an handle.

--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -200,7 +200,6 @@ contextNew backend params = liftIO $ do
             , recordSendBytes = sendBytes ctx
             , recordRecv      = recvRecord ctx
             , recordRecv13    = recvRecord13 ctx
-            , recordNeedFlush = False
             }
 
     return ctx

--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -184,6 +184,7 @@ contextNew backend params = liftIO $ do
             , ctxCertRequests     = crs
             , ctxKeyLogger        = debugKeyLogger debug
             , ctxRecordLayer      = Nothing
+            , ctxHandshakeSync    = Nothing
             }
 
 -- | create a new context on an handle.

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -65,25 +65,26 @@ module Network.TLS.Context.Internal
     ) where
 
 import Network.TLS.Backend
-import Network.TLS.Extension
 import Network.TLS.Cipher
-import Network.TLS.Struct
-import Network.TLS.Struct13
 import Network.TLS.Compression (Compression)
-import Network.TLS.State
+import Network.TLS.Extension
 import Network.TLS.Handshake.State
 import Network.TLS.Hooks
-import Network.TLS.Record.State
-import Network.TLS.Parameters
-import Network.TLS.Measurement
 import Network.TLS.Imports
+import Network.TLS.Measurement
+import Network.TLS.Parameters
+import Network.TLS.Record.Layer
+import Network.TLS.Record.State
+import Network.TLS.State
+import Network.TLS.Struct
+import Network.TLS.Struct13
 import Network.TLS.Types
 import Network.TLS.Util
-import qualified Data.ByteString as B
 
 import Control.Concurrent.MVar
-import Control.Monad.State.Strict
 import Control.Exception (throwIO, Exception())
+import Control.Monad.State.Strict
+import qualified Data.ByteString as B
 import Data.IORef
 import Data.Tuple
 
@@ -131,6 +132,7 @@ data Context = Context
     , ctxPendingActions   :: IORef [PendingAction]
     , ctxCertRequests     :: IORef [Handshake13]  -- ^ pending PHA requests
     , ctxKeyLogger        :: String -> IO ()
+    , ctxRecordLayer      :: Maybe RecordLayer
     }
 
 data Established = NotEstablished

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -68,6 +68,7 @@ import Network.TLS.Backend
 import Network.TLS.Cipher
 import Network.TLS.Compression (Compression)
 import Network.TLS.Extension
+import Network.TLS.Handshake.Control
 import Network.TLS.Handshake.State
 import Network.TLS.Hooks
 import Network.TLS.Imports
@@ -87,7 +88,6 @@ import Control.Monad.State.Strict
 import qualified Data.ByteString as B
 import Data.IORef
 import Data.Tuple
-
 
 -- | Information related to a running context, e.g. current cipher
 data Information = Information
@@ -133,6 +133,7 @@ data Context = Context
     , ctxCertRequests     :: IORef [Handshake13]  -- ^ pending PHA requests
     , ctxKeyLogger        :: String -> IO ()
     , ctxRecordLayer      :: Maybe RecordLayer
+    , ctxHandshakeSync    :: Maybe HandshakeSync
     }
 
 data Established = NotEstablished

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 -- |
 -- Module      : Network.TLS.Context.Internal
 -- License     : BSD-style
@@ -35,6 +37,7 @@ module Network.TLS.Context.Internal
     , contextClose
     , contextSend
     , contextRecv
+    , updateRecordLayer
     , updateMeasure
     , withMeasure
     , withReadLock
@@ -104,7 +107,7 @@ data Information = Information
     } deriving (Show,Eq)
 
 -- | A TLS Context keep tls specific state, parameters and backend information.
-data Context = Context
+data Context = forall bytes . Monoid bytes => Context
     { ctxConnection       :: Backend   -- ^ return the backend object associated with this context
     , ctxSupported        :: Supported
     , ctxShared           :: Shared
@@ -132,9 +135,13 @@ data Context = Context
     , ctxPendingActions   :: IORef [PendingAction]
     , ctxCertRequests     :: IORef [Handshake13]  -- ^ pending PHA requests
     , ctxKeyLogger        :: String -> IO ()
-    , ctxRecordLayer      :: RecordLayer
+    , ctxRecordLayer      :: RecordLayer bytes
     , ctxHandshakeSync    :: HandshakeSync
     }
+
+updateRecordLayer :: Monoid bytes => RecordLayer bytes -> Context -> Context
+updateRecordLayer recordLayer Context{..} =
+    Context { ctxRecordLayer = recordLayer, .. }
 
 data Established = NotEstablished
                  | EarlyDataAllowed Int    -- remaining 0-RTT bytes allowed

--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -301,6 +301,8 @@ keyUpdate :: Context
           -> IO ()
 keyUpdate ctx getState setState = do
     (usedHash, usedCipher, level, applicationSecretN) <- getState ctx
+    unless (level == CryptApplicationSecret) $
+        throwCore $ Error_Protocol ("tried key update without application traffic secret", True, InternalError)
     let applicationSecretN1 = hkdfExpandLabel usedHash applicationSecretN "traffic upd" "" $ hashDigestSize usedHash
     setState ctx usedHash usedCipher level applicationSecretN1
 

--- a/core/Network/TLS/Extension.hs
+++ b/core/Network/TLS/Extension.hs
@@ -32,6 +32,7 @@ module Network.TLS.Extension
     , extensionID_PostHandshakeAuth
     , extensionID_SignatureAlgorithmsCert
     , extensionID_KeyShare
+    , extensionID_QuicTransportParameters
     -- all implemented extensions
     , ServerNameType(..)
     , ServerName(..)
@@ -122,7 +123,8 @@ extensionID_ServerName
   , extensionID_PostHandshakeAuth
   , extensionID_SignatureAlgorithmsCert
   , extensionID_KeyShare
-  , extensionID_SecureRenegotiation :: ExtensionID
+  , extensionID_SecureRenegotiation
+  , extensionID_QuicTransportParameters :: ExtensionID
 extensionID_ServerName                          = 0x0 -- RFC6066
 extensionID_MaxFragmentLength                   = 0x1 -- RFC6066
 extensionID_ClientCertificateUrl                = 0x2 -- RFC6066
@@ -161,6 +163,7 @@ extensionID_PostHandshakeAuth                   = 0x31 -- TLS 1.3
 extensionID_SignatureAlgorithmsCert             = 0x32 -- TLS 1.3
 extensionID_KeyShare                            = 0x33 -- TLS 1.3
 extensionID_SecureRenegotiation                 = 0xff01 -- RFC5746
+extensionID_QuicTransportParameters             = 0xffa5
 
 ------------------------------------------------------------
 
@@ -200,6 +203,7 @@ definedExtensions =
     , extensionID_SignatureAlgorithmsCert
     , extensionID_CertificateAuthorities
     , extensionID_SecureRenegotiation
+    , extensionID_QuicTransportParameters
     ]
 
 -- | all supported extensions by the implementation
@@ -220,6 +224,7 @@ supportedExtensions = [ extensionID_ServerName
                       , extensionID_Cookie
                       , extensionID_PskKeyExchangeModes
                       , extensionID_CertificateAuthorities
+                      , extensionID_QuicTransportParameters
                       ]
 
 ------------------------------------------------------------

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -872,7 +872,9 @@ handshakeClient13' cparams ctx groupSent choice = do
         return accext
     hChSf <- transcriptHash ctx
     runPacketFlight ctx [] $ sendChangeCipherSpec13 ctx
-    when rtt0accepted $ sendPacket13 ctx (Handshake13 [EndOfEarlyData13])
+    let earlyData = clientEarlyData cparams
+    when (rtt0accepted && earlyData /= Just "") $ -- QUIC
+        sendPacket13 ctx (Handshake13 [EndOfEarlyData13])
     setTxState ctx usedHash usedCipher clientHandshakeSecret
     sendClientFlight13 cparams ctx usedHash clientHandshakeSecret
     appKey <- switchToApplicationSecret handshakeSecret hChSf

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -314,11 +314,12 @@ handshakeClient' cparams ctx groups mparams = do
                 -- But HandshakeDigestContext is not created yet.
                 earlyKey <- calculateEarlySecret ctx choice (Right earlySecret) False
                 let ces@(ClientTrafficSecret clientEarlySecret) = pairClient earlyKey
-                runPacketFlight ctx [] $ sendChangeCipherSpec13 ctx
-                setTxState ctx usedHash usedCipher clientEarlySecret
-                let len = ctxFragmentSize ctx
-                mapChunks_ len (sendPacket13 ctx . AppData13) earlyData
-                usingHState ctx $ setTLS13RTT0Status RTT0Sent
+                when (earlyData /= "") $ do
+                    runPacketFlight ctx [] $ sendChangeCipherSpec13 ctx
+                    setTxState ctx usedHash usedCipher clientEarlySecret
+                    let len = ctxFragmentSize ctx
+                    mapChunks_ len (sendPacket13 ctx . AppData13) earlyData
+                    usingHState ctx $ setTLS13RTT0Status RTT0Sent
                 return ces
 
         recvServerHello clientSession sentExts = runRecvState ctx recvState

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -314,12 +314,13 @@ handshakeClient' cparams ctx groups mparams = do
                 -- But HandshakeDigestContext is not created yet.
                 earlyKey <- calculateEarlySecret ctx choice (Right earlySecret) False
                 let ces@(ClientTrafficSecret clientEarlySecret) = pairClient earlyKey
-                when (earlyData /= "") $ do
+                when (earlyData /= "") $ do -- for QUIC
                     runPacketFlight ctx [] $ sendChangeCipherSpec13 ctx
                     setTxState ctx usedHash usedCipher clientEarlySecret
                     let len = ctxFragmentSize ctx
                     mapChunks_ len (sendPacket13 ctx . AppData13) earlyData
-                    usingHState ctx $ setTLS13RTT0Status RTT0Sent
+                -- We set RTT0Sent for QUIC even if earlyData == "".
+                usingHState ctx $ setTLS13RTT0Status RTT0Sent
                 return $ EarlySecretInfo usedCipher ces
 
         recvServerHello clientSession sentExts = runRecvState ctx recvState

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -876,7 +876,8 @@ handshakeClient13' cparams ctx groupSent choice = do
     let applicationSecret = triBase appKey
     setResumptionSecret applicationSecret
     alpn <- usingState_ ctx getNegotiatedProtocol
-    contextSync ctx $ SendClientFinishedI eexts alpn (triClient appKey, triServer appKey)
+    mode <- usingHState ctx getTLS13HandshakeMode
+    contextSync ctx $ SendClientFinishedI eexts alpn (triClient appKey, triServer appKey) mode
     handshakeTerminate13 ctx
   where
     usedCipher = cCipher choice

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -314,7 +314,7 @@ handshakeClient' cparams ctx groups mparams = do
                 -- But HandshakeDigestContext is not created yet.
                 earlyKey <- calculateEarlySecret ctx choice (Right earlySecret) False
                 let ces@(ClientTrafficSecret clientEarlySecret) = pairClient earlyKey
-                when (earlyData /= "") $ do -- for QUIC
+                when (earlyData /= quicEarlyData) $ do
                     runPacketFlight ctx [] $ sendChangeCipherSpec13 ctx
                     setTxState ctx usedHash usedCipher clientEarlySecret
                     let len = ctxFragmentSize ctx
@@ -873,7 +873,7 @@ handshakeClient13' cparams ctx groupSent choice = do
     hChSf <- transcriptHash ctx
     runPacketFlight ctx [] $ sendChangeCipherSpec13 ctx
     let earlyData = clientEarlyData cparams
-    when (rtt0accepted && earlyData /= Just "") $ -- QUIC
+    when (rtt0accepted && earlyData /= Just quicEarlyData) $
         sendPacket13 ctx (Handshake13 [EndOfEarlyData13])
     setTxState ctx usedHash usedCipher clientHandshakeSecret
     sendClientFlight13 cparams ctx usedHash clientHandshakeSecret
@@ -1094,3 +1094,6 @@ contextSync :: Context -> ClientStatusI -> IO ()
 contextSync ctx ctl = case ctxHandshakeSync ctx of
   Nothing                     -> return ()
   Just (HandshakeSync sync _) -> sync ctl
+
+quicEarlyData :: ByteString
+quicEarlyData = ""

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -291,7 +291,8 @@ handshakeClient' cparams ctx groups mparams = do
             let rtt0info = pskInfo >>= get0RTTinfo
                 rtt0 = isJust rtt0info
             extensions0 <- catMaybes <$> getExtensions pskInfo rtt0
-            extensions <- adjustExtentions pskInfo extensions0 $ mkClientHello extensions0
+            let extensions1 = sharedExtensions (clientShared cparams) ++ extensions0
+            extensions <- adjustExtentions pskInfo extensions1 $ mkClientHello extensions1
             sendPacket ctx $ Handshake [mkClientHello extensions]
             mapM_ send0RTT rtt0info
             return (rtt0, map (\(ExtensionRaw i _) -> i) extensions)

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -1084,7 +1084,9 @@ postHandshakeAuthClientWith cparams ctx h@(CertRequest13 certReqCtx exts) =
     bracket (saveHState ctx) (restoreHState ctx) $ \_ -> do
         processHandshake13 ctx h
         processCertRequest13 ctx certReqCtx exts
-        (usedHash, _, CryptApplicationSecret, applicationSecretN) <- getTxState ctx
+        (usedHash, _, level, applicationSecretN) <- getTxState ctx
+        unless (level == CryptApplicationSecret) $
+            throwCore $ Error_Protocol ("unexpected post-handshake authentication request", True, UnexpectedMessage)
         sendClientFlight13 cparams ctx usedHash applicationSecretN
 
 postHandshakeAuthClientWith _ _ _ =

--- a/core/Network/TLS/Handshake/Common.hs
+++ b/core/Network/TLS/Handshake/Common.hs
@@ -21,6 +21,7 @@ module Network.TLS.Handshake.Common
     , storePrivInfo
     , isSupportedGroup
     , checkSupportedGroup
+    , errorToAlert
     ) where
 
 import qualified Data.ByteString as B

--- a/core/Network/TLS/Handshake/Common.hs
+++ b/core/Network/TLS/Handshake/Common.hs
@@ -22,6 +22,7 @@ module Network.TLS.Handshake.Common
     , isSupportedGroup
     , checkSupportedGroup
     , errorToAlert
+    , errorToAlertMessage
     ) where
 
 import qualified Data.ByteString as B
@@ -74,6 +75,12 @@ errorToAlert (Error_Protocol (_, _, ad))   = [(AlertLevel_Fatal, ad)]
 errorToAlert (Error_Packet_unexpected _ _) = [(AlertLevel_Fatal, UnexpectedMessage)]
 errorToAlert (Error_Packet_Parsing _)      = [(AlertLevel_Fatal, DecodeError)]
 errorToAlert _                             = [(AlertLevel_Fatal, InternalError)]
+
+errorToAlertMessage :: TLSError -> String
+errorToAlertMessage (Error_Protocol (msg, _, _))    = msg
+errorToAlertMessage (Error_Packet_unexpected msg _) = msg
+errorToAlertMessage (Error_Packet_Parsing msg)      = msg
+errorToAlertMessage e                               = show e
 
 unexpected :: MonadIO m => String -> Maybe String -> m a
 unexpected msg expected = throwCore $ Error_Packet_unexpected msg (maybe "" (" expected: " ++) expected)

--- a/core/Network/TLS/Handshake/Common13.hs
+++ b/core/Network/TLS/Handshake/Common13.hs
@@ -193,7 +193,7 @@ replacePSKBinder pskz binder = identities `B.append` binders
 
 ----------------------------------------------------------------
 
-sendChangeCipherSpec13 :: Context -> PacketFlightM ()
+sendChangeCipherSpec13 :: Monoid b => Context -> PacketFlightM b ()
 sendChangeCipherSpec13 ctx = do
     sent <- usingHState ctx $ do
                 b <- getCCS13Sent

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -57,9 +57,9 @@ data ServerControl = PutClientHello       -- ^ 'SendRequestRetry', 'SendServerHe
                    | ExitServer           -- ^ 'ServerHandshakeDone'
 
 data ClientStatus =
-    SendClientHello ClientHello
+    SendClientHello
   | RecvServerHello
-  | SendClientFinished Finished
+  | SendClientFinished
   | RecvSessionTicket
   | ClientHandshakeDone
 
@@ -78,10 +78,10 @@ data ClientStatusI =
   | ClientHandshakeFailedI TLSError
 
 data ServerStatus =
-    SendRequestRetry ServerHello
-  | SendServerHello ServerHello
-  | SendServerFinished Finished
-  | SendSessionTicket SessionTicket
+    SendRequestRetry
+  | SendServerHello
+  | SendServerFinished
+  | SendSessionTicket
   | ServerHandshakeDone
 
 instance Show ServerStatus where

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -1,0 +1,155 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Network.TLS.Handshake.Control (
+    ClientControl(..)
+  , ServerControl(..)
+  , ClientStatus(..)
+  , ClientStatusI(..)
+  , ServerStatus(..)
+  , ServerStatusI(..)
+  , NegotiatedProtocol
+  , ClientHello
+  , ServerHello
+  , Finished
+  , SessionTicket
+  , HandshakeSync(..)
+  , putRecordWith
+  , handshakeCheck
+  ) where
+
+import Network.TLS.Cipher
+import Network.TLS.Imports
+import Network.TLS.Struct
+import Network.TLS.Struct13
+import Network.TLS.Types
+
+import qualified Data.ByteString as B
+import Data.IORef
+
+----------------------------------------------------------------
+
+type NegotiatedProtocol = ByteString
+type ClientHello = ByteString
+type ServerHello = ByteString
+type Finished = ByteString
+type SessionTicket = ByteString
+
+----------------------------------------------------------------
+
+data ClientControl = GetClientHello                 -- ^ 'SendClientHello'
+                   | PutServerHello ServerHello     -- ^ 'SendClientHello', 'RecvServerHello', 'ClientNeedsMore'
+                   | PutServerFinished Finished     -- ^ 'SendClientFinished'
+                   | PutSessionTicket SessionTicket -- ^ 'RecvSessionTicket'
+                   | ExitClient                     -- ^ 'ClientHandshakeDone'
+
+data ServerControl = PutClientHello ClientHello -- ^ 'SendRequestRetry', 'SendServerHello', 'ServerNeedsMore'
+                   | GetServerFinished          -- ^ 'SendServerFinished'
+                   | PutClientFinished Finished -- ^ 'SendSessionTicket', 'ServerNeedsMore'
+                   | ExitServer                 -- ^ 'ServerHandshakeDone'
+
+data ClientStatus =
+    ClientNeedsMore
+  | SendClientHello ClientHello (Maybe (ClientTrafficSecret EarlySecret))
+  | RecvServerHello Cipher (TrafficSecrets HandshakeSecret)
+  | SendClientFinished Finished [ExtensionRaw] (Maybe NegotiatedProtocol) (TrafficSecrets ApplicationSecret)
+  | RecvSessionTicket
+  | ClientHandshakeDone
+
+instance Show ClientStatus where
+    show ClientNeedsMore{}     = "ClientNeedsMore"
+    show SendClientHello{}     = "SendClientHello"
+    show RecvServerHello{}     = "RecvServerHello"
+    show SendClientFinished{}  = "SendClientFinished"
+    show RecvSessionTicket{}   = "RecvSessionTicket"
+    show ClientHandshakeDone{} = "ClientHandshakeDone"
+
+data ClientStatusI =
+    SendClientHelloI (Maybe (ClientTrafficSecret EarlySecret))
+  | RecvServerHelloI Cipher (TrafficSecrets HandshakeSecret)
+  | SendClientFinishedI [ExtensionRaw] (Maybe NegotiatedProtocol) (TrafficSecrets ApplicationSecret)
+  | RecvSessionTicketI
+
+data ServerStatus =
+    ServerNeedsMore
+  | SendRequestRetry ServerHello
+  | SendServerHello ServerHello
+                    [ExtensionRaw]
+                    Cipher
+                    (Maybe (ClientTrafficSecret EarlySecret))
+                    (TrafficSecrets HandshakeSecret)
+  | SendServerFinished Finished
+                       (Maybe NegotiatedProtocol)
+                       (TrafficSecrets ApplicationSecret)
+  | SendSessionTicket SessionTicket
+  | ServerHandshakeDone
+
+instance Show ServerStatus where
+    show ServerNeedsMore{}     = "ServerNeedsMore"
+    show SendRequestRetry{}    = "SendRequestRetry"
+    show SendServerHello{}     = "SendServerHello"
+    show SendServerFinished{}  = "SendServerFinished"
+    show SendSessionTicket{}   = "SendSessionTicket"
+    show ServerHandshakeDone{} = "ServerHandshakeDone"
+
+data ServerStatusI =
+    SendRequestRetryI
+  | SendServerHelloI [ExtensionRaw]
+                     Cipher
+                     (Maybe (ClientTrafficSecret EarlySecret))
+                     (TrafficSecrets HandshakeSecret)
+  | SendServerFinishedI (Maybe NegotiatedProtocol)
+                        (TrafficSecrets ApplicationSecret)
+  | SendSessionTicketI
+
+----------------------------------------------------------------
+
+data HandshakeSync = HandshakeSync (ClientStatusI -> IO ())
+                                   (ServerStatusI -> IO ())
+
+----------------------------------------------------------------
+
+putRecordWith :: (ByteString -> IO ())
+              -> IORef (Maybe ByteString)
+              -> ByteString
+              -> HandshakeType13
+              -> a
+              -> IO a
+              -> IO a
+putRecordWith put ref bs1 htyp needsMore body = do
+    mbs0 <- readIORef ref
+    let bs = case mbs0 of
+          Nothing  -> bs1
+          Just bs0 -> bs0 `B.append` bs1
+    (done,mbs) <- handshakeCheck put htyp bs
+    writeIORef ref mbs
+    if done then body else return needsMore
+
+handshakeCheck :: (ByteString -> IO ()) -> HandshakeType13 -> ByteString
+               -> IO (Bool, Maybe ByteString)
+handshakeCheck put htyp bs0 = loop bs0
+  where
+    loop bs
+      | B.length bs < 4 = return (False, Just bs)
+    loop bs = case B.length bs `compare` (len + 4) of
+          EQ | typ == styp -> do
+                   put bs
+                   return (True, Nothing)
+             | otherwise   -> do
+                   put bs
+                   return (False, Nothing)
+          GT | typ == styp -> do
+                   let (record, rest) = B.splitAt (len + 4) bs
+                   put record
+                   return (True, Just rest)
+             | otherwise   -> do
+                   let (record, rest) = B.splitAt (len + 4) bs
+                   put record
+                   loop rest
+          LT               -> return (False, Just bs)
+      where
+        styp = valOfType htyp
+        typ  = bs `B.index` 0
+        len1 = fromIntegral (bs `B.index` 1)
+        len2 = fromIntegral (bs `B.index` 2)
+        len3 = fromIntegral (bs `B.index` 3)
+        len   = len1 * 65536 + len2 * 256 + len3

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -89,8 +89,8 @@ data ClientStatusI =
 data ServerStatus =
     ServerNeedsMore
   | SendRequestRetry ServerHello
-  | SendServerHello ServerHello (Maybe EarlySecretInfo) HandshakeSecretInfo
-  | SendServerFinished Finished ApplicationSecretInfo
+  | SendServerHello ServerHello
+  | SendServerFinished Finished
   | SendSessionTicket SessionTicket
   | ServerHandshakeDone
 

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -18,6 +18,7 @@ module Network.TLS.Handshake.Control (
   ) where
 
 import Network.TLS.Cipher
+import Network.TLS.Handshake.State
 import Network.TLS.Imports
 import Network.TLS.Struct
 import Network.TLS.Struct13
@@ -52,7 +53,7 @@ data ClientStatus =
     ClientNeedsMore
   | SendClientHello ClientHello (Maybe (ClientTrafficSecret EarlySecret))
   | RecvServerHello Cipher (TrafficSecrets HandshakeSecret)
-  | SendClientFinished Finished [ExtensionRaw] (Maybe NegotiatedProtocol) (TrafficSecrets ApplicationSecret)
+  | SendClientFinished Finished [ExtensionRaw] (Maybe NegotiatedProtocol) (TrafficSecrets ApplicationSecret) HandshakeMode13
   | RecvSessionTicket
   | ClientHandshakeDone
 
@@ -67,7 +68,7 @@ instance Show ClientStatus where
 data ClientStatusI =
     SendClientHelloI (Maybe (ClientTrafficSecret EarlySecret))
   | RecvServerHelloI Cipher (TrafficSecrets HandshakeSecret)
-  | SendClientFinishedI [ExtensionRaw] (Maybe NegotiatedProtocol) (TrafficSecrets ApplicationSecret)
+  | SendClientFinishedI [ExtensionRaw] (Maybe NegotiatedProtocol) (TrafficSecrets ApplicationSecret) HandshakeMode13
   | RecvSessionTicketI
   | ClientHandshakeFailedI TLSError
 
@@ -82,7 +83,7 @@ data ServerStatus =
   | SendServerFinished Finished
                        (Maybe NegotiatedProtocol)
                        (TrafficSecrets ApplicationSecret)
-  | SendSessionTicket SessionTicket
+  | SendSessionTicket SessionTicket HandshakeMode13
   | ServerHandshakeDone
 
 instance Show ServerStatus where
@@ -101,7 +102,7 @@ data ServerStatusI =
                      (TrafficSecrets HandshakeSecret)
   | SendServerFinishedI (Maybe NegotiatedProtocol)
                         (TrafficSecrets ApplicationSecret)
-  | SendSessionTicketI
+  | SendSessionTicketI HandshakeMode13
   | ServerHandshakeFailedI TLSError
 
 ----------------------------------------------------------------

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -11,10 +11,6 @@ module Network.TLS.Handshake.Control (
   , HandshakeSecretInfo(..)
   , ApplicationSecretInfo(..)
   , NegotiatedProtocol
-  , ClientHello
-  , ServerHello
-  , Finished
-  , SessionTicket
   , HandshakeSync(..)
   ) where
 
@@ -27,12 +23,6 @@ import Network.TLS.Types
 ----------------------------------------------------------------
 
 type NegotiatedProtocol = ByteString
-type ClientHello = ByteString
-type ServerHello = ByteString
-type Finished = ByteString
-type SessionTicket = ByteString
-
-----------------------------------------------------------------
 
 data EarlySecretInfo = EarlySecretInfo Cipher (ClientTrafficSecret EarlySecret)
                        deriving (Eq, Show)
@@ -71,13 +61,11 @@ data ClientStatusI =
   | ClientHandshakeFailedI TLSError
 
 data ServerStatus =
-    SendRequestRetry
-  | SendServerFinished
+    SendServerFinished
   | SendSessionTicket
   | ServerHandshakeDone
 
 instance Show ServerStatus where
-    show SendRequestRetry{}    = "SendRequestRetry"
     show SendServerFinished{}  = "SendServerFinished"
     show SendSessionTicket{}   = "SendSessionTicket"
     show ServerHandshakeDone{} = "ServerHandshakeDone"

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Network.TLS.Handshake.Control (
     ClientControl(..)
   , ServerControl(..)
@@ -35,17 +33,17 @@ data ApplicationSecretInfo = ApplicationSecretInfo HandshakeMode13 (Maybe Negoti
 
 ----------------------------------------------------------------
 
-data ClientControl = GetClientHello       -- ^ 'SendClientFinished'
-                   | PutSessionTicket     -- ^ 'RecvSessionTicket'
+data ClientControl = EnterClient          -- ^ 'ClientHandshakeComplete', 'ClientHandshakeFailed'
+                   | RecvSessionTickets   -- ^ 'ClientRecvSessionTicket', 'ClientHandshakeFailed'
                    | ExitClient           -- ^ 'ClientHandshakeDone'
 
-data ServerControl = PutClientHello       -- ^ 'SendServerFinished'
-                   | PutClientFinished    -- ^ 'SendSessionTicket'
+data ServerControl = EnterServer          -- ^ 'ServerFinishedSent', 'ServerHandshakeFailed'
+                   | CompleteServer       -- ^ 'ServerHandshakeComplete', 'ServerHandshakeFailed'
                    | ExitServer           -- ^ 'ServerHandshakeDone'
 
 data ClientStatus =
-    SendClientFinished
-  | RecvSessionTicket
+    ClientHandshakeComplete
+  | ClientRecvSessionTicket
   | ClientHandshakeDone
   | ClientHandshakeFailed TLSError
   deriving Show
@@ -58,8 +56,8 @@ data ClientStatusI =
   | ClientHandshakeFailedI TLSError
 
 data ServerStatus =
-    SendServerFinished
-  | SendSessionTicket
+    ServerFinishedSent
+  | ServerHandshakeComplete
   | ServerHandshakeDone
   | ServerHandshakeFailed TLSError
   deriving Show

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -67,7 +67,7 @@ data ClientStatus =
     ClientNeedsMore
   | SendClientHello ClientHello (Maybe EarlySecretInfo)
   | RecvServerHello HandshakeSecretInfo
-  | SendClientFinished Finished [ExtensionRaw] ApplicationSecretInfo
+  | SendClientFinished Finished ApplicationSecretInfo
   | RecvSessionTicket
   | ClientHandshakeDone
 
@@ -89,7 +89,7 @@ data ClientStatusI =
 data ServerStatus =
     ServerNeedsMore
   | SendRequestRetry ServerHello
-  | SendServerHello ServerHello [ExtensionRaw] (Maybe EarlySecretInfo) HandshakeSecretInfo
+  | SendServerHello ServerHello (Maybe EarlySecretInfo) HandshakeSecretInfo
   | SendServerFinished Finished ApplicationSecretInfo
   | SendSessionTicket SessionTicket
   | ServerHandshakeDone

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -25,13 +25,13 @@ import Network.TLS.Types
 type NegotiatedProtocol = ByteString
 
 data EarlySecretInfo = EarlySecretInfo Cipher (ClientTrafficSecret EarlySecret)
-                       deriving (Eq, Show)
+                       deriving Show
 
 data HandshakeSecretInfo = HandshakeSecretInfo Cipher (TrafficSecrets HandshakeSecret)
-                         deriving (Eq, Show)
+                         deriving Show
 
 data ApplicationSecretInfo = ApplicationSecretInfo HandshakeMode13 (Maybe NegotiatedProtocol) (TrafficSecrets ApplicationSecret)
-                         deriving (Eq, Show)
+                         deriving Show
 
 ----------------------------------------------------------------
 

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -16,20 +16,13 @@ module Network.TLS.Handshake.Control (
   , Finished
   , SessionTicket
   , HandshakeSync(..)
-  , putRecordWith
-  , handshakeCheck
   ) where
 
 import Network.TLS.Cipher
 import Network.TLS.Handshake.State
 import Network.TLS.Imports
 import Network.TLS.Struct
-import Network.TLS.Struct13
 import Network.TLS.Types
-
-import qualified Control.Exception as E
-import qualified Data.ByteString as B
-import Data.IORef
 
 ----------------------------------------------------------------
 
@@ -52,27 +45,25 @@ data ApplicationSecretInfo = ApplicationSecretInfo HandshakeMode13 (Maybe Negoti
 
 ----------------------------------------------------------------
 
-data ClientControl = GetClientHello                 -- ^ 'SendClientHello'
-                   | PutServerHello ServerHello     -- ^ 'SendClientHello', 'RecvServerHello', 'ClientNeedsMore'
-                   | PutServerFinished Finished     -- ^ 'SendClientFinished'
-                   | PutSessionTicket SessionTicket -- ^ 'RecvSessionTicket'
-                   | ExitClient                     -- ^ 'ClientHandshakeDone'
+data ClientControl = GetClientHello       -- ^ 'SendClientHello'
+                   | PutServerHello       -- ^ 'SendClientHello', 'RecvServerHello'
+                   | PutServerFinished    -- ^ 'SendClientFinished'
+                   | PutSessionTicket     -- ^ 'RecvSessionTicket'
+                   | ExitClient           -- ^ 'ClientHandshakeDone'
 
-data ServerControl = PutClientHello ClientHello -- ^ 'SendRequestRetry', 'SendServerHello', 'ServerNeedsMore'
-                   | GetServerFinished          -- ^ 'SendServerFinished'
-                   | PutClientFinished Finished -- ^ 'SendSessionTicket', 'ServerNeedsMore'
-                   | ExitServer                 -- ^ 'ServerHandshakeDone'
+data ServerControl = PutClientHello       -- ^ 'SendRequestRetry', 'SendServerHello'
+                   | GetServerFinished    -- ^ 'SendServerFinished'
+                   | PutClientFinished    -- ^ 'SendSessionTicket'
+                   | ExitServer           -- ^ 'ServerHandshakeDone'
 
 data ClientStatus =
-    ClientNeedsMore
-  | SendClientHello ClientHello
+    SendClientHello ClientHello
   | RecvServerHello
   | SendClientFinished Finished
   | RecvSessionTicket
   | ClientHandshakeDone
 
 instance Show ClientStatus where
-    show ClientNeedsMore{}     = "ClientNeedsMore"
     show SendClientHello{}     = "SendClientHello"
     show RecvServerHello{}     = "RecvServerHello"
     show SendClientFinished{}  = "SendClientFinished"
@@ -87,15 +78,13 @@ data ClientStatusI =
   | ClientHandshakeFailedI TLSError
 
 data ServerStatus =
-    ServerNeedsMore
-  | SendRequestRetry ServerHello
+    SendRequestRetry ServerHello
   | SendServerHello ServerHello
   | SendServerFinished Finished
   | SendSessionTicket SessionTicket
   | ServerHandshakeDone
 
 instance Show ServerStatus where
-    show ServerNeedsMore{}     = "ServerNeedsMore"
     show SendRequestRetry{}    = "SendRequestRetry"
     show SendServerHello{}     = "SendServerHello"
     show SendServerFinished{}  = "SendServerFinished"
@@ -113,52 +102,3 @@ data ServerStatusI =
 
 data HandshakeSync = HandshakeSync (ClientStatusI -> IO ())
                                    (ServerStatusI -> IO ())
-
-----------------------------------------------------------------
-
-putRecordWith :: (ByteString -> IO ())
-              -> IORef (Maybe ByteString)
-              -> ByteString
-              -> HandshakeType13
-              -> a
-              -> IO a
-              -> IO a
-putRecordWith put ref bs1 htyp needsMore body = do
-    mbs0 <- readIORef ref
-    let bs = case mbs0 of
-          Nothing  -> bs1
-          Just bs0 -> bs0 `B.append` bs1
-    (done,mbs) <- handshakeCheck put htyp bs
-    writeIORef ref mbs
-    if done then body else return needsMore
-
-handshakeCheck :: (ByteString -> IO ()) -> HandshakeType13 -> ByteString
-               -> IO (Bool, Maybe ByteString)
-handshakeCheck put htyp bs0 = loop bs0
-  where
-    loop bs
-      | B.length bs < 4 = return (False, Just bs)
-    loop bs = case mhtyp0 of
-      Nothing    -> E.throwIO $ Error_Packet_Parsing "Unknown Handshake13 type"
-      Just htyp0 -> case B.length bs `compare` (len + 4) of
-          EQ | htyp == htyp0 -> do
-                   put bs
-                   return (True, Nothing)
-             | otherwise   -> do
-                   put bs
-                   return (False, Nothing)
-          GT | htyp == htyp0 -> do
-                   let (record, rest) = B.splitAt (len + 4) bs
-                   put record
-                   return (True, Just rest)
-             | otherwise   -> do
-                   let (record, rest) = B.splitAt (len + 4) bs
-                   put record
-                   loop rest
-          LT               -> return (False, Just bs)
-      where
-        mhtyp0 = valToType (bs `B.index` 0)
-        len1 = fromIntegral (bs `B.index` 1)
-        len2 = fromIntegral (bs `B.index` 2)
-        len3 = fromIntegral (bs `B.index` 3)
-        len   = len1 * 65536 + len2 * 256 + len3

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -47,11 +47,8 @@ data ClientStatus =
     SendClientFinished
   | RecvSessionTicket
   | ClientHandshakeDone
-
-instance Show ClientStatus where
-    show SendClientFinished{}  = "SendClientFinished"
-    show RecvSessionTicket{}   = "RecvSessionTicket"
-    show ClientHandshakeDone{} = "ClientHandshakeDone"
+  | ClientHandshakeFailed TLSError
+  deriving Show
 
 data ClientStatusI =
     SendClientHelloI (Maybe EarlySecretInfo)
@@ -64,11 +61,8 @@ data ServerStatus =
     SendServerFinished
   | SendSessionTicket
   | ServerHandshakeDone
-
-instance Show ServerStatus where
-    show SendServerFinished{}  = "SendServerFinished"
-    show SendSessionTicket{}   = "SendSessionTicket"
-    show ServerHandshakeDone{} = "ServerHandshakeDone"
+  | ServerHandshakeFailed TLSError
+  deriving Show
 
 data ServerStatusI =
     SendServerHelloI [ExtensionRaw] (Maybe EarlySecretInfo) HandshakeSecretInfo

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -69,6 +69,7 @@ data ClientStatusI =
   | RecvServerHelloI Cipher (TrafficSecrets HandshakeSecret)
   | SendClientFinishedI [ExtensionRaw] (Maybe NegotiatedProtocol) (TrafficSecrets ApplicationSecret)
   | RecvSessionTicketI
+  | ClientHandshakeFailedI TLSError
 
 data ServerStatus =
     ServerNeedsMore
@@ -101,6 +102,7 @@ data ServerStatusI =
   | SendServerFinishedI (Maybe NegotiatedProtocol)
                         (TrafficSecrets ApplicationSecret)
   | SendSessionTicketI
+  | ServerHandshakeFailedI TLSError
 
 ----------------------------------------------------------------
 

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -45,9 +45,7 @@ data ApplicationSecretInfo = ApplicationSecretInfo HandshakeMode13 (Maybe Negoti
 
 ----------------------------------------------------------------
 
-data ClientControl = GetClientHello       -- ^ 'SendClientHello'
-                   | PutServerHello       -- ^ 'SendClientHello', 'RecvServerHello'
-                   | PutServerFinished    -- ^ 'SendClientFinished'
+data ClientControl = GetClientHello       -- ^ 'SendClientFinished'
                    | PutSessionTicket     -- ^ 'RecvSessionTicket'
                    | ExitClient           -- ^ 'ClientHandshakeDone'
 
@@ -56,15 +54,11 @@ data ServerControl = PutClientHello       -- ^ 'SendServerFinished'
                    | ExitServer           -- ^ 'ServerHandshakeDone'
 
 data ClientStatus =
-    SendClientHello
-  | RecvServerHello
-  | SendClientFinished
+    SendClientFinished
   | RecvSessionTicket
   | ClientHandshakeDone
 
 instance Show ClientStatus where
-    show SendClientHello{}     = "SendClientHello"
-    show RecvServerHello{}     = "RecvServerHello"
     show SendClientFinished{}  = "SendClientFinished"
     show RecvSessionTicket{}   = "RecvSessionTicket"
     show ClientHandshakeDone{} = "ClientHandshakeDone"

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -51,8 +51,7 @@ data ClientControl = GetClientHello       -- ^ 'SendClientHello'
                    | PutSessionTicket     -- ^ 'RecvSessionTicket'
                    | ExitClient           -- ^ 'ClientHandshakeDone'
 
-data ServerControl = PutClientHello       -- ^ 'SendRequestRetry', 'SendServerHello'
-                   | GetServerFinished    -- ^ 'SendServerFinished'
+data ServerControl = PutClientHello       -- ^ 'SendServerFinished'
                    | PutClientFinished    -- ^ 'SendSessionTicket'
                    | ExitServer           -- ^ 'ServerHandshakeDone'
 
@@ -79,21 +78,18 @@ data ClientStatusI =
 
 data ServerStatus =
     SendRequestRetry
-  | SendServerHello
   | SendServerFinished
   | SendSessionTicket
   | ServerHandshakeDone
 
 instance Show ServerStatus where
     show SendRequestRetry{}    = "SendRequestRetry"
-    show SendServerHello{}     = "SendServerHello"
     show SendServerFinished{}  = "SendServerFinished"
     show SendSessionTicket{}   = "SendSessionTicket"
     show ServerHandshakeDone{} = "ServerHandshakeDone"
 
 data ServerStatusI =
-    SendRequestRetryI
-  | SendServerHelloI [ExtensionRaw] (Maybe EarlySecretInfo) HandshakeSecretInfo
+    SendServerHelloI [ExtensionRaw] (Maybe EarlySecretInfo) HandshakeSecretInfo
   | SendServerFinishedI ApplicationSecretInfo
   | SendSessionTicketI
   | ServerHandshakeFailedI TLSError

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -65,9 +65,9 @@ data ServerControl = PutClientHello ClientHello -- ^ 'SendRequestRetry', 'SendSe
 
 data ClientStatus =
     ClientNeedsMore
-  | SendClientHello ClientHello (Maybe EarlySecretInfo)
-  | RecvServerHello HandshakeSecretInfo
-  | SendClientFinished Finished ApplicationSecretInfo
+  | SendClientHello ClientHello
+  | RecvServerHello
+  | SendClientFinished Finished
   | RecvSessionTicket
   | ClientHandshakeDone
 

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -83,7 +83,8 @@ data ServerStatus =
   | SendServerFinished Finished
                        (Maybe NegotiatedProtocol)
                        (TrafficSecrets ApplicationSecret)
-  | SendSessionTicket SessionTicket HandshakeMode13
+                       HandshakeMode13
+  | SendSessionTicket SessionTicket
   | ServerHandshakeDone
 
 instance Show ServerStatus where
@@ -102,7 +103,8 @@ data ServerStatusI =
                      (TrafficSecrets HandshakeSecret)
   | SendServerFinishedI (Maybe NegotiatedProtocol)
                         (TrafficSecrets ApplicationSecret)
-  | SendSessionTicketI HandshakeMode13
+                        HandshakeMode13
+  | SendSessionTicketI
   | ServerHandshakeFailedI TLSError
 
 ----------------------------------------------------------------

--- a/core/Network/TLS/Handshake/QUIC.hs
+++ b/core/Network/TLS/Handshake/QUIC.hs
@@ -63,29 +63,22 @@ quicClient :: Weak ThreadId
 quicClient _ ask get _ _ GetClientHello = do
     rsp <- ask
     case rsp of
-      SendClientHelloI early -> do
-          ch <- get
-          return $ SendClientHello ch early
+      SendClientHelloI _ -> SendClientHello <$> get
       ClientHandshakeFailedI e -> E.throwIO e
       _ -> error "quicClient"
 quicClient _ ask get put ref (PutServerHello sh) =
     putRecordWith put ref sh HandshakeType_ServerHello13 ClientNeedsMore $ do
         rsp <- ask
         case rsp of
-            SendClientHelloI early -> do
-                ch <- get
-                return $ SendClientHello ch early
-            RecvServerHelloI handSec -> do
-                return $ RecvServerHello handSec
+            SendClientHelloI _ -> SendClientHello <$> get
+            RecvServerHelloI _ -> return RecvServerHello
             ClientHandshakeFailedI e -> E.throwIO e
             _ -> error "quicClient"
 quicClient _ ask get put ref (PutServerFinished sf) =
     putRecordWith put ref sf HandshakeType_Finished13 ClientNeedsMore $ do
         rsp <- ask
         case rsp of
-          SendClientFinishedI _ appSec -> do
-              cf <- get
-              return $ SendClientFinished cf appSec
+          SendClientFinishedI _ _ -> SendClientFinished <$> get
           ClientHandshakeFailedI e -> E.throwIO e
           _ -> error "quicClient"
 quicClient _ ask _ put ref (PutSessionTicket nst) =

--- a/core/Network/TLS/Handshake/QUIC.hs
+++ b/core/Network/TLS/Handshake/QUIC.hs
@@ -15,13 +15,6 @@ quicServer :: Weak ThreadId
            -> IO ServerStatusI
            -> ServerController
 quicServer _ ask PutClientHello = do
-        rsp <- ask
-        case rsp of
-          SendRequestRetryI -> return SendRequestRetry
-          SendServerHelloI{} -> return SendServerHello
-          ServerHandshakeFailedI e -> E.throwIO e
-          _ -> error "quicServer"
-quicServer _ ask GetServerFinished = do
     rsp <- ask
     case rsp of
       SendServerFinishedI _ -> return SendServerFinished

--- a/core/Network/TLS/Handshake/QUIC.hs
+++ b/core/Network/TLS/Handshake/QUIC.hs
@@ -4,11 +4,9 @@ module Network.TLS.Handshake.QUIC where
 
 import Network.TLS.Handshake.Control
 import Network.TLS.Imports
-import Network.TLS.Struct13
 
 import Control.Concurrent
 import qualified Control.Exception as E
-import Data.IORef
 import System.Mem.Weak
 
 type ServerController = ServerControl -> IO ServerStatus
@@ -17,31 +15,27 @@ type ClientController = ClientControl -> IO ClientStatus
 quicServer :: Weak ThreadId
            -> IO ServerStatusI
            -> IO ByteString
-           -> (ByteString -> IO ())
-           -> IORef (Maybe ByteString)
            -> ServerController
-quicServer _ ask get put ref (PutClientHello ch) =
-    putRecordWith put ref ch HandshakeType_ClientHello13 ServerNeedsMore $ do
+quicServer _ ask get PutClientHello = do
         rsp <- ask
         case rsp of
           SendRequestRetryI -> SendRequestRetry <$> get
           SendServerHelloI{} -> SendServerHello <$> get
           ServerHandshakeFailedI e -> E.throwIO e
           _ -> error "quicServer"
-quicServer _ ask get _ _ GetServerFinished = do
+quicServer _ ask get GetServerFinished = do
     rsp <- ask
     case rsp of
       SendServerFinishedI _ -> SendServerFinished <$> get
       ServerHandshakeFailedI e -> E.throwIO e
       _ -> error "quicServer"
-quicServer _ ask get put ref (PutClientFinished cf) =
-    putRecordWith put ref cf HandshakeType_Finished13 ServerNeedsMore $ do
+quicServer _ ask get PutClientFinished = do
         rsp <- ask
         case rsp of
           SendSessionTicketI -> SendSessionTicket <$> get
           ServerHandshakeFailedI e -> E.throwIO e
           _ -> error "quicServer"
-quicServer wtid _ _ _ _ ExitServer = do
+quicServer wtid _ _ ExitServer = do
     mtid <- deRefWeak wtid
     case mtid of
       Nothing  -> return ()
@@ -51,38 +45,33 @@ quicServer wtid _ _ _ _ ExitServer = do
 quicClient :: Weak ThreadId
            -> IO ClientStatusI
            -> IO ByteString
-           -> (ByteString -> IO ())
-           -> IORef (Maybe ByteString)
            -> ClientController
-quicClient _ ask get _ _ GetClientHello = do
+quicClient _ ask get GetClientHello = do
     rsp <- ask
     case rsp of
       SendClientHelloI _ -> SendClientHello <$> get
       ClientHandshakeFailedI e -> E.throwIO e
       _ -> error "quicClient"
-quicClient _ ask get put ref (PutServerHello sh) =
-    putRecordWith put ref sh HandshakeType_ServerHello13 ClientNeedsMore $ do
+quicClient _ ask get PutServerHello = do
         rsp <- ask
         case rsp of
             SendClientHelloI _ -> SendClientHello <$> get
             RecvServerHelloI _ -> return RecvServerHello
             ClientHandshakeFailedI e -> E.throwIO e
             _ -> error "quicClient"
-quicClient _ ask get put ref (PutServerFinished sf) =
-    putRecordWith put ref sf HandshakeType_Finished13 ClientNeedsMore $ do
+quicClient _ ask get PutServerFinished = do
         rsp <- ask
         case rsp of
           SendClientFinishedI _ _ -> SendClientFinished <$> get
           ClientHandshakeFailedI e -> E.throwIO e
           _ -> error "quicClient"
-quicClient _ ask _ put ref (PutSessionTicket nst) =
-    putRecordWith put ref nst HandshakeType_NewSessionTicket13 ClientNeedsMore $ do
+quicClient _ ask _ PutSessionTicket = do
         rsp <- ask
         case rsp of
           RecvSessionTicketI -> return RecvSessionTicket
           ClientHandshakeFailedI e -> E.throwIO e
           _ -> error "quicClient"
-quicClient wtid _ _ _ _ ExitClient = do
+quicClient wtid _ _ ExitClient = do
     mtid <- deRefWeak wtid
     case mtid of
       Nothing  -> return ()

--- a/core/Network/TLS/Handshake/QUIC.hs
+++ b/core/Network/TLS/Handshake/QUIC.hs
@@ -5,52 +5,29 @@ module Network.TLS.Handshake.QUIC where
 import Network.TLS.Handshake.Control
 
 import Control.Concurrent
-import qualified Control.Exception as E
 import System.Mem.Weak
 
 type ServerController = ServerControl -> IO ServerStatus
 type ClientController = ClientControl -> IO ClientStatus
 
 quicServer :: Weak ThreadId
-           -> IO ServerStatusI
+           -> IO ServerStatus
            -> ServerController
-quicServer _ ask PutClientHello = do
-    rsp <- ask
-    case rsp of
-      SendServerFinishedI _ -> return SendServerFinished
-      ServerHandshakeFailedI e -> E.throwIO e
-      _ -> error "quicServer"
-quicServer _ ask PutClientFinished = do
-        rsp <- ask
-        case rsp of
-          SendSessionTicketI -> return SendSessionTicket
-          ServerHandshakeFailedI e -> E.throwIO e
-          _ -> error "quicServer"
 quicServer wtid _ ExitServer = do
     mtid <- deRefWeak wtid
     case mtid of
       Nothing  -> return ()
       Just tid -> killThread tid
     return ServerHandshakeDone
+quicServer _ ask _ = ask
 
 quicClient :: Weak ThreadId
-           -> IO ClientStatusI
+           -> IO ClientStatus
            -> ClientController
-quicClient _ ask GetClientHello = do
-        rsp <- ask
-        case rsp of
-          SendClientFinishedI _ _ -> return SendClientFinished
-          ClientHandshakeFailedI e -> E.throwIO e
-          _ -> error "quicClient"
-quicClient _ ask PutSessionTicket = do
-        rsp <- ask
-        case rsp of
-          RecvSessionTicketI -> return RecvSessionTicket
-          ClientHandshakeFailedI e -> E.throwIO e
-          _ -> error "quicClient"
 quicClient wtid _ ExitClient = do
     mtid <- deRefWeak wtid
     case mtid of
       Nothing  -> return ()
       Just tid -> killThread tid
     return ClientHandshakeDone
+quicClient _ ask _ = ask

--- a/core/Network/TLS/Handshake/QUIC.hs
+++ b/core/Network/TLS/Handshake/QUIC.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Network.TLS.Handshake.QUIC where
+
+import Network.TLS.Extension
+import Network.TLS.Handshake.Control
+import Network.TLS.Imports
+import Network.TLS.Struct
+import Network.TLS.Struct13
+
+import Control.Concurrent
+import Data.IORef
+
+type ServerController = ServerControl -> IO ServerStatus
+type ClientController = ClientControl -> IO ClientStatus
+
+quicServer :: ThreadId
+           -> IO ServerStatusI
+           -> IO ByteString
+           -> (ByteString -> IO ())
+           -> IORef (Maybe ByteString)
+           -> ServerController
+quicServer _ ask get put ref (PutClientHello ch) =
+    putRecordWith put ref ch HandshakeType_ClientHello13 ServerNeedsMore $ do
+        rsp <- ask
+        case rsp of
+          SendRequestRetryI -> SendRequestRetry <$> get
+          SendServerHelloI exts cipher earlySec hndSecs -> do
+              sh <- get
+              let exts' = filter (\(ExtensionRaw eid _) -> eid == extensionID_QuicTransportParameters) exts
+              return $ SendServerHello sh exts' cipher earlySec hndSecs
+          _ -> error "quicServer"
+quicServer _ ask get _ _ GetServerFinished = do
+    rsp <- ask
+    case rsp of
+      SendServerFinishedI alpn appSecs -> do
+          sf <- get
+          return $ SendServerFinished sf alpn appSecs
+      _ -> error "quicServer"
+quicServer _ ask get put ref (PutClientFinished cf) =
+    putRecordWith put ref cf HandshakeType_Finished13 ServerNeedsMore $ do
+        rsp <- ask
+        case rsp of
+          SendSessionTicketI -> SendSessionTicket <$> get
+          _ -> error "quicServer"
+quicServer tid _ _ _ _ ExitServer = do
+    killThread tid
+    return ServerHandshakeDone
+
+quicClient :: ThreadId
+           -> IO ClientStatusI
+           -> IO ByteString
+           -> (ByteString -> IO ())
+           -> IORef (Maybe ByteString)
+           -> ClientController
+quicClient _ ask get _ _ GetClientHello = do
+    rsp <- ask
+    case rsp of
+      SendClientHelloI early -> do
+          ch <- get
+          return $ SendClientHello ch early
+      _ -> error "quicClient"
+quicClient _ ask get put ref (PutServerHello sh) =
+    putRecordWith put ref sh HandshakeType_ServerHello13 ClientNeedsMore $ do
+        rsp <- ask
+        case rsp of
+            SendClientHelloI early -> do
+                ch <- get
+                return $ SendClientHello ch early
+            RecvServerHelloI c handSecs -> do
+                return $ RecvServerHello c handSecs
+            _ -> error "quicClient"
+quicClient _ ask get put ref (PutServerFinished sf) =
+    putRecordWith put ref sf HandshakeType_Finished13 ClientNeedsMore $ do
+        rsp <- ask
+        case rsp of
+          SendClientFinishedI exts alpn appSecs -> do
+              let exts' = filter (\(ExtensionRaw eid _) -> eid == extensionID_QuicTransportParameters) exts
+              cf <- get
+              return $ SendClientFinished cf exts' alpn appSecs
+          _ -> error "quicClient"
+quicClient _ ask _ put ref (PutSessionTicket nst) =
+    putRecordWith put ref nst HandshakeType_NewSessionTicket13 ClientNeedsMore $ do
+        rsp <- ask
+        case rsp of
+          RecvSessionTicketI -> return RecvSessionTicket
+          _ -> error "quicClient"
+quicClient tid _ _ _ _ ExitClient = do
+    killThread tid
+    return ClientHandshakeDone

--- a/core/Network/TLS/Handshake/QUIC.hs
+++ b/core/Network/TLS/Handshake/QUIC.hs
@@ -36,18 +36,18 @@ quicServer _ ask get put ref (PutClientHello ch) =
 quicServer _ ask get _ _ GetServerFinished = do
     rsp <- ask
     case rsp of
-      SendServerFinishedI alpn appSecs -> do
+      SendServerFinishedI alpn appSecs mode -> do
           sf <- get
-          return $ SendServerFinished sf alpn appSecs
+          return $ SendServerFinished sf alpn appSecs mode
       ServerHandshakeFailedI e -> E.throwIO e
       _ -> error "quicServer"
 quicServer _ ask get put ref (PutClientFinished cf) =
     putRecordWith put ref cf HandshakeType_Finished13 ServerNeedsMore $ do
         rsp <- ask
         case rsp of
-          SendSessionTicketI mode -> do
+          SendSessionTicketI -> do
               nst <- get
-              return $ SendSessionTicket nst mode
+              return $ SendSessionTicket nst
           ServerHandshakeFailedI e -> E.throwIO e
           _ -> error "quicServer"
 quicServer wtid _ _ _ _ ExitServer = do

--- a/core/Network/TLS/Handshake/QUIC.hs
+++ b/core/Network/TLS/Handshake/QUIC.hs
@@ -37,19 +37,6 @@ quicClient :: Weak ThreadId
            -> IO ClientStatusI
            -> ClientController
 quicClient _ ask GetClientHello = do
-    rsp <- ask
-    case rsp of
-      SendClientHelloI _ -> return SendClientHello
-      ClientHandshakeFailedI e -> E.throwIO e
-      _ -> error "quicClient"
-quicClient _ ask PutServerHello = do
-        rsp <- ask
-        case rsp of
-            SendClientHelloI _ -> return SendClientHello
-            RecvServerHelloI _ -> return RecvServerHello
-            ClientHandshakeFailedI e -> E.throwIO e
-            _ -> error "quicClient"
-quicClient _ ask PutServerFinished = do
         rsp <- ask
         case rsp of
           SendClientFinishedI _ _ -> return SendClientFinished

--- a/core/Network/TLS/Handshake/QUIC.hs
+++ b/core/Network/TLS/Handshake/QUIC.hs
@@ -25,26 +25,20 @@ quicServer _ ask get put ref (PutClientHello ch) =
         rsp <- ask
         case rsp of
           SendRequestRetryI -> SendRequestRetry <$> get
-          SendServerHelloI _ earlySec handSec  -> do
-              sh <- get
-              return $ SendServerHello sh earlySec handSec
+          SendServerHelloI{} -> SendServerHello <$> get
           ServerHandshakeFailedI e -> E.throwIO e
           _ -> error "quicServer"
 quicServer _ ask get _ _ GetServerFinished = do
     rsp <- ask
     case rsp of
-      SendServerFinishedI appSec -> do
-          sf <- get
-          return $ SendServerFinished sf appSec
+      SendServerFinishedI _ -> SendServerFinished <$> get
       ServerHandshakeFailedI e -> E.throwIO e
       _ -> error "quicServer"
 quicServer _ ask get put ref (PutClientFinished cf) =
     putRecordWith put ref cf HandshakeType_Finished13 ServerNeedsMore $ do
         rsp <- ask
         case rsp of
-          SendSessionTicketI -> do
-              nst <- get
-              return $ SendSessionTicket nst
+          SendSessionTicketI -> SendSessionTicket <$> get
           ServerHandshakeFailedI e -> E.throwIO e
           _ -> error "quicServer"
 quicServer wtid _ _ _ _ ExitServer = do

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -771,7 +771,13 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
         applicationSecret = triBase appKey
     setTxState ctx usedHash usedCipher serverApplicationSecret0
     alpn <- usingState_ ctx getNegotiatedProtocol
-    mode <- usingHState ctx getTLS13HandshakeMode
+    -- TLS13RTT0Status is not exposed, so needs to distinguish
+    -- RTT0 and PreSharedKey.
+    let mode
+         | rtt0OK                   = RTT0
+         | authenticated && not hrr = PreSharedKey
+         | hrr                      = HelloRetryRequest
+         | otherwise                = FullHandshake
     let appSecInfo = ApplicationSecretInfo mode alpn (cas,sas)
     contextSync ctx $ SendServerFinishedI appSecInfo
     ----------------------------------------------------------------

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -770,7 +770,8 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
         applicationSecret = triBase appKey
     setTxState ctx usedHash usedCipher serverApplicationSecret0
     alpn <- usingState_ ctx getNegotiatedProtocol
-    contextSync ctx $ SendServerFinishedI alpn (cas,sas)
+    mode <- usingHState ctx getTLS13HandshakeMode
+    contextSync ctx $ SendServerFinishedI alpn (cas,sas) mode
     ----------------------------------------------------------------
     if rtt0OK then
         setEstablished ctx (EarlyDataAllowed rtt0max)
@@ -782,8 +783,7 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
             handshakeTerminate13 ctx
             setRxState ctx usedHash usedCipher clientApplicationSecret0
             sendNewSessionTicket applicationSecret sfSentTime
-            mode <- usingHState ctx getTLS13HandshakeMode
-            contextSync ctx $ SendSessionTicketI mode
+            contextSync ctx $ SendSessionTicketI
         expectFinished _ hs = unexpected (show hs) (Just "finished 13")
 
     let expectEndOfEarlyData EndOfEarlyData13 =

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -11,6 +11,7 @@ module Network.TLS.Handshake.Server
     , handshakeServerWith
     , requestCertificateServer
     , postHandshakeAuthServerWith
+    , quicMaxEarlyDataSize
     ) where
 
 import Network.TLS.Parameters
@@ -804,7 +805,7 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
           unless skip $ recvHandshake13hash ctx (expectCertVerify sparams ctx)
           recvHandshake13hash ctx expectFinished
           ensureRecvComplete ctx
-      else if rtt0OK && rtt0max == 0xffffffff then
+      else if rtt0OK && rtt0max == quicMaxEarlyDataSize then
         setPendingActions ctx [PendingActionHash True expectFinished]
       else if rtt0OK then
         setPendingActions ctx [PendingAction True expectEndOfEarlyData
@@ -1197,3 +1198,7 @@ contextSync :: Context -> ServerStatusI -> IO ()
 contextSync ctx ctl = case ctxHandshakeSync ctx of
   Nothing                     -> return ()
   Just (HandshakeSync _ sync) -> sync ctl
+
+-- | Max early data size for QUIC.
+quicMaxEarlyDataSize :: Int
+quicMaxEarlyDataSize = 0xffffffff

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -1030,7 +1030,6 @@ helloRetryRequest sparams ctx chosenVersion usedCipher exts serverGroups clientS
           runPacketFlight ctx $ do
                 loadPacket13 ctx $ Handshake13 [hrr]
                 sendChangeCipherSpec13 ctx
-          contextSync ctx SendRequestRetryI
           handshakeServer sparams ctx
 
 findHighestVersionFrom :: Version -> [Version] -> Maybe Version

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -918,7 +918,12 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
         let earlyDataExtension
               | rtt0OK = Just $ ExtensionRaw extensionID_EarlyData $ extensionEncode (EarlyDataIndication Nothing)
               | otherwise = Nothing
-        let extensions = catMaybes [earlyDataExtension, groupExtension, sniExtension] ++ protoExt
+        let extensions = sharedExtensions (serverShared sparams)
+                      ++ catMaybes [earlyDataExtension
+                                   ,groupExtension
+                                   ,sniExtension
+                                   ]
+                      ++ protoExt
         loadPacket13 ctx $ Handshake13 [EncryptedExtensions13 extensions]
 
     sendNewSessionTicket applicationSecret sfSentTime = when sendNST $ do

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -748,7 +748,6 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
         let shs@(ServerTrafficSecret serverHandshakeSecret) = triServer handKey
             chs@(ClientTrafficSecret clientHandshakeSecret) = triClient handKey
             handSecret = triBase handKey
-        flushFlightIfNeeded ctx
         liftIO $ do
             if rtt0OK
                 then setRxState ctx usedHash usedCipher CryptEarlySecret clientEarlySecret

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -749,7 +749,7 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
             clientHandshakeSecret = triClient handKey
             handSecret = triBase handKey
         liftIO $ do
-            if rtt0OK
+            if rtt0OK && rtt0max /= quicMaxEarlyDataSize
                 then setRxState ctx usedHash usedCipher clientEarlySecret
                 else setRxState ctx usedHash usedCipher clientHandshakeSecret
             setTxState ctx usedHash usedCipher serverHandshakeSecret

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -798,6 +798,8 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
           unless skip $ recvHandshake13hash ctx (expectCertVerify sparams ctx)
           recvHandshake13hash ctx expectFinished
           ensureRecvComplete ctx
+      else if rtt0OK && rtt0max == 0xffffffff then
+        setPendingActions ctx [PendingActionHash True expectFinished]
       else if rtt0OK then
         setPendingActions ctx [PendingAction True expectEndOfEarlyData
                               ,PendingActionHash True expectFinished]

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -782,7 +782,8 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
             handshakeTerminate13 ctx
             setRxState ctx usedHash usedCipher clientApplicationSecret0
             sendNewSessionTicket applicationSecret sfSentTime
-            contextSync ctx SendSessionTicketI
+            mode <- usingHState ctx getTLS13HandshakeMode
+            contextSync ctx $ SendSessionTicketI mode
         expectFinished _ hs = unexpected (show hs) (Just "finished 13")
 
     let expectEndOfEarlyData EndOfEarlyData13 =

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -1178,7 +1178,9 @@ postHandshakeAuthServerWith sparams ctx h@(Certificate13 certCtx certs _ext) = d
     processHandshake13 ctx certReq
     processHandshake13 ctx h
 
-    (usedHash, _, CryptApplicationSecret, applicationSecretN) <- getRxState ctx
+    (usedHash, _, level, applicationSecretN) <- getRxState ctx
+    unless (level == CryptApplicationSecret) $
+        throwCore $ Error_Protocol ("tried post-handshake authentication without application traffic secret", True, InternalError)
 
     let expectFinished hChBeforeCf (Finished13 verifyData) = do
             checkFinished usedHash applicationSecretN hChBeforeCf verifyData

--- a/core/Network/TLS/Handshake/State.hs
+++ b/core/Network/TLS/Handshake/State.hs
@@ -482,12 +482,14 @@ computeKeyBlock hst masterSecret ver cc = (pendingTx, pendingRx)
         pendingTx = RecordState
                   { stCryptState  = if cc == ClientRole then cstClient else cstServer
                   , stMacState    = if cc == ClientRole then msClient else msServer
+                  , stCryptLevel  = CryptMasterSecret
                   , stCipher      = Just cipher
                   , stCompression = hstPendingCompression hst
                   }
         pendingRx = RecordState
                   { stCryptState  = if cc == ClientRole then cstServer else cstClient
                   , stMacState    = if cc == ClientRole then msServer else msClient
+                  , stCryptLevel  = CryptMasterSecret
                   , stCipher      = Just cipher
                   , stCompression = hstPendingCompression hst
                   }

--- a/core/Network/TLS/Handshake/State13.hs
+++ b/core/Network/TLS/Handshake/State13.hs
@@ -8,7 +8,11 @@
 -- Portability : unknown
 --
 module Network.TLS.Handshake.State13
-       ( getTxState
+       ( CryptLevel ( CryptEarlySecret
+                    , CryptHandshakeSecret
+                    , CryptApplicationSecret
+                    )
+       , getTxState
        , getRxState
        , setTxState
        , setRxState
@@ -37,32 +41,33 @@ import Network.TLS.Struct
 import Network.TLS.Imports
 import Network.TLS.Util
 
-getTxState :: Context -> IO (Hash, Cipher, ByteString)
+getTxState :: Context -> IO (Hash, Cipher, CryptLevel, ByteString)
 getTxState ctx = getXState ctx ctxTxState
 
-getRxState :: Context -> IO (Hash, Cipher, ByteString)
+getRxState :: Context -> IO (Hash, Cipher, CryptLevel, ByteString)
 getRxState ctx = getXState ctx ctxRxState
 
 getXState :: Context
           -> (Context -> MVar RecordState)
-          -> IO (Hash, Cipher, ByteString)
+          -> IO (Hash, Cipher, CryptLevel, ByteString)
 getXState ctx func = do
     tx <- readMVar (func ctx)
     let Just usedCipher = stCipher tx
         usedHash = cipherHash usedCipher
+        level = stCryptLevel tx
         secret = cstMacSecret $ stCryptState tx
-    return (usedHash, usedCipher, secret)
+    return (usedHash, usedCipher, level, secret)
 
-setTxState :: Context -> Hash -> Cipher -> ByteString -> IO ()
+setTxState :: Context -> Hash -> Cipher -> CryptLevel -> ByteString -> IO ()
 setTxState = setXState ctxTxState BulkEncrypt
 
-setRxState :: Context -> Hash -> Cipher -> ByteString -> IO ()
+setRxState :: Context -> Hash -> Cipher -> CryptLevel -> ByteString -> IO ()
 setRxState = setXState ctxRxState BulkDecrypt
 
 setXState :: (Context -> MVar RecordState) -> BulkDirection
-          -> Context -> Hash -> Cipher -> ByteString
+          -> Context -> Hash -> Cipher -> CryptLevel -> ByteString
           -> IO ()
-setXState func encOrDec ctx h cipher secret =
+setXState func encOrDec ctx h cipher lvl secret =
     modifyMVar_ (func ctx) (\_ -> return rt)
   where
     bulk    = cipherBulk cipher
@@ -78,6 +83,7 @@ setXState func encOrDec ctx h cipher secret =
     rt = RecordState {
         stCryptState  = cst
       , stMacState    = MacState { msSequence = 0 }
+      , stCryptLevel  = lvl
       , stCipher      = Just cipher
       , stCompression = nullCompression
       }

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -397,6 +397,8 @@ data Shared = Shared
       --
       -- See the default value of 'ValidationCache'.
     , sharedValidationCache :: ValidationCache
+      -- | Additional extensions for ClientHello and EncryptedExtensions.
+    , sharedExtensions      :: [ExtensionRaw]
     }
 
 instance Show Shared where
@@ -407,6 +409,7 @@ instance Default Shared where
             , sharedSessionManager  = noSessionManager
             , sharedCAStore         = mempty
             , sharedValidationCache = def
+            , sharedExtensions      = []
             }
 
 -- | Group usage callback possible return values.

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -1,0 +1,9 @@
+module Network.TLS.QUIC (
+    -- * Hash
+      hkdfExpandLabel
+    , hkdfExtract
+    , hashDigestSize
+    ) where
+
+import Network.TLS.Crypto (hashDigestSize)
+import Network.TLS.KeySchedule (hkdfExtract, hkdfExpandLabel)

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -133,8 +133,8 @@ newQUICClient cparams callbacks = do
     processI put (SendClientFinishedI exts appSecInfo) = do
         quicInstallKeys callbacks (InstallApplicationKeys appSecInfo)
         quicNotifyExtensions callbacks (filterQTP exts)
-        put SendClientFinished
-    processI put RecvSessionTicketI = put RecvSessionTicket
+        put ClientHandshakeComplete
+    processI put RecvSessionTicketI = put ClientRecvSessionTicket
     processI put (ClientHandshakeFailedI e) = put (ClientHandshakeFailed e)
 
 newQUICServer :: ServerParams -> QUICCallbacks -> IO ServerController
@@ -159,8 +159,8 @@ newQUICServer sparams callbacks = do
         quicNotifyExtensions callbacks (filterQTP exts)
     processI put (SendServerFinishedI appSecInfo) = do
         quicInstallKeys callbacks (InstallApplicationKeys appSecInfo)
-        put SendServerFinished
-    processI put SendSessionTicketI = put SendSessionTicket
+        put ServerFinishedSent
+    processI put SendSessionTicketI = put ServerHandshakeComplete
     processI put (ServerHandshakeFailedI e) = put (ServerHandshakeFailed e)
 
 getErrorCause :: TLSException -> TLSError

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -29,6 +29,7 @@ module Network.TLS.QUIC (
     , ServerControl(..)
     , ServerStatus(..)
     -- * Common
+    , CryptLevel(..)
     , QuicSecretEvent(..)
     , QuicCallbacks(..)
     , NegotiatedProtocol
@@ -58,12 +59,12 @@ import Network.TLS.Handshake.State13
 import Network.TLS.Imports
 import Network.TLS.KeySchedule (hkdfExtract, hkdfExpandLabel)
 import Network.TLS.Record.Layer
+import Network.TLS.Record.State
 import Network.TLS.Struct
 import Network.TLS.Types
 
 import Control.Concurrent
 import qualified Control.Exception as E
-import Data.IORef
 
 nullBackend :: Backend
 nullBackend = Backend {
@@ -79,50 +80,57 @@ data QuicSecretEvent
     | SyncApplicationSecret ApplicationSecretInfo
 
 data QuicCallbacks = QuicCallbacks
-    { quicNotifySecretEvent :: QuicSecretEvent -> IO ()
+    { quicRecv              :: CryptLevel -> IO ByteString
+    , quicNotifySecretEvent :: QuicSecretEvent -> IO ()
     , quicNotifyExtensions  :: [ExtensionRaw] -> IO ()
     }
 
-getLevel :: Context -> IO CryptLevel
-getLevel ctx = do
+getTxLevel :: Context -> IO CryptLevel
+getTxLevel ctx = do
     (_, _, level, _) <- getTxState ctx
+    return level
+
+getRxLevel :: Context -> IO CryptLevel
+getRxLevel ctx = do
+    (_, _, level, _) <- getRxState ctx
     return level
 
 prepare :: (a -> IO ())
         -> IO (IO ByteString
-              ,ByteString -> IO ()
               ,a -> IO ()
               ,IO a
-              ,ByteString -> IO ()
-              ,IO ByteString
-              ,IORef (Maybe ByteString))
+              ,ByteString -> IO ())
 prepare processI = do
     c1 <- newChan
-    c2 <- newChan
     mvar <- newEmptyMVar
-    ref <- newIORef Nothing
     let send = writeChan c1
         get  = readChan  c1
-        recv = readChan  c2
-        put  = writeChan c2
         sync a = processI a >> putMVar mvar a
         ask  = takeMVar mvar
-    return (get, put, sync, ask, send, recv, ref)
+    return (get, sync, ask, send)
+
+newRecordLayer :: Context -> QuicCallbacks
+               -> (ByteString -> IO ())
+               -> RecordLayer [(CryptLevel, ByteString)]
+newRecordLayer ctx callbacks send = newTransparentRecordLayer get send recv
+  where
+    get     = getTxLevel ctx
+    recv    = getRxLevel ctx >>= quicRecv callbacks
 
 newQUICClient :: ClientParams -> QuicCallbacks -> IO ClientController
 newQUICClient cparams callbacks = do
-    (get, put, sync, ask, send, recv, ref) <- prepare processI
+    (get, sync, ask, send) <- prepare processI
     ctx <- contextNew nullBackend cparams
     let ctx' = updateRecordLayer rl ctx
           { ctxHandshakeSync = HandshakeSync sync (\_ -> return ())
           }
-        rl = newTransparentRecordLayer (getLevel ctx') send recv
+        rl = newRecordLayer ctx callbacks send
         failed = sync . ClientHandshakeFailedI
     tid <- forkIO $ E.handle failed $ do
         handshake ctx'
         void $ recvData ctx'
     wtid <- mkWeakThreadId tid
-    return (quicClient wtid ask get put ref)
+    return (quicClient wtid ask get)
 
   where
     processI (SendClientHelloI mEarlySecInfo) =
@@ -137,18 +145,18 @@ newQUICClient cparams callbacks = do
 
 newQUICServer :: ServerParams -> QuicCallbacks -> IO ServerController
 newQUICServer sparams callbacks = do
-    (get, put, sync, ask, send, recv, ref) <- prepare processI
+    (get, sync, ask, send) <- prepare processI
     ctx <- contextNew nullBackend sparams
     let ctx' = updateRecordLayer rl ctx
           { ctxHandshakeSync = HandshakeSync (\_ -> return ()) sync
           }
-        rl = newTransparentRecordLayer (getLevel ctx') send recv
+        rl = newRecordLayer ctx callbacks send
         failed = sync . ServerHandshakeFailedI
     tid <- forkIO $ E.handle failed $ do
         handshake ctx'
         void $ recvData ctx'
     wtid <- mkWeakThreadId tid
-    return (quicServer wtid ask get put ref)
+    return (quicServer wtid ask get)
 
   where
     processI (SendServerHelloI exts mEarlySecInfo handSecInfo) = do

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -31,7 +31,9 @@ module Network.TLS.QUIC (
     , ServerHello
     , Finished
     , SessionTicket
-    , errorToAlert
+    , errorToAlertDescription
+    , fromAlertDescription
+    , toAlertDescription
     ) where
 
 import Network.TLS.Backend
@@ -46,7 +48,7 @@ import Network.TLS.Handshake.QUIC
 import Network.TLS.Imports
 import Network.TLS.KeySchedule (hkdfExtract, hkdfExpandLabel)
 import Network.TLS.Record.Layer
-import Network.TLS.Struct (ExtensionRaw(..), ExtensionID)
+import Network.TLS.Struct
 import Network.TLS.Types
 
 import Control.Concurrent
@@ -108,3 +110,12 @@ newQUICServer sparams = do
         handshake ctx'
         void $ recvData ctx'
     return (quicServer tid ask get put ref)
+
+errorToAlertDescription :: TLSError -> AlertDescription
+errorToAlertDescription = snd . head . errorToAlert
+
+fromAlertDescription :: AlertDescription -> Word8
+fromAlertDescription = valOfType
+
+toAlertDescription :: Word8 -> Maybe AlertDescription
+toAlertDescription = valToType

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -33,10 +33,6 @@ module Network.TLS.QUIC (
     , QuicSecretEvent(..)
     , QuicCallbacks(..)
     , NegotiatedProtocol
-    , ClientHello
-    , ServerHello
-    , Finished
-    , SessionTicket
     , HandshakeMode13(..)
     , errorToAlertDescription
     , fromAlertDescription

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -38,6 +38,7 @@ module Network.TLS.QUIC (
     , errorToAlertDescription
     , fromAlertDescription
     , toAlertDescription
+    , quicMaxEarlyDataSize
     ) where
 
 import Network.TLS.Backend
@@ -48,6 +49,7 @@ import Network.TLS.Crypto (hashDigestSize)
 import Network.TLS.Extension (extensionID_QuicTransportParameters)
 import Network.TLS.Handshake.Common
 import Network.TLS.Handshake.Control
+import Network.TLS.Handshake.Server
 import Network.TLS.Handshake.QUIC
 import Network.TLS.Handshake.State
 import Network.TLS.Imports

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -15,6 +15,9 @@ module Network.TLS.QUIC (
     , HandshakeSecret
     , ApplicationSecret
     , TrafficSecrets
+    , EarlySecretInfo(..)
+    , HandshakeSecretInfo(..)
+    , ApplicationSecretInfo(..)
     -- * Client handshake controller
     , newQUICClient
     , ClientController

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -31,6 +31,7 @@ module Network.TLS.QUIC (
     , ServerHello
     , Finished
     , SessionTicket
+    , HandshakeMode13(..)
     , errorToAlertDescription
     , fromAlertDescription
     , toAlertDescription
@@ -45,6 +46,7 @@ import Network.TLS.Extension (extensionID_QuicTransportParameters)
 import Network.TLS.Handshake.Common
 import Network.TLS.Handshake.Control
 import Network.TLS.Handshake.QUIC
+import Network.TLS.Handshake.State
 import Network.TLS.Imports
 import Network.TLS.KeySchedule (hkdfExtract, hkdfExpandLabel)
 import Network.TLS.Record.Layer

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -127,12 +127,10 @@ newQUICClient cparams callbacks = do
     return (quicClient wtid ask)
 
   where
-    processI notify (SendClientHelloI mEarlySecInfo) = do
+    processI _      (SendClientHelloI mEarlySecInfo) =
         quicNotifySecretEvent callbacks (SyncEarlySecret mEarlySecInfo)
-        notify
-    processI notify (RecvServerHelloI handSecInfo) = do
+    processI _      (RecvServerHelloI handSecInfo) =
         quicNotifySecretEvent callbacks (SyncHandshakeSecret handSecInfo)
-        notify
     processI notify (SendClientFinishedI exts appSecInfo) = do
         quicNotifySecretEvent callbacks (SyncApplicationSecret appSecInfo)
         quicNotifyExtensions callbacks (filterQTP exts)

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -95,7 +95,8 @@ newQUICClient cparams = do
     tid <- forkIO $ E.handle failed $ do
         handshake ctx'
         void $ recvData ctx'
-    return (quicClient tid ask get put ref)
+    wtid <- mkWeakThreadId tid
+    return (quicClient wtid ask get put ref)
 
 newQUICServer :: ServerParams -> IO ServerController
 newQUICServer sparams = do
@@ -109,7 +110,8 @@ newQUICServer sparams = do
     tid <- forkIO $ E.handle failed $ do
         handshake ctx'
         void $ recvData ctx'
-    return (quicServer tid ask get put ref)
+    wtid <- mkWeakThreadId tid
+    return (quicServer wtid ask get put ref)
 
 errorToAlertDescription :: TLSError -> AlertDescription
 errorToAlertDescription = snd . head . errorToAlert

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Network.TLS.QUIC (
     -- * Hash
       hkdfExpandLabel
@@ -6,8 +7,99 @@ module Network.TLS.QUIC (
     -- * Extensions
     , ExtensionRaw(..)
     , ExtensionID
+    , extensionID_QuicTransportParameters
+    -- * Secrets
+    , ServerTrafficSecret(..)
+    , ClientTrafficSecret(..)
+    , EarlySecret
+    , HandshakeSecret
+    , ApplicationSecret
+    , TrafficSecrets
+    -- * Client handshake controller
+    , newQUICClient
+    , ClientController
+    , ClientControl(..)
+    , ClientStatus(..)
+    -- * Server handshake controller
+    , newQUICServer
+    , ServerController
+    , ServerControl(..)
+    , ServerStatus(..)
+    -- * Common
+    , NegotiatedProtocol
+    , ClientHello
+    , ServerHello
+    , Finished
+    , SessionTicket
     ) where
 
+import Network.TLS.Backend
+import Network.TLS.Context
+import Network.TLS.Context.Internal
+import Network.TLS.Core
 import Network.TLS.Crypto (hashDigestSize)
+import Network.TLS.Extension (extensionID_QuicTransportParameters)
+import Network.TLS.Handshake.Control
+import Network.TLS.Handshake.QUIC
+import Network.TLS.Imports
 import Network.TLS.KeySchedule (hkdfExtract, hkdfExpandLabel)
+import Network.TLS.Record.Layer
 import Network.TLS.Struct (ExtensionRaw(..), ExtensionID)
+import Network.TLS.Types
+
+import Control.Concurrent
+import Data.IORef
+
+nullBackend :: Backend
+nullBackend = Backend {
+    backendFlush = return ()
+  , backendClose = return ()
+  , backendSend  = \_ -> return ()
+  , backendRecv  = \_ -> return ""
+  }
+
+prepare :: IO (IO ByteString
+              ,ByteString -> IO ()
+              ,a -> IO ()
+              ,IO a
+              ,RecordLayer
+              ,IORef (Maybe ByteString))
+prepare = do
+    c1 <- newChan
+    c2 <- newChan
+    mvar <- newEmptyMVar
+    ref <- newIORef Nothing
+    let send = writeChan c1
+        get  = readChan  c1
+        recv = readChan  c2
+        put  = writeChan c2
+        sync = putMVar mvar
+        ask  = takeMVar mvar
+        rl   =  newTransparentRecordLayer send recv
+    return (get, put, sync, ask, rl, ref)
+
+newQUICClient :: ClientParams -> IO ClientController
+newQUICClient cparams = do
+    (get, put, sync, ask, rl, ref) <- prepare
+    ctx <- contextNew nullBackend cparams
+    let ctx' = ctx {
+            ctxRecordLayer   = Just rl
+          , ctxHandshakeSync = Just (HandshakeSync sync (\_ -> return ()))
+          }
+    tid <- forkIO $ do
+        handshake ctx'
+        void $ recvData ctx'
+    return (quicClient tid ask get put ref)
+
+newQUICServer :: ServerParams -> IO ServerController
+newQUICServer sparams = do
+    (get, put, sync, ask, rl, ref) <- prepare
+    ctx <- contextNew nullBackend sparams
+    let ctx' = ctx {
+            ctxRecordLayer   = Just rl
+          , ctxHandshakeSync = Just (HandshakeSync (\_ -> return ()) sync)
+          }
+    tid <- forkIO $ do
+        handshake ctx'
+        void $ recvData ctx'
+    return (quicServer tid ask get put ref)

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -3,7 +3,11 @@ module Network.TLS.QUIC (
       hkdfExpandLabel
     , hkdfExtract
     , hashDigestSize
+    -- * Extensions
+    , ExtensionRaw(..)
+    , ExtensionID
     ) where
 
 import Network.TLS.Crypto (hashDigestSize)
 import Network.TLS.KeySchedule (hkdfExtract, hkdfExpandLabel)
+import Network.TLS.Struct (ExtensionRaw(..), ExtensionID)

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -29,6 +29,7 @@ module Network.TLS.QUIC (
     , ServerControl(..)
     , ServerStatus(..)
     -- * Common
+    , QuicSecretEvent(..)
     , QuicCallbacks(..)
     , NegotiatedProtocol
     , ClientHello
@@ -71,8 +72,14 @@ nullBackend = Backend {
   , backendRecv  = \_ -> return ""
   }
 
+data QuicSecretEvent
+    = SyncEarlySecret (Maybe EarlySecretInfo)
+    | SyncHandshakeSecret HandshakeSecretInfo
+    | SyncApplicationSecret ApplicationSecretInfo
+
 data QuicCallbacks = QuicCallbacks
-    { quicNotifyExtensions :: [ExtensionRaw] -> IO ()
+    { quicNotifySecretEvent :: QuicSecretEvent -> IO ()
+    , quicNotifyExtensions  :: [ExtensionRaw] -> IO ()
     }
 
 prepare :: (a -> IO ())

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -156,15 +156,13 @@ newQUICServer sparams callbacks = do
     return (quicServer wtid ask)
 
   where
-    processI notify (SendServerHelloI exts mEarlySecInfo handSecInfo) = do
+    processI _      (SendServerHelloI exts mEarlySecInfo handSecInfo) = do
         quicNotifySecretEvent callbacks (SyncEarlySecret mEarlySecInfo)
         quicNotifySecretEvent callbacks (SyncHandshakeSecret handSecInfo)
         quicNotifyExtensions callbacks (filterQTP exts)
-        notify
     processI notify (SendServerFinishedI appSecInfo) = do
         quicNotifySecretEvent callbacks (SyncApplicationSecret appSecInfo)
         notify
-    processI notify SendRequestRetryI = notify
     processI notify SendSessionTicketI = notify
     processI notify (ServerHandshakeFailedI _) = notify
 

--- a/core/Network/TLS/Record/Layer.hs
+++ b/core/Network/TLS/Record/Layer.hs
@@ -6,9 +6,11 @@ module Network.TLS.Record.Layer (
   ) where
 
 import Network.TLS.Imports
-import Network.TLS.Packet
 import Network.TLS.Record
 import Network.TLS.Struct
+
+import qualified Control.Exception as E
+import qualified Data.ByteString as B
 
 data RecordLayer = RecordLayer {
     -- Sending.hs and Sending13.hs
@@ -29,8 +31,9 @@ newTransparentRecordLayer send recv = RecordLayer {
 transparentEncodeRecord :: Record Plaintext -> IO (Either TLSError ByteString)
 transparentEncodeRecord (Record ProtocolType_ChangeCipherSpec _ _) =
     return $ Right ""
-transparentEncodeRecord (Record ProtocolType_Alert _ frag) =
-    error $ show $ decodeAlerts $ fragmentGetBytes frag
+transparentEncodeRecord (Record ProtocolType_Alert _ frag) = do
+    let Just desc = valToType (fragmentGetBytes frag `B.index` 1)
+    E.throwIO $ Error_Protocol ("transparentEncodeRecord", True, desc)
 transparentEncodeRecord (Record _ _ frag) =
     return $ Right $ fragmentGetBytes frag
 

--- a/core/Network/TLS/Record/Layer.hs
+++ b/core/Network/TLS/Record/Layer.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Network.TLS.Record.Layer (
+    RecordLayer(..)
+  , newTransparentRecordLayer
+  ) where
+
+import Network.TLS.Imports
+import Network.TLS.Packet
+import Network.TLS.Record
+import Network.TLS.Struct
+
+data RecordLayer = RecordLayer {
+    -- Sending.hs and Sending13.hs
+    encodeRecord :: Record Plaintext -> IO (Either TLSError ByteString)
+    -- IO.hs
+  , sendBytes    :: ByteString -> IO ()
+    -- IO.hs
+  , recvRecord   :: IO (Either TLSError (Record Plaintext))
+  }
+
+newTransparentRecordLayer :: (ByteString -> IO ()) -> IO ByteString -> RecordLayer
+newTransparentRecordLayer send recv = RecordLayer {
+    encodeRecord = transparentEncodeRecord
+  , sendBytes    = transparentSendBytes send
+  , recvRecord   = transparentRecvRecord recv
+  }
+
+transparentEncodeRecord :: Record Plaintext -> IO (Either TLSError ByteString)
+transparentEncodeRecord (Record ProtocolType_ChangeCipherSpec _ _) =
+    return $ Right ""
+transparentEncodeRecord (Record ProtocolType_Alert _ frag) =
+    error $ show $ decodeAlerts $ fragmentGetBytes frag
+transparentEncodeRecord (Record _ _ frag) =
+    return $ Right $ fragmentGetBytes frag
+
+transparentSendBytes :: (ByteString -> IO ()) -> ByteString -> IO ()
+transparentSendBytes _    "" = return ()
+transparentSendBytes send bs = send bs
+
+transparentRecvRecord :: IO ByteString -> IO (Either TLSError (Record Plaintext))
+transparentRecvRecord recv = do
+    bs <- recv
+    return $ Right $ Record ProtocolType_Handshake TLS12 (fragmentPlaintext bs)

--- a/core/Network/TLS/Record/Layer.hs
+++ b/core/Network/TLS/Record/Layer.hs
@@ -12,21 +12,21 @@ import Network.TLS.Struct
 import qualified Control.Exception as E
 import qualified Data.ByteString as B
 
-data RecordLayer = RecordLayer {
+data RecordLayer bytes = RecordLayer {
     -- Sending.hs
-    recordEncode    :: Record Plaintext -> IO (Either TLSError ByteString)
+    recordEncode    :: Record Plaintext -> IO (Either TLSError bytes)
 
     -- Sending13.hs
-  , recordEncode13  :: Record Plaintext -> IO (Either TLSError ByteString)
+  , recordEncode13  :: Record Plaintext -> IO (Either TLSError bytes)
 
     -- IO.hs
-  , recordSendBytes :: ByteString -> IO ()
+  , recordSendBytes :: bytes -> IO ()
   , recordRecv      :: Bool -> Int -> IO (Either TLSError (Record Plaintext))
   , recordRecv13    :: IO (Either TLSError (Record Plaintext))
   , recordNeedFlush :: Bool
   }
 
-newTransparentRecordLayer :: (ByteString -> IO ()) -> IO ByteString -> RecordLayer
+newTransparentRecordLayer :: (ByteString -> IO ()) -> IO ByteString -> RecordLayer ByteString
 newTransparentRecordLayer send recv = RecordLayer {
     recordEncode    = transparentEncodeRecord
   , recordEncode13  = transparentEncodeRecord

--- a/core/Network/TLS/Record/State.hs
+++ b/core/Network/TLS/Record/State.hs
@@ -10,6 +10,7 @@
 module Network.TLS.Record.State
     ( CryptState(..)
     , CryptLevel(..)
+    , HasCryptLevel(..)
     , MacState(..)
     , RecordOptions(..)
     , RecordState(..)
@@ -38,6 +39,7 @@ import Network.TLS.Packet
 import Network.TLS.MAC
 import Network.TLS.Util
 import Network.TLS.Imports
+import Network.TLS.Types
 
 import qualified Data.ByteString as B
 
@@ -65,6 +67,11 @@ data CryptLevel
     | CryptHandshakeSecret
     | CryptApplicationSecret
     deriving (Eq,Show)
+
+class HasCryptLevel a where getCryptLevel :: proxy a -> CryptLevel
+instance HasCryptLevel EarlySecret where getCryptLevel _ = CryptEarlySecret
+instance HasCryptLevel HandshakeSecret where getCryptLevel _ = CryptHandshakeSecret
+instance HasCryptLevel ApplicationSecret where getCryptLevel _ = CryptApplicationSecret
 
 data RecordState = RecordState
     { stCipher      :: Maybe Cipher

--- a/core/Network/TLS/Record/State.hs
+++ b/core/Network/TLS/Record/State.hs
@@ -9,6 +9,7 @@
 --
 module Network.TLS.Record.State
     ( CryptState(..)
+    , CryptLevel(..)
     , MacState(..)
     , RecordOptions(..)
     , RecordState(..)
@@ -57,9 +58,18 @@ data RecordOptions = RecordOptions
     , recordTLS13 :: Bool                     -- TLS13 record processing
     }
 
+data CryptLevel
+    = CryptInitial
+    | CryptMasterSecret
+    | CryptEarlySecret
+    | CryptHandshakeSecret
+    | CryptApplicationSecret
+    deriving (Show)
+
 data RecordState = RecordState
     { stCipher      :: Maybe Cipher
     , stCompression :: Compression
+    , stCryptLevel  :: !CryptLevel
     , stCryptState  :: !CryptState
     , stMacState    :: !MacState
     } deriving (Show)
@@ -109,6 +119,7 @@ newRecordState :: RecordState
 newRecordState = RecordState
     { stCipher      = Nothing
     , stCompression = nullCompression
+    , stCryptLevel  = CryptInitial
     , stCryptState  = CryptState BulkStateUninitialized B.empty B.empty
     , stMacState    = MacState 0
     }

--- a/core/Network/TLS/Record/State.hs
+++ b/core/Network/TLS/Record/State.hs
@@ -64,7 +64,7 @@ data CryptLevel
     | CryptEarlySecret
     | CryptHandshakeSecret
     | CryptApplicationSecret
-    deriving (Show)
+    deriving (Eq,Show)
 
 data RecordState = RecordState
     { stCipher      :: Maybe Cipher

--- a/core/Network/TLS/Sending.hs
+++ b/core/Network/TLS/Sending.hs
@@ -36,14 +36,15 @@ import Data.IORef
 
 -- | encodePacket transform a packet into marshalled data related to current state
 -- and updating state on the go
-encodePacket :: Context -> Packet -> IO (Either TLSError ByteString)
-encodePacket ctx pkt = do
+encodePacket :: Monoid bytes
+             => Context -> RecordLayer bytes -> Packet -> IO (Either TLSError bytes)
+encodePacket ctx recordLayer pkt = do
     (ver, _) <- decideRecordVersion ctx
     let pt = packetType pkt
         mkRecord bs = Record pt ver (fragmentPlaintext bs)
         len = ctxFragmentSize ctx
     records <- map mkRecord <$> packetToFragments ctx len pkt
-    bs <- fmap B.concat <$> forEitherM records (recordEncode $ ctxRecordLayer ctx)
+    bs <- fmap mconcat <$> forEitherM records (recordEncode recordLayer)
     when (pkt == ChangeCipherSpec) $ switchTxEncryption ctx
     return bs
 

--- a/core/Network/TLS/Sending13.hs
+++ b/core/Network/TLS/Sending13.hs
@@ -21,6 +21,7 @@ import Network.TLS.Imports
 import Network.TLS.Packet
 import Network.TLS.Packet13
 import Network.TLS.Record
+import qualified Network.TLS.Record.Layer as RL
 import Network.TLS.Sending
 import Network.TLS.Struct
 import Network.TLS.Struct13
@@ -34,7 +35,7 @@ encodePacket13 ctx pkt = do
         mkRecord bs = Record pt TLS12 (fragmentPlaintext bs)
         len = ctxFragmentSize ctx
     records <- map mkRecord <$> packetToFragments ctx len pkt
-    fmap B.concat <$> forEitherM records (encodeRecord ctx)
+    fmap B.concat <$> forEitherM records (contextEncodeRecord ctx)
 
 prepareRecord :: Context -> RecordM a -> IO (Either TLSError a)
 prepareRecord = runTxState
@@ -66,3 +67,8 @@ updateHandshake13 ctx hs
     isIgnored NewSessionTicket13{} = True
     isIgnored KeyUpdate13{}        = True
     isIgnored _                    = False
+
+contextEncodeRecord :: Context -> Record Plaintext -> IO (Either TLSError ByteString)
+contextEncodeRecord ctx = case ctxRecordLayer ctx of
+  Nothing -> encodeRecord ctx
+  Just rl -> RL.encodeRecord rl

--- a/core/Network/TLS/Types.hs
+++ b/core/Network/TLS/Types.hs
@@ -101,22 +101,22 @@ data HandshakeSecret
 data ApplicationSecret
 data ResumptionSecret
 
-newtype BaseSecret a = BaseSecret ByteString deriving Show
-newtype ClientTrafficSecret a = ClientTrafficSecret ByteString deriving Show
-newtype ServerTrafficSecret a = ServerTrafficSecret ByteString deriving Show
+newtype BaseSecret a = BaseSecret ByteString deriving (Eq, Show)
+newtype ClientTrafficSecret a = ClientTrafficSecret ByteString deriving (Eq, Show)
+newtype ServerTrafficSecret a = ServerTrafficSecret ByteString deriving (Eq, Show)
 
 data SecretTriple a = SecretTriple
     { triBase   :: BaseSecret a
     , triClient :: ClientTrafficSecret a
     , triServer :: ServerTrafficSecret a
-    }
+    } deriving (Eq, Show)
 
 data SecretPair a = SecretPair
     { pairBase   :: BaseSecret a
     , pairClient :: ClientTrafficSecret a
-    }
+    } deriving (Eq, Show)
 
 type TrafficSecrets a = (ClientTrafficSecret a, ServerTrafficSecret a)
 
 -- Master secret for TLS 1.2 or earlier.
-newtype MasterSecret = MasterSecret ByteString deriving Show
+newtype MasterSecret = MasterSecret ByteString deriving (Eq, Show)

--- a/core/Network/TLS/Types.hs
+++ b/core/Network/TLS/Types.hs
@@ -28,6 +28,7 @@ module Network.TLS.Types
     , BaseSecret(..)
     , ClientTrafficSecret(..)
     , ServerTrafficSecret(..)
+    , TrafficSecrets
     , SecretTriple(..)
     , SecretPair(..)
     , MasterSecret(..)
@@ -114,6 +115,8 @@ data SecretPair a = SecretPair
     { pairBase   :: BaseSecret a
     , pairClient :: ClientTrafficSecret a
     }
+
+type TrafficSecrets a = (ClientTrafficSecret a, ServerTrafficSecret a)
 
 -- Master secret for TLS 1.2 or earlier.
 newtype MasterSecret = MasterSecret ByteString deriving Show

--- a/core/Network/TLS/Types.hs
+++ b/core/Network/TLS/Types.hs
@@ -26,6 +26,7 @@ module Network.TLS.Types
     , ApplicationSecret
     , ResumptionSecret
     , BaseSecret(..)
+    , AnyTrafficSecret(..)
     , ClientTrafficSecret(..)
     , ServerTrafficSecret(..)
     , TrafficSecrets
@@ -102,6 +103,7 @@ data ApplicationSecret
 data ResumptionSecret
 
 newtype BaseSecret a = BaseSecret ByteString deriving (Eq, Show)
+newtype AnyTrafficSecret a = AnyTrafficSecret ByteString deriving (Eq, Show)
 newtype ClientTrafficSecret a = ClientTrafficSecret ByteString deriving (Eq, Show)
 newtype ServerTrafficSecret a = ServerTrafficSecret ByteString deriving (Eq, Show)
 

--- a/core/Network/TLS/Types.hs
+++ b/core/Network/TLS/Types.hs
@@ -102,23 +102,23 @@ data HandshakeSecret
 data ApplicationSecret
 data ResumptionSecret
 
-newtype BaseSecret a = BaseSecret ByteString deriving (Eq, Show)
-newtype AnyTrafficSecret a = AnyTrafficSecret ByteString deriving (Eq, Show)
-newtype ClientTrafficSecret a = ClientTrafficSecret ByteString deriving (Eq, Show)
-newtype ServerTrafficSecret a = ServerTrafficSecret ByteString deriving (Eq, Show)
+newtype BaseSecret a = BaseSecret ByteString deriving Show
+newtype AnyTrafficSecret a = AnyTrafficSecret ByteString deriving Show
+newtype ClientTrafficSecret a = ClientTrafficSecret ByteString deriving Show
+newtype ServerTrafficSecret a = ServerTrafficSecret ByteString deriving Show
 
 data SecretTriple a = SecretTriple
     { triBase   :: BaseSecret a
     , triClient :: ClientTrafficSecret a
     , triServer :: ServerTrafficSecret a
-    } deriving (Eq, Show)
+    }
 
 data SecretPair a = SecretPair
     { pairBase   :: BaseSecret a
     , pairClient :: ClientTrafficSecret a
-    } deriving (Eq, Show)
+    }
 
 type TrafficSecrets a = (ClientTrafficSecret a, ServerTrafficSecret a)
 
 -- Master secret for TLS 1.2 or earlier.
-newtype MasterSecret = MasterSecret ByteString deriving (Eq, Show)
+newtype MasterSecret = MasterSecret ByteString deriving Show

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -70,6 +70,7 @@ Library
                      Network.TLS.Extra
                      Network.TLS.Extra.Cipher
                      Network.TLS.Extra.FFDHE
+                     Network.TLS.QUIC
   other-modules:     Network.TLS.Cap
                      Network.TLS.Struct
                      Network.TLS.Struct13

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -107,10 +107,11 @@ Library
                      Network.TLS.Parameters
                      Network.TLS.PostHandshake
                      Network.TLS.Record
-                     Network.TLS.Record.Types
-                     Network.TLS.Record.Engage
                      Network.TLS.Record.Disengage
+                     Network.TLS.Record.Engage
+                     Network.TLS.Record.Layer
                      Network.TLS.Record.State
+                     Network.TLS.Record.Types
                      Network.TLS.RNG
                      Network.TLS.State
                      Network.TLS.Session

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -86,14 +86,16 @@ Library
                      Network.TLS.ErrT
                      Network.TLS.Extension
                      Network.TLS.Handshake
+                     Network.TLS.Handshake.Certificate
+                     Network.TLS.Handshake.Client
                      Network.TLS.Handshake.Common
                      Network.TLS.Handshake.Common13
-                     Network.TLS.Handshake.Certificate
+                     Network.TLS.Handshake.Control
                      Network.TLS.Handshake.Key
-                     Network.TLS.Handshake.Client
-                     Network.TLS.Handshake.Server
                      Network.TLS.Handshake.Process
+                     Network.TLS.Handshake.QUIC
                      Network.TLS.Handshake.Random
+                     Network.TLS.Handshake.Server
                      Network.TLS.Handshake.Signature
                      Network.TLS.Handshake.State
                      Network.TLS.Handshake.State13


### PR DESCRIPTION
As discussed in #392, I have implemented QUIC APIs based on threads. This does not change `Client.hs` and `Server.hs` a lot. QUIC APIs are provided in `Network.TLS.QUIC`. So, `Network.TLS` remains the same.

I joined 16th QUIC interop and am now confident the quality of this code: https://docs.google.com/spreadsheets/d/1D0tW89vOoaScs3IY9RGC0UesWGAwE6xyLk0l4JtvTVg

@ocheron I don't expect that this PR will be merged quickly. But I would like to get feedback if any.
