### PR TITLE
Stateless handshaker

### DIFF
--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -42,7 +42,6 @@ import Network.TLS.Parameters
 import Network.TLS.IO
 import Network.TLS.Session
 import Network.TLS.Handshake
-import Network.TLS.Handshake.Control
 import Network.TLS.Handshake.Common
 import Network.TLS.Handshake.Common13
 import Network.TLS.Handshake.Process
@@ -208,7 +207,6 @@ recvData13 ctx = do
                 let !label' = B.copy label
                 sessionEstablish (sharedSessionManager $ ctxShared ctx) label' sdata
                 -- putStrLn $ "NewSessionTicket received: lifetime = " ++ show life ++ " sec"
-            contextSync ctx RecvSessionTicketI
             loopHandshake13 hs
         loopHandshake13 (KeyUpdate13 mode:hs) = do
             checkAlignment hs
@@ -327,7 +325,3 @@ updateKey ctx way = liftIO $ do
             sendPacket13 ctx $ Handshake13 [KeyUpdate13 req]
             keyUpdate ctx getTxState setTxState
     return tls13
-
-contextSync :: Context -> ClientStatusI -> IO ()
-contextSync ctx ctl = case ctxHandshakeSync ctx of
-    HandshakeSync sync _ -> sync ctl

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -298,7 +298,7 @@ handshakeClient' cparams ctx groups mparams = do
             mEarlySecInfo <- case rtt0info of
                Nothing   -> return Nothing
                Just info -> Just <$> send0RTT info
-            contextSync ctx $ SendClientHello mEarlySecInfo
+            unless hrr $ contextSync ctx $ SendClientHello mEarlySecInfo
             return (rtt0, map (\(ExtensionRaw i _) -> i) extensions)
 
         get0RTTinfo (_, sdata, choice, _) = do

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -880,8 +880,7 @@ handshakeClient13' cparams ctx groupSent choice = do
     let applicationSecret = triBase appKey
     setResumptionSecret applicationSecret
     alpn <- usingState_ ctx getNegotiatedProtocol
-    mode <- usingHState ctx getTLS13HandshakeMode
-    let appSecInfo = ApplicationSecretInfo mode alpn (triClient appKey, triServer appKey)
+    let appSecInfo = ApplicationSecretInfo alpn (triClient appKey, triServer appKey)
     contextSync ctx $ SendClientFinished eexts appSecInfo
     handshakeTerminate13 ctx
   where

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -238,8 +238,9 @@ handshakeClient' cparams ctx groups mparams = do
               Just cookie -> return $ Just $ toExtensionRaw cookie
 
         postHandshakeAuthExtension
-          | tls13     = return $ Just $ toExtensionRaw PostHandshakeAuth
-          | otherwise = return Nothing
+          | ctxQUICMode ctx = return Nothing
+          | tls13           = return $ Just $ toExtensionRaw PostHandshakeAuth
+          | otherwise       = return Nothing
 
         adjustExtentions pskInfo exts ch =
             case pskInfo of

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -292,7 +292,7 @@ handshakeClient' cparams ctx groups mparams = do
             let rtt0info = pskInfo >>= get0RTTinfo
                 rtt0 = isJust rtt0info
             extensions0 <- catMaybes <$> getExtensions pskInfo rtt0
-            let extensions1 = sharedExtensions (clientShared cparams) ++ extensions0
+            let extensions1 = sharedHelloExtensions (clientShared cparams) ++ extensions0
             extensions <- adjustExtentions pskInfo extensions1 $ mkClientHello extensions1
             sendPacket ctx $ Handshake [mkClientHello extensions]
             mEarlySecInfo <- case rtt0info of

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -879,8 +879,7 @@ handshakeClient13' cparams ctx groupSent choice = do
     appKey <- switchToApplicationSecret handshakeSecret hChSf
     let applicationSecret = triBase appKey
     setResumptionSecret applicationSecret
-    alpn <- usingState_ ctx getNegotiatedProtocol
-    let appSecInfo = ApplicationSecretInfo alpn (triClient appKey, triServer appKey)
+    let appSecInfo = ApplicationSecretInfo (triClient appKey, triServer appKey)
     contextSync ctx $ SendClientFinished eexts appSecInfo
     handshakeTerminate13 ctx
   where

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -298,7 +298,7 @@ handshakeClient' cparams ctx groups mparams = do
             mEarlySecInfo <- case rtt0info of
                Nothing   -> return Nothing
                Just info -> Just <$> send0RTT info
-            contextSync ctx $ SendClientHelloI mEarlySecInfo
+            contextSync ctx $ SendClientHello mEarlySecInfo
             return (rtt0, map (\(ExtensionRaw i _) -> i) extensions)
 
         get0RTTinfo (_, sdata, choice, _) = do
