### PR TITLE
add getFinished and getPeerFinished functions for Context, closes #442

### DIFF
--- a/core/Network/TLS.hs
+++ b/core/Network/TLS.hs
@@ -117,6 +117,8 @@ module Network.TLS
     , updateKey
     , KeyUpdateRequest(..)
     , requestCertificate
+    , getFinished
+    , getPeerFinished
     -- ** Modifying hooks in context
     , Hooks(..)
     , contextModifyHooks

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -141,6 +141,8 @@ data Context = forall bytes . Monoid bytes => Context
     , ctxRecordLayer      :: RecordLayer bytes
     , ctxHandshakeSync    :: HandshakeSync
     , ctxQUICMode         :: Bool
+    , ctxFinished         :: IORef (Maybe FinishedData)
+    , ctxPeerFinished     :: IORef (Maybe FinishedData)
     }
 
 data HandshakeSync = HandshakeSync (Context -> ClientState -> IO ())

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -980,7 +980,7 @@ handshakeClient13' cparams ctx groupSent choice = do
     expectCertVerify _ _ p = unexpected (show p) (Just "certificate verify")
 
     expectFinished (ServerTrafficSecret baseKey) hashValue (Finished13 verifyData) =
-        checkFinished usedHash baseKey hashValue verifyData
+        checkFinished ctx usedHash baseKey hashValue verifyData
     expectFinished _ _ p = unexpected (show p) (Just "server finished")
 
     setResumptionSecret applicationSecret = do

--- a/core/Network/TLS/Handshake/Common.hs
+++ b/core/Network/TLS/Handshake/Common.hs
@@ -51,6 +51,7 @@ import Network.TLS.Imports
 
 import Control.Monad.State.Strict
 import Control.Exception (IOException, handle, fromException, throwIO)
+import Data.IORef (writeIORef)
 
 handshakeFailed :: TLSError -> IO ()
 handshakeFailed err = throwIO $ HandshakeFailed err
@@ -127,6 +128,7 @@ sendChangeCipherAndFinish ctx role = do
     liftIO $ contextFlush ctx
     cf <- usingState_ ctx getVersion >>= \ver -> usingHState ctx $ getHandshakeDigest ver role
     sendPacket ctx (Handshake [Finished cf])
+    writeIORef (ctxFinished ctx) $ Just cf
     liftIO $ contextFlush ctx
 
 recvChangeCipherAndFinish :: Context -> IO ()

--- a/core/Network/TLS/Handshake/Process.hs
+++ b/core/Network/TLS/Handshake/Process.hs
@@ -36,6 +36,7 @@ import Control.Concurrent.MVar
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (gets)
 import Data.X509 (CertificateChain(..), Certificate(..), getCertificate)
+import Data.IORef (writeIORef)
 
 processHandshake :: Context -> Handshake -> IO ()
 processHandshake ctx hs = do
@@ -136,6 +137,7 @@ processClientFinished ctx fdata = do
     (cc,ver) <- usingState_ ctx $ (,) <$> isClientContext <*> getVersion
     expected <- usingHState ctx $ getHandshakeDigest ver $ invertRole cc
     when (expected /= fdata) $ decryptError "cannot verify finished"
+    writeIORef (ctxPeerFinished ctx) $ Just fdata
 
 -- initialize a new Handshake context (initial handshake or renegotiations)
 startHandshake :: Context -> Version -> ClientRandom -> IO ()

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -789,7 +789,7 @@ doHandshake13 sparams ctx chosenVersion usedCipher exts usedHash clientKeyShare 
 
     let expectFinished hChBeforeCf (Finished13 verifyData) = liftIO $ do
             let ClientTrafficSecret chs = clientHandshakeSecret
-            checkFinished usedHash chs hChBeforeCf verifyData
+            checkFinished ctx usedHash chs hChBeforeCf verifyData
             handshakeTerminate13 ctx
             setRxState ctx usedHash usedCipher clientApplicationSecret0
             sendNewSessionTicket applicationSecret sfSentTime
