### PR TITLE
QUIC mode

### DIFF
--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -190,6 +190,7 @@ contextNew backend params = liftIO $ do
             , ctxKeyLogger        = debugKeyLogger debug
             , ctxRecordLayer      = recordLayer
             , ctxHandshakeSync    = HandshakeSync syncNoOp syncNoOp
+            , ctxQUICMode         = False
             }
 
         syncNoOp _ = return ()

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -137,6 +137,7 @@ data Context = forall bytes . Monoid bytes => Context
     , ctxKeyLogger        :: String -> IO ()
     , ctxRecordLayer      :: RecordLayer bytes
     , ctxHandshakeSync    :: HandshakeSync
+    , ctxQUICMode         :: Bool
     }
 
 updateRecordLayer :: Monoid bytes => RecordLayer bytes -> Context -> Context


### PR DESCRIPTION
This explicitly defines `supportedQUIC` in `Supported`. The name might be a little bit strange. But I chose here because it is convenient to export `defaultSupported` with other QUIC parameters.