### PR TITLE
Maximum fragment size

### DIFF
--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -163,6 +163,7 @@ contextNew backend params = liftIO $ do
             , ctxShared       = shared
             , ctxSupported    = supported
             , ctxState        = stvar
+            , ctxFragmentSize = Just 16384
             , ctxTxState      = tx
             , ctxRxState      = rx
             , ctxHandshake    = hs

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -115,6 +115,7 @@ data Context = Context
     , ctxSSLv2ClientHello :: IORef Bool    -- ^ enable the reception of compatibility SSLv2 client hello.
                                            -- the flag will be set to false regardless of its initial value
                                            -- after the first packet received.
+    , ctxFragmentSize     :: Maybe Int        -- ^ maximum size of plaintext fragments
     , ctxTxState          :: MVar RecordState -- ^ current tx state
     , ctxRxState          :: MVar RecordState -- ^ current rx state
     , ctxHandshake        :: MVar (Maybe HandshakeState) -- ^ optional handshake state

--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -101,7 +101,8 @@ sendData ctx dataToSend = liftIO $ do
         -- All chunks are protected with the same write lock because we don't
         -- want to interleave writes from other threads in the middle of our
         -- possibly large write.
-        mapM_ (mapChunks_ 16384 sendP) (L.toChunks dataToSend)
+        let len = ctxFragmentSize ctx
+        mapM_ (mapChunks_ len sendP) (L.toChunks dataToSend)
 
 -- | Get data out of Data packet, and automatically renegotiate if a Handshake
 -- ClientHello is received.  An empty result means EOF.

--- a/core/Network/TLS/Credentials.hs
+++ b/core/Network/TLS/Credentials.hs
@@ -34,10 +34,8 @@ type Credential = (CertificateChain, PrivKey)
 
 newtype Credentials = Credentials [Credential]
 
-#if MIN_VERSION_base(4,9,0)
 instance Semigroup Credentials where
     Credentials l1 <> Credentials l2 = Credentials (l1 ++ l2)
-#endif
 
 instance Monoid Credentials where
     mempty = Credentials []

--- a/core/Network/TLS/Credentials.hs
+++ b/core/Network/TLS/Credentials.hs
@@ -80,7 +80,7 @@ credentialLoadX509ChainFromMemory :: ByteString
                   -> [ByteString]
                   -> ByteString
                   -> Either String Credential
-credentialLoadX509ChainFromMemory certData chainData privateData = do
+credentialLoadX509ChainFromMemory certData chainData privateData =
     let x509   = readSignedObjectFromMemory certData
         chains = map readSignedObjectFromMemory chainData
         keys   = readKeyFileFromMemory privateData

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -102,7 +102,7 @@ handshakeClient' cparams ctx groups mparams = do
                     | otherwise -> throwCore $ Error_Protocol ("server-selected group is not supported", True, IllegalParameter)
                   Just _  -> error "handshakeClient': invalid KeyShare value"
                   Nothing -> throwCore $ Error_Protocol ("key exchange not implemented in HRR, expected key_share extension", True, HandshakeFailure)
-          else do
+          else
             handshakeClient13 cparams ctx groupToSend
       else do
         when rtt0 $

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -311,7 +311,8 @@ handshakeClient' cparams ctx groups mparams = do
                 let ClientTrafficSecret clientEarlySecret = pairClient earlyKey
                 runPacketFlight ctx $ sendChangeCipherSpec13 ctx
                 setTxState ctx usedHash usedCipher clientEarlySecret
-                mapChunks_ 16384 (sendPacket13 ctx . AppData13) earlyData
+                let len = ctxFragmentSize ctx
+                mapChunks_ len (sendPacket13 ctx . AppData13) earlyData
                 usingHState ctx $ setTLS13RTT0Status RTT0Sent
 
         recvServerHello clientSession sentExts = runRecvState ctx recvState

--- a/core/Network/TLS/Imports.hs
+++ b/core/Network/TLS/Imports.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# OPTIONS_GHC -fno-warn-dodgy-exports #-} -- Char8
 
 -- |
 -- Module      : Network.TLS.Imports
@@ -13,7 +12,6 @@ module Network.TLS.Imports
     (
     -- generic exports
       ByteString
-    , module Data.ByteString.Char8 -- instance
     , module Control.Applicative
     , module Control.Monad
 #if !MIN_VERSION_base(4,13,0)
@@ -30,7 +28,7 @@ module Network.TLS.Imports
     ) where
 
 import Data.ByteString (ByteString)
-import Data.ByteString.Char8 ()
+import Data.ByteString.Char8 () -- instance
 
 import Control.Applicative
 import Control.Monad

--- a/core/Network/TLS/Imports.hs
+++ b/core/Network/TLS/Imports.hs
@@ -22,16 +22,9 @@ module Network.TLS.Imports
     , module Data.Bits
     , module Data.List
     , module Data.Maybe
-#if MIN_VERSION_base(4,9,0)
     , module Data.Semigroup
-#else
-    , module Data.Monoid
-#endif
     , module Data.Ord
     , module Data.Word
-#if !MIN_VERSION_base(4,8,0)
-    , sortOn
-#endif
     -- project definition
     , showBytesHex
     ) where
@@ -47,24 +40,12 @@ import Control.Monad.Fail (MonadFail)
 import Data.Bits
 import Data.List
 import Data.Maybe hiding (fromJust)
-#if MIN_VERSION_base(4,9,0)
 import Data.Semigroup
-#else
-import Data.Monoid
-#endif
 import Data.Ord
 import Data.Word
 
 import Data.ByteArray.Encoding as B
 import qualified Prelude as P
-
-#if !MIN_VERSION_base(4,8,0)
-import Prelude ((.))
-
-sortOn :: Ord b => (a -> b) -> [a] -> [a]
-sortOn f =
-  map P.snd . sortBy (comparing P.fst) . map (\x -> let y = f x in y `P.seq` (y, x))
-#endif
 
 showBytesHex :: ByteString -> P.String
 showBytesHex bs = P.show (B.convertToBase B.Base16 bs :: ByteString)

--- a/core/Network/TLS/Util.hs
+++ b/core/Network/TLS/Util.hs
@@ -86,15 +86,17 @@ forEitherM (x:xs) f = f x >>= doTail
     doTail (Left e)  = return (Left e)
 
 mapChunks_ :: Monad m
-           => Int -> (B.ByteString -> m a) -> B.ByteString -> m ()
+           => Maybe Int -> (B.ByteString -> m a) -> B.ByteString -> m ()
 mapChunks_ len f = mapM_ f . getChunks len
 
-getChunks :: Int -> B.ByteString -> [B.ByteString]
-getChunks len bs
-    | B.length bs > len =
-        let (chunk, remain) = B.splitAt len bs
-         in chunk : getChunks len remain
-    | otherwise = [bs]
+getChunks :: Maybe Int -> B.ByteString -> [B.ByteString]
+getChunks Nothing    = (: [])
+getChunks (Just len) = go
+  where
+    go bs | B.length bs > len =
+              let (chunk, remain) = B.splitAt len bs
+               in chunk : go remain
+          | otherwise = [bs]
 
 -- | An opaque newtype wrapper to prevent from poking inside content that has
 -- been saved.


### PR DESCRIPTION
Replaces the constant 16384 used at multiple places with a runtime variable held by the context.
A `Nothing` value can be used to disable fragmentation (assuming an alternative record layer is able to deal with this). The variable could be changed to IORef later, to implement extension "max_fragment_length".

The PR also includes some code clean-up, mostly related to CPP.