@@ -864,7 +864,7 @@ handshakeClient13' cparams ctx groupSent choice = do
         clientHandshakeSecret = triClient hkey
         serverHandshakeSecret = triServer hkey
         handSecInfo = HandshakeSecretInfo usedCipher (clientHandshakeSecret,serverHandshakeSecret)
-    contextSync ctx $ RecvServerHelloI handSecInfo
+    contextSync ctx $ RecvServerHello handSecInfo
     (rtt0accepted,eexts) <- runRecvHandshake13 $ do
         accext <- recvHandshake13 ctx expectEncryptedExtensions
         unless resuming $ recvHandshake13 ctx expectCertRequest
@@ -882,7 +882,7 @@ handshakeClient13' cparams ctx groupSent choice = do
     alpn <- usingState_ ctx getNegotiatedProtocol
     mode <- usingHState ctx getTLS13HandshakeMode
     let appSecInfo = ApplicationSecretInfo mode alpn (triClient appKey, triServer appKey)
-    contextSync ctx $ SendClientFinishedI eexts appSecInfo
+    contextSync ctx $ SendClientFinished eexts appSecInfo
     handshakeTerminate13 ctx
   where
     usedCipher = cCipher choice
@@ -1091,6 +1091,6 @@ postHandshakeAuthClientWith cparams ctx h@(CertRequest13 certReqCtx exts) =
 postHandshakeAuthClientWith _ _ _ =
     throwCore $ Error_Protocol ("unexpected handshake message received in postHandshakeAuthClientWith", True, UnexpectedMessage)
 
-contextSync :: Context -> ClientStatusI -> IO ()
+contextSync :: Context -> ClientState -> IO ()
 contextSync ctx ctl = case ctxHandshakeSync ctx of
     HandshakeSync sync _ -> sync ctl

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -45,14 +45,10 @@ data ClientStatusI =
     SendClientHelloI (Maybe EarlySecretInfo)
   | RecvServerHelloI HandshakeSecretInfo
   | SendClientFinishedI [ExtensionRaw] ApplicationSecretInfo
-  | RecvSessionTicketI
-  | ClientHandshakeFailedI TLSError
 
 data ServerStatusI =
     SendServerHelloI [ExtensionRaw] (Maybe EarlySecretInfo) HandshakeSecretInfo
   | SendServerFinishedI ApplicationSecretInfo