@@ -1179,7 +1179,7 @@ postHandshakeAuthServerWith sparams ctx h@(Certificate13 certCtx certs _ext) = d
         throwCore $ Error_Protocol ("tried post-handshake authentication without application traffic secret", True, InternalError)
 
     let expectFinished hChBeforeCf (Finished13 verifyData) = do
-            checkFinished usedHash applicationSecretN hChBeforeCf verifyData
+            checkFinished ctx usedHash applicationSecretN hChBeforeCf verifyData
             void $ restoreHState ctx baseHState
         expectFinished _ hs = unexpected (show hs) (Just "finished 13")
 

--- a/core/Tests/Tests.hs
+++ b/core/Tests/Tests.hs
@@ -80,12 +80,14 @@ runTLSPipePredicate :: (ClientParams, ServerParams) -> (Maybe Information -> Boo
 runTLSPipePredicate params p = runTLSPipe params tlsServer tlsClient
   where tlsServer ctx queue = do
             handshake ctx
+            checkCtxFinished ctx
             checkInfoPredicate ctx
             d <- recvData ctx
             writeChan queue [d]
             bye ctx
         tlsClient queue ctx = do
             handshake ctx
+            checkCtxFinished ctx
             checkInfoPredicate ctx
             d <- readChan queue
             sendData ctx (L.fromChunks [d])
@@ -109,12 +111,14 @@ runTLSPipeSimple13 params mode mEarlyData = runTLSPipe params tlsServer tlsClien
                     chunks <- replicateM (length ls) $ recvData ctx
                     (ls, ed) `assertEq` (map B.length chunks, B.concat chunks)
             d <- recvData ctx
+            checkCtxFinished ctx
             writeChan queue [d]
             minfo <- contextGetInformation ctx
             Just mode `assertEq` (minfo >>= infoTLS13HandshakeMode)
             bye ctx
         tlsClient queue ctx = do
             handshake ctx
+            checkCtxFinished ctx
             d <- readChan queue
             sendData ctx (L.fromChunks [d])
             minfo <- contextGetInformation ctx
@@ -132,12 +136,14 @@ runTLSPipeCapture13 params = do
   where tlsServer ref ctx queue = do
             installHook ctx ref
             handshake ctx
+            checkCtxFinished ctx
             d <- recvData ctx
             writeChan queue [d]
             bye ctx
         tlsClient ref queue ctx = do
             installHook ctx ref
             handshake ctx
+            checkCtxFinished ctx
             d <- readChan queue
             sendData ctx (L.fromChunks [d])
             byeBye ctx
@@ -149,6 +155,7 @@ runTLSPipeSimpleKeyUpdate :: (ClientParams, ServerParams) -> PropertyM IO ()
 runTLSPipeSimpleKeyUpdate params = runTLSPipeN 3 params tlsServer tlsClient
   where tlsServer ctx queue = do
             handshake ctx
+            checkCtxFinished ctx
             d0 <- recvData ctx
             req <- generate $ elements [OneWay, TwoWay]
             _ <- updateKey ctx req
@@ -158,6 +165,7 @@ runTLSPipeSimpleKeyUpdate params = runTLSPipeN 3 params tlsServer tlsClient
             bye ctx
         tlsClient queue ctx = do
             handshake ctx
+            checkCtxFinished ctx
             d0 <- readChan queue
             sendData ctx (L.fromChunks [d0])
             d1 <- readChan queue
@@ -175,11 +183,13 @@ runTLSInitFailureGen params hsServer hsClient = do
     assertIsLeft sRes
   where tlsServer ctx = do
             _ <- hsServer ctx
+            checkCtxFinished ctx
             minfo <- contextGetInformation ctx
             byeBye ctx
             return $ "server success: " ++ show minfo
         tlsClient ctx = do
             _ <- hsClient ctx
+            checkCtxFinished ctx
             minfo <- contextGetInformation ctx
             byeBye ctx
             return $ "client success: " ++ show minfo
@@ -747,6 +757,7 @@ prop_post_handshake_auth = do
             byeBye ctx
         hsServer ctx = do
             handshake ctx
+            checkCtxFinished ctx
             recvDataAssert ctx "request 1"
             _ <- requestCertificate ctx  -- single request
             sendData ctx "response 1"
@@ -756,6 +767,7 @@ prop_post_handshake_auth = do
             sendData ctx "response 2"
         hsClient ctx = do
             handshake ctx
+            checkCtxFinished ctx
             sendData ctx "request 1"
             recvDataAssert ctx "response 1"
             sendData ctx "request 2"
@@ -844,6 +856,7 @@ prop_handshake_alpn = do
     runTLSPipe params' tlsServer tlsClient
   where tlsServer ctx queue = do
             handshake ctx
+            checkCtxFinished ctx
             proto <- getNegotiatedProtocol ctx
             Just "h2" `assertEq` proto
             d <- recvData ctx
@@ -851,6 +864,7 @@ prop_handshake_alpn = do
             bye ctx
         tlsClient queue ctx = do
             handshake ctx
+            checkCtxFinished ctx
             proto <- getNegotiatedProtocol ctx
             Just "h2" `assertEq` proto
             d <- readChan queue
@@ -875,6 +889,7 @@ prop_handshake_sni = do
     Just (Just serverName) `assertEq` receivedName
   where tlsServer ctx queue = do
             handshake ctx
+            checkCtxFinished ctx
             sni <- getClientSNI ctx
             Just serverName `assertEq` sni
             d <- recvData ctx
@@ -882,6 +897,7 @@ prop_handshake_sni = do
             bye ctx
         tlsClient queue ctx = do
             handshake ctx
+            checkCtxFinished ctx
             sni <- getClientSNI ctx
             Just serverName `assertEq` sni
             d <- readChan queue
@@ -905,11 +921,13 @@ prop_handshake_renegotiation = do
         else runTLSPipe (cparams, sparams') tlsServer tlsClient
   where tlsServer ctx queue = do
             hsServer ctx
+            checkCtxFinished ctx
             d <- recvData ctx
             writeChan queue [d]
             bye ctx
         tlsClient queue ctx = do
             hsClient ctx
+            checkCtxFinished ctx
             d <- readChan queue
             sendData ctx (L.fromChunks [d])
             byeBye ctx
@@ -939,12 +957,14 @@ prop_thread_safety = do
     runTLSPipe params tlsServer tlsClient
   where tlsServer ctx queue = do
             handshake ctx
+            checkCtxFinished ctx
             runReaderWriters ctx "client-value" "server-value"
             d <- recvData ctx
             writeChan queue [d]
             bye ctx
         tlsClient queue ctx = do
             handshake ctx
+            checkCtxFinished ctx
             runReaderWriters ctx "server-value" "client-value"
             d <- readChan queue
             sendData ctx (L.fromChunks [d])
@@ -969,6 +989,15 @@ recvDataAssert :: Context -> C8.ByteString -> IO ()
 recvDataAssert ctx expected = do
     got <- recvData ctx
     assertEq expected got
+
+checkCtxFinished :: Context -> IO ()
+checkCtxFinished ctx = do
+    ctxFinished <- getFinished ctx
+    unless (isJust ctxFinished) $
+        fail "unexpected ctxFinished"
+    ctxPeerFinished <- getPeerFinished ctx
+    unless (isJust ctxPeerFinished) $
+        fail "unexpected ctxPeerFinished"
 
 main :: IO ()
 main = defaultMain $ testGroup "tls"


### PR DESCRIPTION
@kazu-yamamoto this is partially done.

I tried putting Finished into HandshakeState but it has Show instance (although I didn't check if it's actually needed, but it would be a breaking change to remove it), and IORef does not.

Currently, I think, it stores Finished of the current peer for both Client and Server, and stores client's Finished in the server only.

I could not find the place in the client where server's Finished is validated - does client do it at all? If not, should it be added?

Also, re FinishedData vs wire-bytes, FinishedData is the same as ByteString - is it not wire-bytes?