### PR TITLE
Setting necessary QUIC parameters before 1RTT gets ready (2)

### DIFF
--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -79,7 +79,6 @@ import Network.TLS.Parameters
 import Network.TLS.Measurement
 import Network.TLS.Types (Role(..))
 import Network.TLS.Handshake (handshakeClient, handshakeClientWith, handshakeServer, handshakeServerWith)
-import Network.TLS.Handshake.Control (HandshakeSync(..))
 import Network.TLS.PostHandshake (requestCertificateServer, postHandshakeAuthClientWith, postHandshakeAuthServerWith)
 import Network.TLS.X509
 import Network.TLS.RNG
@@ -192,7 +191,7 @@ contextNew backend params = liftIO $ do
             , ctxQUICMode         = False
             }
 
-        syncNoOp _ = return ()
+        syncNoOp _ _ = return ()
 
         recordLayer = RecordLayer
             { recordEncode    = encodeRecord ctx

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -65,6 +65,9 @@ module Network.TLS.Context.Internal
     , addCertRequest13
     , getCertRequest13
     , decideRecordVersion
+
+    -- * Misc
+    , HandshakeSync(..)
     ) where
 
 import Network.TLS.Backend
@@ -139,6 +142,9 @@ data Context = forall bytes . Monoid bytes => Context
     , ctxHandshakeSync    :: HandshakeSync
     , ctxQUICMode         :: Bool
     }
+
+data HandshakeSync = HandshakeSync (Context -> ClientState -> IO ())
+                                   (Context -> ServerState -> IO ())
 
 updateRecordLayer :: Monoid bytes => RecordLayer bytes -> Context -> Context
 updateRecordLayer recordLayer Context{..} =

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -1092,4 +1092,4 @@ postHandshakeAuthClientWith _ _ _ =
 
 contextSync :: Context -> ClientState -> IO ()
 contextSync ctx ctl = case ctxHandshakeSync ctx of
-    HandshakeSync sync _ -> sync ctl
+    HandshakeSync sync _ -> sync ctx ctl

--- a/core/Network/TLS/Handshake/Control.hs
+++ b/core/Network/TLS/Handshake/Control.hs
@@ -12,7 +12,6 @@ module Network.TLS.Handshake.Control (
   , HandshakeSecretInfo(..)
   , ApplicationSecretInfo(..)
   , NegotiatedProtocol
-  , HandshakeSync(..)
   ) where
 
 import Network.TLS.Cipher
@@ -48,8 +47,3 @@ data ClientState =
 data ServerState =
     SendServerHello [ExtensionRaw] (Maybe EarlySecretInfo) HandshakeSecretInfo
   | SendServerFinished ApplicationSecretInfo
-
-----------------------------------------------------------------
-
-data HandshakeSync = HandshakeSync (ClientState -> IO ())
-                                   (ServerState -> IO ())

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -1191,4 +1191,4 @@ postHandshakeAuthServerWith _ _ _ =
 
 contextSync :: Context -> ServerState -> IO ()
 contextSync ctx ctl = case ctxHandshakeSync ctx of
-    HandshakeSync _ sync -> sync ctl
+    HandshakeSync _ sync -> sync ctx ctl

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -139,12 +139,12 @@ data QUICCallbacks = QUICCallbacks
       -- proceed any longer.  If the TLS handshake protocol cannot recover from
       -- this error, the failure condition will be reported back to QUIC through
       -- the control interface.
-    , quicInstallKeys       :: KeyScheduleEvent -> IO ()
+    , quicInstallKeys       :: Context -> KeyScheduleEvent -> IO ()
       -- ^ Called by TLS when new encryption material is ready to be used in the
       -- handshake.  The next 'quicSend' or 'quicRecv' may now use the
       -- associated encryption level (although the previous level is also
       -- possible: directions Send/Recv do not change at the same time).
-    , quicNotifyExtensions  :: [ExtensionRaw] -> IO ()
+    , quicNotifyExtensions  :: Context -> [ExtensionRaw] -> IO ()
       -- ^ Called by TLS when QUIC-specific extensions have been received from
       -- the peer.
     , quicDone :: Context -> IO ()
@@ -182,7 +182,7 @@ tlsQUICClient :: ClientParams -> QUICCallbacks -> IO ()
 tlsQUICClient cparams callbacks = do
     ctx0 <- contextNew nullBackend cparams
     let ctx1 = ctx0