-  | SendSessionTicketI
-  | ServerHandshakeFailedI TLSError
 
 ----------------------------------------------------------------
 

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -6,8 +6,8 @@
 -- Portability : unknown
 --
 module Network.TLS.Handshake.Control (
-    ClientStatusI(..)
-  , ServerStatusI(..)
+    ClientState(..)
+  , ServerState(..)
   , EarlySecretInfo(..)
   , HandshakeSecretInfo(..)
   , ApplicationSecretInfo(..)
@@ -41,16 +41,16 @@ data ApplicationSecretInfo = ApplicationSecretInfo HandshakeMode13 (Maybe Negoti
 
 ----------------------------------------------------------------
 
-data ClientStatusI =
-    SendClientHelloI (Maybe EarlySecretInfo)
-  | RecvServerHelloI HandshakeSecretInfo
-  | SendClientFinishedI [ExtensionRaw] ApplicationSecretInfo
+data ClientState =
+    SendClientHello (Maybe EarlySecretInfo)
+  | RecvServerHello HandshakeSecretInfo
+  | SendClientFinished [ExtensionRaw] ApplicationSecretInfo
 
-data ServerStatusI =
-    SendServerHelloI [ExtensionRaw] (Maybe EarlySecretInfo) HandshakeSecretInfo
-  | SendServerFinishedI ApplicationSecretInfo
+data ServerState =
+    SendServerHello [ExtensionRaw] (Maybe EarlySecretInfo) HandshakeSecretInfo
+  | SendServerFinished ApplicationSecretInfo
 
 ----------------------------------------------------------------
 
-data HandshakeSync = HandshakeSync (ClientStatusI -> IO ())
-                                   (ServerStatusI -> IO ())
+data HandshakeSync = HandshakeSync (ClientState -> IO ())
+                                   (ServerState -> IO ())

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -6,14 +6,8 @@
 -- Portability : unknown
 --
 module Network.TLS.Handshake.Control (
-    ClientControl(..)
-  , ServerControl(..)
-  , ClientStatus(..)
-  , ClientStatusI(..)
-  , ServerStatus(..)
+    ClientStatusI(..)
   , ServerStatusI(..)
-  , ClientController
-  , ServerController
   , EarlySecretInfo(..)
   , HandshakeSecretInfo(..)
   , ApplicationSecretInfo(..)
@@ -47,90 +41,12 @@ data ApplicationSecretInfo = ApplicationSecretInfo HandshakeMode13 (Maybe Negoti
 
 ----------------------------------------------------------------
 
--- | Interface to execute the next handshake step for a TLS client.
-type ClientController = ClientControl -> IO ClientStatus
-
--- | Interface to execute the next handshake step for a TLS server.
-type ServerController = ServerControl -> IO ServerStatus
-
--- | Tell what step to execute in the client handshake.
-data ClientControl
-    = EnterClient
-      -- ^ Start and run the client handshake until the @Finished@ message is
-      -- sent.
-      --
-      -- Possible responses: 'ClientHandshakeComplete', 'ClientHandshakeFailed'
-    | RecvSessionTickets
-      -- ^ Continue to listen to incoming messages in order to receive and
-      -- process session tickets.  This call can be repeated until external
-      -- confirmation is received that server already sent all tickets.
-      --
-      -- Possible responses: 'ClientRecvSessionTicket', 'ClientHandshakeFailed'
-    | ExitClient
-      -- ^ Terminate the TLS client, possibly prematurely, and free resources.
-      --
-      -- Possible response: 'ClientHandshakeDone'
-
--- | Tell what step to execute in the server handshake.
-data ServerControl
-    = EnterServer
-      -- ^ Start and run the server handshake until the @Finished@ message is
-      -- sent.
-      --
-      -- Possible responses: 'ServerFinishedSent', 'ServerHandshakeFailed'
-    | CompleteServer
-      -- ^ Continue the handshake in order to receive the client @Finished@
-      -- message and complete the handshake.
-      --
-      -- Possible responses: 'ServerHandshakeComplete', 'ServerHandshakeFailed'
-    | ExitServer
-      -- ^ Terminate the TLS server, possibly prematurely, and free resources.
-      --
-      -- Possible response: 'ServerHandshakeDone'
-
--- | Handshake status of the TLS client.
-data ClientStatus
-  = ClientHandshakeComplete
-    -- ^ The client just sent its @Finished@ message sucessfully, so the
-    -- handshake is considered complete.  Still the client should continue to
-    -- run in order to receive session tickets, until final confirmation by the
-    -- server.
-  | ClientRecvSessionTicket
-    -- ^ The client has received one session ticket successfully, and can still
-    -- run in case the server wants to send more tickets.
-  | ClientHandshakeDone
-    -- ^ The client exited sucessfully and released all resources.
-  | ClientHandshakeFailed TLSError
-    -- ^ The client handshake aborted prematurely for the specified reason and
-    -- resources have been released.  An alert can be sent to the peer.
-  deriving Show
-
 data ClientStatusI =
     SendClientHelloI (Maybe EarlySecretInfo)
   | RecvServerHelloI HandshakeSecretInfo
   | SendClientFinishedI [ExtensionRaw] ApplicationSecretInfo
   | RecvSessionTicketI
   | ClientHandshakeFailedI TLSError
-
--- | Handshake status of the TLS server.
-data ServerStatus
-  = ServerFinishedSent
-    -- ^ The server just sent its @Finished@ message sucessfully, and now
-    -- expects to receive the final client flight.
-    --
-    -- Application traffic secrets have been installed so the server can already
-    -- send application traffic if required (but to an unverified client at this
-    -- point).
-  | ServerHandshakeComplete
-    -- ^ The server just received and verified the client @Finished@ message, so
-    -- the handshake is considered complete and confirmed.  Session tickets have
-    -- been emitted sucessfully too.
-  | ServerHandshakeDone
-    -- ^ The server exited sucessfully and released all resources.
-  | ServerHandshakeFailed TLSError
-    -- ^ The server handshake aborted prematurely for the specified reason and
-    -- resources have been released.  An alert can be sent to the peer.
-  deriving Show
 
 data ServerStatusI =
     SendServerHelloI [ExtensionRaw] (Maybe EarlySecretInfo) HandshakeSecretInfo

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -35,7 +35,7 @@ data HandshakeSecretInfo = HandshakeSecretInfo Cipher (TrafficSecrets HandshakeS
                          deriving Show
 
 -- | Handshake information generated for traffic at application level.
-data ApplicationSecretInfo = ApplicationSecretInfo (TrafficSecrets ApplicationSecret)
+newtype ApplicationSecretInfo = ApplicationSecretInfo (TrafficSecrets ApplicationSecret)
                          deriving Show
 
 ----------------------------------------------------------------

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -16,7 +16,6 @@ module Network.TLS.Handshake.Control (
   ) where
 
 import Network.TLS.Cipher
-import Network.TLS.Handshake.State
 import Network.TLS.Imports
 import Network.TLS.Struct
 import Network.TLS.Types
@@ -36,7 +35,7 @@ data HandshakeSecretInfo = HandshakeSecretInfo Cipher (TrafficSecrets HandshakeS
                          deriving Show
 
 -- | Handshake information generated for traffic at application level.
-data ApplicationSecretInfo = ApplicationSecretInfo HandshakeMode13 (Maybe NegotiatedProtocol) (TrafficSecrets ApplicationSecret)
+data ApplicationSecretInfo = ApplicationSecretInfo (Maybe NegotiatedProtocol) (TrafficSecrets ApplicationSecret)
                          deriving Show
 
 ----------------------------------------------------------------

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -35,7 +35,7 @@ data HandshakeSecretInfo = HandshakeSecretInfo Cipher (TrafficSecrets HandshakeS
                          deriving Show
 
 -- | Handshake information generated for traffic at application level.
-data ApplicationSecretInfo = ApplicationSecretInfo (Maybe NegotiatedProtocol) (TrafficSecrets ApplicationSecret)
+data ApplicationSecretInfo = ApplicationSecretInfo (TrafficSecrets ApplicationSecret)
                          deriving Show
 
 ----------------------------------------------------------------

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -774,8 +774,7 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
         serverApplicationSecret0 = triServer appKey
         applicationSecret = triBase appKey
     setTxState ctx usedHash usedCipher serverApplicationSecret0
-    alpn <- usingState_ ctx getNegotiatedProtocol
-    let appSecInfo = ApplicationSecretInfo alpn (clientApplicationSecret0,serverApplicationSecret0)
+    let appSecInfo = ApplicationSecretInfo (clientApplicationSecret0,serverApplicationSecret0)
     contextSync ctx $ SendServerFinished appSecInfo
     ----------------------------------------------------------------
     if rtt0OK then

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -775,14 +775,7 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
         applicationSecret = triBase appKey
     setTxState ctx usedHash usedCipher serverApplicationSecret0
     alpn <- usingState_ ctx getNegotiatedProtocol
-    -- TLS13RTT0Status is not exposed, so needs to distinguish
-    -- RTT0 and PreSharedKey.
-    let mode
-         | rtt0OK                   = RTT0
-         | authenticated && not hrr = PreSharedKey
-         | hrr                      = HelloRetryRequest
-         | otherwise                = FullHandshake
-    let appSecInfo = ApplicationSecretInfo mode alpn (clientApplicationSecret0,serverApplicationSecret0)
+    let appSecInfo = ApplicationSecretInfo alpn (clientApplicationSecret0,serverApplicationSecret0)
     contextSync ctx $ SendServerFinished appSecInfo
     ----------------------------------------------------------------
     if rtt0OK then

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -756,7 +756,7 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
                  | is0RTTvalid = Just $ EarlySecretInfo usedCipher clientEarlySecret
                  | otherwise   = Nothing
                 handSecInfo = HandshakeSecretInfo usedCipher (clientHandshakeSecret,serverHandshakeSecret)
-            contextSync ctx $ SendServerHelloI exts mEarlySecInfo handSecInfo
+            contextSync ctx $ SendServerHello exts mEarlySecInfo handSecInfo
     ----------------------------------------------------------------
         sendExtensions rtt0OK protoExt
         case mCredInfo of
@@ -783,7 +783,7 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
          | hrr                      = HelloRetryRequest
          | otherwise                = FullHandshake
     let appSecInfo = ApplicationSecretInfo mode alpn (clientApplicationSecret0,serverApplicationSecret0)
-    contextSync ctx $ SendServerFinishedI appSecInfo
+    contextSync ctx $ SendServerFinished appSecInfo
     ----------------------------------------------------------------
     if rtt0OK then
         setEstablished ctx (EarlyDataAllowed rtt0max)
@@ -1198,6 +1198,6 @@ postHandshakeAuthServerWith sparams ctx h@(Certificate13 certCtx certs _ext) = d
 postHandshakeAuthServerWith _ _ _ =
     throwCore $ Error_Protocol ("unexpected handshake message received in postHandshakeAuthServerWith", True, UnexpectedMessage)
 
-contextSync :: Context -> ServerStatusI -> IO ()
+contextSync :: Context -> ServerState -> IO ()
 contextSync ctx ctl = case ctxHandshakeSync ctx of
     HandshakeSync _ sync -> sync ctl

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -808,9 +808,7 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
           unless skip $ recvHandshake13hash ctx (expectCertVerify sparams ctx)
           recvHandshake13hash ctx expectFinished
           ensureRecvComplete ctx
-      else if rtt0OK && ctxQUICMode ctx then
-        setPendingActions ctx [PendingActionHash True expectFinished]
-      else if rtt0OK then
+      else if rtt0OK && not (ctxQUICMode ctx) then
         setPendingActions ctx [PendingAction True expectEndOfEarlyData
                               ,PendingActionHash True expectFinished]
       else

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -796,7 +796,6 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
             handshakeTerminate13 ctx
             setRxState ctx usedHash usedCipher clientApplicationSecret0
             sendNewSessionTicket applicationSecret sfSentTime
-            contextSync ctx $ SendSessionTicketI
         expectFinished _ hs = unexpected (show hs) (Just "finished 13")
 
     let expectEndOfEarlyData EndOfEarlyData13 =

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -754,7 +754,7 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
                 else setRxState ctx usedHash usedCipher clientHandshakeSecret
             setTxState ctx usedHash usedCipher serverHandshakeSecret
             let mEarlySecInfo
-                 | is0RTTvalid = Just $ EarlySecretInfo usedCipher clientEarlySecret
+                 | rtt0OK      = Just $ EarlySecretInfo usedCipher clientEarlySecret
                  | otherwise   = Nothing
                 handSecInfo = HandshakeSecretInfo usedCipher (clientHandshakeSecret,serverHandshakeSecret)
             contextSync ctx $ SendServerHello exts mEarlySecInfo handSecInfo

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -369,7 +369,7 @@ doHandshake sparams mcred ctx chosenVersion usedCipher usedCompression clientSes
                       -- field of this extension SHALL be empty.
                       Just _  -> return [ ExtensionRaw extensionID_ServerName ""]
                       Nothing -> return []
-            let extensions = sharedExtensions (serverShared sparams)
+            let extensions = sharedHelloExtensions (serverShared sparams)
                           ++ secRengExt ++ emsExt ++ protoExt ++ sniExt
             usingState_ ctx (setVersion chosenVersion)
             usingHState ctx $ setServerHelloParameters chosenVersion srand usedCipher usedCompression
@@ -932,7 +932,7 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
         let earlyDataExtension
               | rtt0OK = Just $ ExtensionRaw extensionID_EarlyData $ extensionEncode (EarlyDataIndication Nothing)
               | otherwise = Nothing
-        let extensions = sharedExtensions (serverShared sparams)
+        let extensions = sharedHelloExtensions (serverShared sparams)
                       ++ catMaybes [earlyDataExtension
                                    ,groupExtension
                                    ,sniExtension

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -369,7 +369,8 @@ doHandshake sparams mcred ctx chosenVersion usedCipher usedCompression clientSes
                       -- field of this extension SHALL be empty.
                       Just _  -> return [ ExtensionRaw extensionID_ServerName ""]
                       Nothing -> return []
-            let extensions = secRengExt ++ emsExt ++ protoExt ++ sniExt
+            let extensions = sharedExtensions (serverShared sparams)
+                          ++ secRengExt ++ emsExt ++ protoExt ++ sniExt
             usingState_ ctx (setVersion chosenVersion)
             usingHState ctx $ setServerHelloParameters chosenVersion srand usedCipher usedCompression
             return $ ServerHello chosenVersion srand session (cipherID usedCipher)

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -404,7 +404,7 @@ data Shared = Shared
       -- based on the TLS version.
       --
       -- Default: @[]@
-    , sharedExtensions      :: [ExtensionRaw]
+    , sharedHelloExtensions :: [ExtensionRaw]
     }
 
 instance Show Shared where
@@ -415,7 +415,7 @@ instance Default Shared where
             , sharedSessionManager  = noSessionManager
             , sharedCAStore         = mempty
             , sharedValidationCache = def
-            , sharedExtensions      = []
+            , sharedHelloExtensions = []
             }
 
 -- | Group usage callback possible return values.

--- a/core/Network/TLS/Parameters.hs
+++ b/core/Network/TLS/Parameters.hs
@@ -397,7 +397,13 @@ data Shared = Shared
       --
       -- See the default value of 'ValidationCache'.
     , sharedValidationCache :: ValidationCache
-      -- | Additional extensions for ClientHello and EncryptedExtensions.
+      -- | Additional extensions to be sent during the Hello sequence.
+      --
+      -- For a client this is always included in message ClientHello.  For a
+      -- server, this is sent in messages ServerHello or EncryptedExtensions
+      -- based on the TLS version.
+      --
+      -- Default: @[]@
     , sharedExtensions      :: [ExtensionRaw]
     }
 

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -207,11 +207,11 @@ newQUICClient cparams callbacks = do
     handshake ctx2
     void $ recvData ctx2
   where
-    sync (SendClientHelloI mEarlySecInfo) =
+    sync (SendClientHello mEarlySecInfo) =
         quicInstallKeys callbacks (InstallEarlyKeys mEarlySecInfo)
-    sync (RecvServerHelloI handSecInfo) =
+    sync (RecvServerHello handSecInfo) =
         quicInstallKeys callbacks (InstallHandshakeKeys handSecInfo)
-    sync (SendClientFinishedI exts appSecInfo) = do
+    sync (SendClientFinished exts appSecInfo) = do
         quicInstallKeys callbacks (InstallApplicationKeys appSecInfo)
         quicNotifyExtensions callbacks (filterQTP exts)
 
@@ -234,11 +234,11 @@ newQUICServer sparams callbacks = do
     handshake ctx2
     quicDone callbacks
   where
-    sync (SendServerHelloI exts mEarlySecInfo handSecInfo) = do
+    sync (SendServerHello exts mEarlySecInfo handSecInfo) = do
         quicInstallKeys callbacks (InstallEarlyKeys mEarlySecInfo)
         quicInstallKeys callbacks (InstallHandshakeKeys handSecInfo)
         quicNotifyExtensions callbacks (filterQTP exts)
-    sync (SendServerFinishedI appSecInfo) = do
+    sync (SendServerFinished appSecInfo) = do
         quicInstallKeys callbacks (InstallApplicationKeys appSecInfo)
 
 {-

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -13,30 +13,7 @@
 -- * QUIC starts a TLS client or server thread with 'newQUICClient' or
 --   'newQUICServer'.
 --
--- * QUIC executes and monitors the progress of the handshake with the
---   'ClientController' or 'ServerController' functions.  It sends continuation
---   messages and listens for the resulting status, success or failure.  At any
---   point it can decide to terminate the current handshake with constructors
---   'ExitClient' and 'ExitServer' .
---
--- The main steps of the handshake defined in the 'ClientController' /
--- 'ServerController' state machines are:
---
--- * @FinishedSent@: message Finished has been sent, endpoint is ready to send
---   application traffic
---
--- * @HandshakeComplete@: peer message Finished has been received and verified,
---   endpoint is ready to receive application traffic
---
--- * @HandshakeConfirmed@: TLS handshake is no more needed, session tickets have
---   all been transferred
---
--- Out of those three defined steps, only two are really used.  For a client,
--- steps @FinishedSent@ and @HandshakeComplete@ are the same.  For a server,
--- steps @HandshakeComplete@ and @HandshakeConfirmed@ are the same.
---
--- On the southbound API, TLS invokes QUIC callbacks to use the QUIC transport
--- protocol:
+--  TLS invokes QUIC callbacks to use the QUIC transport
 --
 -- * TLS uses 'quicSend' and 'quicRecv' to send and receive handshake message
 --   fragments.
@@ -46,6 +23,8 @@
 --
 -- * TLS calls 'quicNotifyExtensions' to notify to QUIC the transport parameters
 --   exchanged through the handshake protocol.
+--
+-- * TLS server calls 'quicDone' when the handshake is done.
 --
 module Network.TLS.QUIC (
     -- * Supported
@@ -68,16 +47,16 @@ module Network.TLS.QUIC (
     , EarlySecretInfo(..)
     , HandshakeSecretInfo(..)
     , ApplicationSecretInfo(..)
-    -- * Client handshake controller
+    -- * Handshakers
     , newQUICClient
-    -- * Server handshake controller
     , newQUICServer
-    -- * Common
+    -- * Callback
     , CryptLevel(..)
     , KeyScheduleEvent(..)
     , QUICCallbacks(..)
     , NegotiatedProtocol
     , HandshakeMode13(..)
+    -- * Common
     , errorTLS
     , errorToAlertDescription
     , errorToAlertMessage

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -226,15 +226,6 @@ tlsQUICServer sparams callbacks = do
     sync (SendServerFinished appSecInfo) =
         quicInstallKeys callbacks (InstallApplicationKeys appSecInfo)
 
-{-
-getErrorCause :: TLSException -> TLSError
-getErrorCause (HandshakeFailed e) = e
-getErrorCause (Terminated _ _ e) = e
-getErrorCause e =
-    let msg = "unexpected TLS exception: " ++ show e
-     in Error_Protocol (msg, True, InternalError)
--}
-
 filterQTP :: [ExtensionRaw] -> [ExtensionRaw]
 filterQTP = filter (\(ExtensionRaw eid _) -> eid == extensionID_QuicTransportParameters)
 

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -147,7 +147,7 @@ data QUICCallbacks = QUICCallbacks
     , quicNotifyExtensions  :: [ExtensionRaw] -> IO ()
       -- ^ Called by TLS when QUIC-specific extensions have been received from
       -- the peer.
-    , quicDone :: IO ()
+    , quicDone :: Context -> IO ()
       -- ^ Called by Server TLS when the handshake is done.
     }
 
@@ -213,7 +213,7 @@ newQUICServer sparams callbacks = do
         rl = newRecordLayer ctx1 callbacks
         ctx2 = updateRecordLayer rl ctx1
     handshake ctx2
-    quicDone callbacks
+    quicDone callbacks ctx2
   where
     sync (SendServerHello exts mEarlySecInfo handSecInfo) = do
         quicInstallKeys callbacks (InstallEarlyKeys mEarlySecInfo)

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -166,6 +166,8 @@ data QUICCallbacks = QUICCallbacks
     , quicNotifyExtensions  :: [ExtensionRaw] -> IO ()
       -- ^ Called by TLS when QUIC-specific extensions have been received from
       -- the peer.
+    , quicDone :: IO ()
+      -- ^ Called by Server TLS when the handshake is done.
     }
 
 getTxLevel :: Context -> IO CryptLevel
@@ -230,7 +232,7 @@ newQUICServer sparams callbacks = do
         rl = newRecordLayer ctx1 callbacks
         ctx2 = updateRecordLayer rl ctx1
     handshake ctx2
-    void $ recvData ctx2
+    quicDone callbacks
   where
     sync (SendServerHelloI exts mEarlySecInfo handSecInfo) = do
         quicInstallKeys callbacks (InstallEarlyKeys mEarlySecInfo)

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -10,8 +10,8 @@
 --
 -- On the northbound API:
 --
--- * QUIC starts a TLS client or server thread with 'newQUICClient' or
---   'newQUICServer'.
+-- * QUIC starts a TLS client or server thread with 'quicClient' or
+--   'quicServer'.
 --
 --  TLS invokes QUIC callbacks to use the QUIC transport
 --
@@ -28,8 +28,8 @@
 --
 module Network.TLS.QUIC (
     -- * Handshakers
-      newQUICClient
-    , newQUICServer
+      tlsQUICClient
+    , tlsQUICServer
     -- * Callback
     , QUICCallbacks(..)
     , CryptLevel(..)
@@ -148,7 +148,7 @@ data QUICCallbacks = QUICCallbacks
       -- ^ Called by TLS when QUIC-specific extensions have been received from
       -- the peer.
     , quicDone :: Context -> IO ()
-      -- ^ Called when 'handshake' is done. 'newQUICServer' is
+      -- ^ Called when 'handshake' is done. 'tlsQUICServer' is
       -- finished after calling this hook. 'newQUICClinet' calls
       -- 'recvData' after calling this hook to wait for new session
       -- tickets.
@@ -178,8 +178,8 @@ newRecordLayer ctx callbacks = newTransparentRecordLayer get send recv
 --
 -- Execution and synchronization between the internal TLS thread and external
 -- QUIC threads is done through the 'ClientController' interface returned.
-newQUICClient :: ClientParams -> QUICCallbacks -> IO ()
-newQUICClient cparams callbacks = do
+tlsQUICClient :: ClientParams -> QUICCallbacks -> IO ()
+tlsQUICClient cparams callbacks = do
     ctx0 <- contextNew nullBackend cparams
     let ctx1 = ctx0
            { ctxHandshakeSync = HandshakeSync sync (\_ -> return ())
@@ -206,8 +206,8 @@ newQUICClient cparams callbacks = do
 --
 -- Execution and synchronization between the internal TLS thread and external
 -- QUIC threads is done through the 'ServerController' interface returned.
-newQUICServer :: ServerParams -> QUICCallbacks -> IO ()
-newQUICServer sparams callbacks = do
+tlsQUICServer :: ServerParams -> QUICCallbacks -> IO ()
+tlsQUICServer sparams callbacks = do
     ctx0 <- contextNew nullBackend sparams
     let ctx1 = ctx0
           { ctxHandshakeSync = HandshakeSync (\_ -> return ()) sync

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -212,8 +212,6 @@ newQUICClient cparams callbacks = do
     sync (SendClientFinishedI exts appSecInfo) = do
         quicInstallKeys callbacks (InstallApplicationKeys appSecInfo)
         quicNotifyExtensions callbacks (filterQTP exts)
-    sync RecvSessionTicketI = return ()
-    sync (ClientHandshakeFailedI _e) = return ()
 
 -- | Start a TLS handshake thread for a QUIC server.  The server will use the
 -- specified TLS parameters and call the provided callback functions to send and
@@ -240,8 +238,6 @@ newQUICServer sparams callbacks = do
         quicNotifyExtensions callbacks (filterQTP exts)
     sync (SendServerFinishedI appSecInfo) = do
         quicInstallKeys callbacks (InstallApplicationKeys appSecInfo)
-    sync SendSessionTicketI = return ()
-    sync (ServerHandshakeFailedI _e) = return ()
 
 {-
 getErrorCause :: TLSException -> TLSError

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -186,7 +186,7 @@ tlsQUICClient cparams callbacks = do
            , ctxFragmentSize = Nothing
            , ctxQUICMode = True
            }
-        rl = newRecordLayer ctx1 callbacks
+        rl = newRecordLayer ctx2 callbacks
         ctx2 = updateRecordLayer rl ctx1
     handshake ctx2
     quicDone callbacks ctx2
@@ -214,7 +214,7 @@ tlsQUICServer sparams callbacks = do
           , ctxFragmentSize = Nothing
           , ctxQUICMode = True
           }
-        rl = newRecordLayer ctx1 callbacks
+        rl = newRecordLayer ctx2 callbacks
         ctx2 = updateRecordLayer rl ctx1
     handshake ctx2
     quicDone callbacks ctx2
@@ -223,7 +223,7 @@ tlsQUICServer sparams callbacks = do
         quicInstallKeys callbacks (InstallEarlyKeys mEarlySecInfo)
         quicInstallKeys callbacks (InstallHandshakeKeys handSecInfo)
         quicNotifyExtensions callbacks (filterQTP exts)
-    sync (SendServerFinished appSecInfo) = do
+    sync (SendServerFinished appSecInfo) =
         quicInstallKeys callbacks (InstallApplicationKeys appSecInfo)
 
 {-

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -27,42 +27,44 @@
 -- * TLS server calls 'quicDone' when the handshake is done.
 --
 module Network.TLS.QUIC (
-    -- * Supported
-      defaultSupported
-    -- * Hash
-    , hkdfExpandLabel
-    , hkdfExtract
-    , hashDigestSize
-    -- * Extensions
-    , ExtensionRaw(..)
-    , ExtensionID
-    , extensionID_QuicTransportParameters
+    -- * Handshakers
+      newQUICClient
+    , newQUICServer
+    -- * Callback
+    , QUICCallbacks(..)
+    , CryptLevel(..)
+    , KeyScheduleEvent(..)
     -- * Secrets
-    , ServerTrafficSecret(..)
-    , ClientTrafficSecret(..)
+    , EarlySecretInfo(..)
+    , HandshakeSecretInfo(..)
+    , ApplicationSecretInfo(..)
     , EarlySecret
     , HandshakeSecret
     , ApplicationSecret
     , TrafficSecrets
-    , EarlySecretInfo(..)
-    , HandshakeSecretInfo(..)
-    , ApplicationSecretInfo(..)
-    -- * Handshakers
-    , newQUICClient
-    , newQUICServer
-    -- * Callback
-    , CryptLevel(..)
-    , KeyScheduleEvent(..)
-    , QUICCallbacks(..)
+    , ServerTrafficSecret(..)
+    , ClientTrafficSecret(..)
+    -- * Negotiated parameters
     , NegotiatedProtocol
     , HandshakeMode13(..)
-    -- * Common
+    -- * Extensions
+    , ExtensionRaw(..)
+    , ExtensionID
+    , extensionID_QuicTransportParameters
+    -- * Errors
     , errorTLS
     , errorToAlertDescription
     , errorToAlertMessage
     , fromAlertDescription
     , toAlertDescription
+    -- * Hash
+    , hkdfExpandLabel
+    , hkdfExtract
+    , hashDigestSize
+    -- * Constants
     , quicMaxEarlyDataSize
+    -- * Supported
+    , defaultSupported
     ) where
 
 import Network.TLS.Backend


### PR DESCRIPTION
The old implementation of QUIC early data is just specifying wire data (`ByteString`) to the configuration. This is good for HTTP/1.1 whose protocol is based on text. But for HTTP/3, it's hard to generate early data in advance since multiple threads generate frames.

The current implementation of QUIC early data is just specifying `Bool` (use0RTT) to the configuration. If `True`, the client controller MUST return after sending Client Hello so that QUIC applications can send streams and internal code encrypted them with client early secret.

If `False`, the client controller MUST return after sending Client Finished. Unfortunately, the old two-phase approach cannot implements this two modes.

This PR removes the controls and the exported states. The *handshakers* purely synchronize with QUIC threands through callbacks. The result of interoperability tests is very good.
