### PR TITLE
Setting necessary QUIC parameters before 1RTT gets ready

### DIFF
--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -880,7 +880,8 @@ handshakeClient13' cparams ctx groupSent choice = do
     appKey <- switchToApplicationSecret handshakeSecret hChSf
     let applicationSecret = triBase appKey
     setResumptionSecret applicationSecret
-    let appSecInfo = ApplicationSecretInfo (triClient appKey, triServer appKey)
+    alpn <- usingState_ ctx getNegotiatedProtocol
+    let appSecInfo = ApplicationSecretInfo alpn (triClient appKey, triServer appKey)
     contextSync ctx $ SendClientFinished eexts appSecInfo
     handshakeTerminate13 ctx
   where

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -881,7 +881,8 @@ handshakeClient13' cparams ctx groupSent choice = do
     let applicationSecret = triBase appKey
     setResumptionSecret applicationSecret
     alpn <- usingState_ ctx getNegotiatedProtocol
-    let appSecInfo = ApplicationSecretInfo alpn (triClient appKey, triServer appKey)
+    mode <- usingHState ctx getTLS13HandshakeMode
+    let appSecInfo = ApplicationSecretInfo mode alpn (triClient appKey, triServer appKey)
     contextSync ctx $ SendClientFinished eexts appSecInfo
     handshakeTerminate13 ctx
   where

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -35,7 +35,7 @@ data HandshakeSecretInfo = HandshakeSecretInfo Cipher (TrafficSecrets HandshakeS
                          deriving Show
 
 -- | Handshake information generated for traffic at application level.
-newtype ApplicationSecretInfo = ApplicationSecretInfo (TrafficSecrets ApplicationSecret)
+data ApplicationSecretInfo = ApplicationSecretInfo (TrafficSecrets ApplicationSecret)
                          deriving Show
 
 ----------------------------------------------------------------

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -16,6 +16,7 @@ module Network.TLS.Handshake.Control (
   ) where
 
 import Network.TLS.Cipher
+import Network.TLS.Handshake.State
 import Network.TLS.Imports
 import Network.TLS.Struct
 import Network.TLS.Types
@@ -35,7 +36,7 @@ data HandshakeSecretInfo = HandshakeSecretInfo Cipher (TrafficSecrets HandshakeS
                          deriving Show
 
 -- | Handshake information generated for traffic at application level.
-data ApplicationSecretInfo = ApplicationSecretInfo (Maybe NegotiatedProtocol) (TrafficSecrets ApplicationSecret)
+data ApplicationSecretInfo = ApplicationSecretInfo HandshakeMode13 (Maybe NegotiatedProtocol) (TrafficSecrets ApplicationSecret)
                          deriving Show
 
 ----------------------------------------------------------------

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -35,7 +35,7 @@ data HandshakeSecretInfo = HandshakeSecretInfo Cipher (TrafficSecrets HandshakeS
                          deriving Show
 
 -- | Handshake information generated for traffic at application level.
-data ApplicationSecretInfo = ApplicationSecretInfo (TrafficSecrets ApplicationSecret)
+data ApplicationSecretInfo = ApplicationSecretInfo (Maybe NegotiatedProtocol) (TrafficSecrets ApplicationSecret)
                          deriving Show
 
 ----------------------------------------------------------------

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -775,7 +775,8 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
         serverApplicationSecret0 = triServer appKey
         applicationSecret = triBase appKey
     setTxState ctx usedHash usedCipher serverApplicationSecret0
-    let appSecInfo = ApplicationSecretInfo (clientApplicationSecret0,serverApplicationSecret0)
+    alpn <- usingState_ ctx getNegotiatedProtocol
+    let appSecInfo = ApplicationSecretInfo alpn (clientApplicationSecret0,serverApplicationSecret0)
     contextSync ctx $ SendServerFinished appSecInfo
     ----------------------------------------------------------------
     if rtt0OK then

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -197,8 +197,8 @@ tlsQUICClient cparams callbacks = do
     sync (RecvServerHello handSecInfo) =
         quicInstallKeys callbacks (InstallHandshakeKeys handSecInfo)
     sync (SendClientFinished exts appSecInfo) = do
-        quicInstallKeys callbacks (InstallApplicationKeys appSecInfo)
         quicNotifyExtensions callbacks (filterQTP exts)
+        quicInstallKeys callbacks (InstallApplicationKeys appSecInfo)
 
 -- | Start a TLS handshake thread for a QUIC server.  The server will use the
 -- specified TLS parameters and call the provided callback functions to send and
@@ -220,9 +220,9 @@ tlsQUICServer sparams callbacks = do
     quicDone callbacks ctx2
   where
     sync (SendServerHello exts mEarlySecInfo handSecInfo) = do
+        quicNotifyExtensions callbacks (filterQTP exts)
         quicInstallKeys callbacks (InstallEarlyKeys mEarlySecInfo)
         quicInstallKeys callbacks (InstallHandshakeKeys handSecInfo)
-        quicNotifyExtensions callbacks (filterQTP exts)
     sync (SendServerFinished appSecInfo) =
         quicInstallKeys callbacks (InstallApplicationKeys appSecInfo)
 


### PR DESCRIPTION
QUIC nodes must know necessary QUIC parameters before 1RTT gets ready. This includes initial values for flow control exchanged in EE. For this, the ordering of `quicNotifyExtensions` and `quicInstallKeys` must be reversed.

This also includes `ALPN`. Applications want to choose H3 or HQ (HTTP/0.9 over QUIC) before sending 1RTT packets. For this, three commits are reverted.

Inter-operability tests for this PR are already done based on QUIC draft-28.