-           { ctxHandshakeSync = HandshakeSync sync (\_ -> return ())
+           { ctxHandshakeSync = HandshakeSync sync (\_ _ -> return ())
            , ctxFragmentSize = Nothing
            , ctxQUICMode = True
            }
@@ -192,13 +192,13 @@ tlsQUICClient cparams callbacks = do
     quicDone callbacks ctx2
     void $ recvData ctx2 -- waiting for new session tickets
   where
-    sync (SendClientHello mEarlySecInfo) =
-        quicInstallKeys callbacks (InstallEarlyKeys mEarlySecInfo)
-    sync (RecvServerHello handSecInfo) =
-        quicInstallKeys callbacks (InstallHandshakeKeys handSecInfo)
-    sync (SendClientFinished exts appSecInfo) = do
-        quicInstallKeys callbacks (InstallApplicationKeys appSecInfo)
-        quicNotifyExtensions callbacks (filterQTP exts)
+    sync ctx (SendClientHello mEarlySecInfo) =
+        quicInstallKeys callbacks ctx (InstallEarlyKeys mEarlySecInfo)
+    sync ctx (RecvServerHello handSecInfo) =
+        quicInstallKeys callbacks ctx (InstallHandshakeKeys handSecInfo)
+    sync ctx (SendClientFinished exts appSecInfo) = do
+        quicInstallKeys callbacks ctx (InstallApplicationKeys appSecInfo)
+        quicNotifyExtensions callbacks ctx (filterQTP exts)
 
 -- | Start a TLS handshake thread for a QUIC server.  The server will use the
 -- specified TLS parameters and call the provided callback functions to send and
@@ -210,7 +210,7 @@ tlsQUICServer :: ServerParams -> QUICCallbacks -> IO ()
 tlsQUICServer sparams callbacks = do
     ctx0 <- contextNew nullBackend sparams
     let ctx1 = ctx0
-          { ctxHandshakeSync = HandshakeSync (\_ -> return ()) sync
+          { ctxHandshakeSync = HandshakeSync (\_ _ -> return ()) sync
           , ctxFragmentSize = Nothing
           , ctxQUICMode = True
           }
@@ -219,12 +219,12 @@ tlsQUICServer sparams callbacks = do
     handshake ctx2
     quicDone callbacks ctx2
   where
-    sync (SendServerHello exts mEarlySecInfo handSecInfo) = do
-        quicInstallKeys callbacks (InstallEarlyKeys mEarlySecInfo)
-        quicInstallKeys callbacks (InstallHandshakeKeys handSecInfo)
-        quicNotifyExtensions callbacks (filterQTP exts)
-    sync (SendServerFinished appSecInfo) =
-        quicInstallKeys callbacks (InstallApplicationKeys appSecInfo)
+    sync ctx (SendServerHello exts mEarlySecInfo handSecInfo) = do
+        quicInstallKeys callbacks ctx (InstallEarlyKeys mEarlySecInfo)
+        quicInstallKeys callbacks ctx (InstallHandshakeKeys handSecInfo)
+        quicNotifyExtensions callbacks ctx (filterQTP exts)
+    sync ctx (SendServerFinished appSecInfo) =
+        quicInstallKeys callbacks ctx (InstallApplicationKeys appSecInfo)
 
 filterQTP :: [ExtensionRaw] -> [ExtensionRaw]
 filterQTP = filter (\(ExtensionRaw eid _) -> eid == extensionID_QuicTransportParameters)

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -197,8 +197,8 @@ tlsQUICClient cparams callbacks = do
     sync ctx (RecvServerHello handSecInfo) =
         quicInstallKeys callbacks ctx (InstallHandshakeKeys handSecInfo)
     sync ctx (SendClientFinished exts appSecInfo) = do
-        quicInstallKeys callbacks ctx (InstallApplicationKeys appSecInfo)
         quicNotifyExtensions callbacks ctx (filterQTP exts)
+        quicInstallKeys callbacks ctx (InstallApplicationKeys appSecInfo)
 
 -- | Start a TLS handshake thread for a QUIC server.  The server will use the
 -- specified TLS parameters and call the provided callback functions to send and
@@ -220,9 +220,9 @@ tlsQUICServer sparams callbacks = do
     quicDone callbacks ctx2
   where
     sync ctx (SendServerHello exts mEarlySecInfo handSecInfo) = do
+        quicNotifyExtensions callbacks ctx (filterQTP exts)
         quicInstallKeys callbacks ctx (InstallEarlyKeys mEarlySecInfo)
         quicInstallKeys callbacks ctx (InstallHandshakeKeys handSecInfo)
-        quicNotifyExtensions callbacks ctx (filterQTP exts)
     sync ctx (SendServerFinished appSecInfo) =
         quicInstallKeys callbacks ctx (InstallApplicationKeys appSecInfo)
 


### PR DESCRIPTION
This is an alternative to #432. `Context` is passed to `sync` from client and server. `RTT0Status` is not exported since `Information` has `infoIsEarlyDataAccepted`.