### PR TITLE
Sort ciphersuites based on hardware-acceleration support

### DIFF
--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -1,5 +1,5 @@
 Name:                tls
-Version:             1.5.4
+Version:             1.5.5
 Description:
    Native Haskell TLS and SSL protocol implementation for server and client.
    .

--- a/debug/src/Common.hs
+++ b/debug/src/Common.hs
@@ -1,5 +1,6 @@
 -- Disable this warning so we can still test deprecated functionality.
 {-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
+{-# LANGUAGE CPP #-}
 module Common
     ( printCiphers
     , printDHParams
@@ -18,6 +19,7 @@ import Data.Char (isDigit)
 import Numeric (showHex)
 import Network.Socket
 
+import Crypto.System.CPU
 import Data.X509.CertificateStore
 import System.X509
 
@@ -81,16 +83,22 @@ printCiphers :: IO ()
 printCiphers = do
     putStrLn "Supported ciphers"
     putStrLn "====================================="
-    forM_ ciphersuite_all $ \c -> do
+    forM_ ciphersuite_all_det $ \c ->
         putStrLn (pad 50 (cipherName c) ++ " = " ++ pad 5 (show $ cipherID c) ++ "  0x" ++ showHex (cipherID c) "")
     putStrLn ""
     putStrLn "Ciphersuites"
     putStrLn "====================================="
     forM_ namedCiphersuites $ \(name, _) -> putStrLn name
+    putStrLn ""
+    putStrLn ("Using cryptonite-" ++ VERSION_cryptonite ++ " with CPU support for: " ++ cpuSupport)
   where
     pad n s
         | length s < n = s ++ replicate (n - length s) ' '
         | otherwise    = s
+
+    cpuSupport
+        | null processorOptions = "(nothing)"
+        | otherwise = intercalate ", " (map show processorOptions)
 
 printDHParams :: IO ()
 printDHParams = do

--- a/debug/tls-debug.cabal
+++ b/debug/tls-debug.cabal
@@ -27,8 +27,8 @@ Executable           tls-stunnel
                    , x509-system >= 1.0
                    , x509-validation >= 1.5
                    , data-default-class
-                   , cryptonite >= 0.24
-                   , tls >= 1.5.3
+                   , cryptonite >= 0.27
+                   , tls >= 1.5.5
                    , tls-session-manager
   if os(windows)
     Buildable:       False
@@ -74,10 +74,10 @@ Executable           tls-simpleclient
                    , network
                    , bytestring
                    , data-default-class
-                   , cryptonite >= 0.14
+                   , cryptonite >= 0.27
                    , x509-store
                    , x509-system >= 1.0
-                   , tls >= 1.5.3 && < 1.6
+                   , tls >= 1.5.5 && < 1.6
   Buildable:         True
   ghc-options:       -Wall -fno-warn-missing-signatures
 
@@ -91,10 +91,10 @@ Executable           tls-simpleserver
                    , network
                    , bytestring
                    , data-default-class
-                   , cryptonite
+                   , cryptonite >= 0.27
                    , x509-store
                    , x509-system >= 1.0
-                   , tls >= 1.5.3 && < 1.6
+                   , tls >= 1.5.5 && < 1.6
                    , tls-session-manager
   Buildable:         True
   ghc-options:       -Wall -fno-warn-missing-signatures


### PR DESCRIPTION
Uses runtime flags provided by cryptonite to define AEAD cipher preference based on hardware-acceleration support.

The main lists of ciphersuites `_default`, `_all` and `_strong` are modified, most application code will directly get this.

A version of those lists without dynamic ordering is provided in case application code needs it.
This gives almost identical order to what was there previously, except the position of CCM ciphers is slightly ajusted.

Debug tools are extended to show the optimizations that are active.

Closes #369.